### PR TITLE
add test for function lyd_attr_parent()

### DIFF
--- a/tests_internal/CMakeLists.txt
+++ b/tests_internal/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.6)
 set(internal_tests
   test_lys_find_grouping_up
   test_lys_node_switch
-  test_lyd_list_equal)
+  test_lyd_list_equal
+  test_lyd_attr_parent)
 
 include_directories(SYSTEM ${CMOCKA_INCLUDE_DIR})
 

--- a/tests_internal/tree_internal/test_lyd_attr_parent.c
+++ b/tests_internal/tree_internal/test_lyd_attr_parent.c
@@ -1,0 +1,92 @@
+/*
+ * @file test_lyd_attr_parent.c
+ * @author: Antonio Paunovic <antonio.paunovic@sartura.hr>
+ * @brief unit tests for functions from tree_internal.h header
+ *
+ * Copyright (C) 2016 Deutsche Telekom AG.
+ *
+ * Author: Antonio Paunovic <antonio.paunovic@sartura.hr>
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "../../src/libyang.h"
+#include "../../src/tree_internal.h"
+
+struct ly_ctx *ctx = NULL;
+struct lyd_node *root = NULL;
+
+static int
+setup_f(void **state)
+{
+    (void) state; /* unused */
+
+    return 0;
+}
+
+static int
+teardown_f(void **state)
+{
+    (void) state; /* unused */
+    if (ctx) {
+        ly_ctx_destroy(ctx, NULL);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Test for function lyd_attr_parent()
+ *
+ * Trivial case of success is implemented.
+ */
+static void
+test_lyd_attr_parent(void **state)
+{
+    (void)state; /* unused */
+
+    struct lyd_node *root;
+    const struct lyd_node *parent;
+    struct lyd_attr *attr;
+
+    attr = calloc(1, sizeof(*attr));
+    attr->name = "test_attr";
+    attr->value = "test_val";
+
+    root = calloc(1, sizeof(*root));
+    root->attr = attr;
+
+    parent = lyd_attr_parent(root, attr);
+
+    assert_string_equal(parent->attr->name, "test_attr");
+    assert_ptr_equal(parent->attr, attr);
+
+    free(attr);
+    free(root);
+}
+
+int main(void)
+{
+  const struct CMUnitTest tests[] = {
+    cmocka_unit_test_setup_teardown(test_lyd_attr_parent, setup_f, teardown_f),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Hi Radek, 
little test for mentioned function. There is trouble testing it for negative result because it segfaults somewhere in macro LY_TREE_DFS. I hope I'll figure it out soon. 

Regards,
Antonio

Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>
Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>