### PR TITLE
add test for function lyd_check_mandatory_tree()

### DIFF
--- a/tests_internal/CMakeLists.txt
+++ b/tests_internal/CMakeLists.txt
@@ -4,9 +4,12 @@ set(internal_tests
   test_lys_find_grouping_up
   test_lys_node_switch
   test_lyd_list_equal
-  test_lyd_attr_parent)
+  test_lyd_attr_parent
+  test_lyd_check_mandatory_tree)
 
 include_directories(SYSTEM ${CMOCKA_INCLUDE_DIR})
+
+configure_file("${PROJECT_SOURCE_DIR}/tests_internal/config.h.in" "${PROJECT_SOURCE_DIR}/tests_internal/config.h" ESCAPE_QUOTES @ONLY)
 
 foreach(test_name IN LISTS internal_tests)
     add_executable(${test_name} $<TARGET_OBJECTS:yangobj> tree_internal/${test_name}.c)

--- a/tests_internal/config.h.in
+++ b/tests_internal/config.h.in
@@ -1,0 +1,18 @@
+/**
+ * @file config.h
+ * @author Antonio Paunovic <antonio.paunovic@sartura.hr>
+ * @brief cmocka tests configuration header.
+ *
+ * Copyright (C) 2016 Deutsche Telekom AG.
+ *
+ * Author: Antonio Paunovic <antonio.paunovic@sartura.hr>
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+*/
+
+#define TESTS_DIR "@CMAKE_SOURCE_DIR@/tests_internal"
+

--- a/tests_internal/tree_internal/files/mandatories.yang
+++ b/tests_internal/tree_internal/files/mandatories.yang
@@ -1,0 +1,29 @@
+module mandatories {
+       namespace "urn:mandatories";
+       prefix "m";
+
+       revision 2016-03-01 {
+                description
+                 "version 2";
+                reference "RFC XXXX";
+       }
+
+       container bigbox {
+                leaf littlething {
+                     type string;
+                     mandatory true;
+                }
+
+                leaf-list thingies {
+                     min-elements 2;
+                     max-elements 4;
+                     type string;
+                }
+       }
+
+       leaf bigthing {
+            type string;
+            mandatory false;
+       }
+}
+

--- a/tests_internal/tree_internal/files/mandatories_example.xml
+++ b/tests_internal/tree_internal/files/mandatories_example.xml
@@ -1,0 +1,7 @@
+<bigbox xmlns="urn:mandatories">
+  <littlething>can go in a box</littlething>
+  <thingies>1 stuff</thingies>
+  <thingies>2 stuff</thingies>
+  <thingies>3 stuff</thingies>
+  <thingies>4 stuff</thingies>
+</bigbox>

--- a/tests_internal/tree_internal/files/mandatories_general.xml
+++ b/tests_internal/tree_internal/files/mandatories_general.xml
@@ -1,0 +1,5 @@
+<bigbox xmlns="urn:mandatories">
+  <thingies>1 stuff</thingies>
+  <thingies>2 stuff</thingies>
+  <thingies>3 stuff</thingies>
+</bigbox>

--- a/tests_internal/tree_internal/files/mandatories_max.xml
+++ b/tests_internal/tree_internal/files/mandatories_max.xml
@@ -1,0 +1,8 @@
+<bigbox xmlns="urn:mandatories">
+  <littlething>can go in a box</littlething>
+  <thingies>1 stuff</thingies>
+  <thingies>2 stuff</thingies>
+  <thingies>3 stuff</thingies>
+  <thingies>4 stuff</thingies>
+  <thingies>5 stuff</thingies>
+</bigbox>

--- a/tests_internal/tree_internal/files/mandatories_min.xml
+++ b/tests_internal/tree_internal/files/mandatories_min.xml
@@ -1,0 +1,4 @@
+<bigbox xmlns="urn:mandatories">
+  <littlething>can go in a box</littlething>
+  <thingies>1 stuff</thingies>
+</bigbox>

--- a/tests_internal/tree_internal/files/mandatories_toplevel_fail.yang
+++ b/tests_internal/tree_internal/files/mandatories_toplevel_fail.yang
@@ -1,0 +1,28 @@
+module mandatories {
+       namespace "urn:mandatories";
+       prefix "m";
+
+       revision 2016-03-01 {
+                description
+                 "version 2";
+                reference "RFC XXXX";
+       }
+
+       container bigbox {
+                leaf littlething {
+                     type string;
+                     mandatory true;
+                }
+
+                leaf-list thingies {
+                     min-elements 2;
+                     type string;
+                }
+       }
+
+       leaf bigthing {
+            type string;
+            mandatory true;
+       }
+}
+

--- a/tests_internal/tree_internal/test_lyd_check_mandatory_tree.c
+++ b/tests_internal/tree_internal/test_lyd_check_mandatory_tree.c
@@ -1,0 +1,130 @@
+/*
+ * @file test_lyd_check_mandatory_tree.c
+ * @author: Antonio Paunovic <antonio.paunovic@sartura.hr>
+ * @brief unit tests for functions from tree_internal.h header
+ *
+ * Copyright (C) 2016 Deutsche Telekom AG.
+ *
+ * Author: Antonio Paunovic <antonio.paunovic@sartura.hr>
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "../../src/libyang.h"
+#include "../../src/tree_internal.h"
+#include "../config.h"
+
+
+struct ly_ctx *ctx = NULL;
+struct lys_module *module;
+struct lyd_node *root;
+int rc;
+
+static void
+test_general_mandatory_leaf()
+{
+    ctx = ly_ctx_new(TESTS_DIR"/tree_internal/");
+    module = (struct lys_module *) lys_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories.yang", LYS_IN_YANG);
+    root = lyd_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_general.xml", LYD_XML, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_null(root);
+    assert_true(ly_errno != 0);
+    ly_ctx_destroy(ctx, NULL);
+}
+
+static void
+test_toplevel_mandatory_leaf()
+{
+    ctx = ly_ctx_new(TESTS_DIR"/tree_internal/");
+    module = (struct lys_module *) lys_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_toplevel_fail.yang", LYS_IN_YANG);
+    root = lyd_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_example.xml", LYD_XML, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_null(root);
+    assert_true(ly_errno != 0);
+    ly_ctx_destroy(ctx, NULL);
+}
+
+static void
+test_listleaf_max()
+{
+    ctx = ly_ctx_new(TESTS_DIR"/tree_internal/");
+    module = (struct lys_module *) lys_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories.yang", LYS_IN_YANG);
+    root = lyd_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_max.xml", LYD_XML, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_null(root);
+    assert_true(ly_errno != 0);
+    ly_ctx_destroy(ctx, NULL);
+}
+
+static void
+test_listleaf_min()
+{
+
+    ctx = ly_ctx_new(TESTS_DIR"/tree_internal/");
+    module = (struct lys_module *) lys_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories.yang", LYS_IN_YANG);
+    root = lyd_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_min.xml", LYD_XML, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_null(root);
+    assert_true(ly_errno != 0);
+    ly_ctx_destroy(ctx, NULL);
+}
+
+static void
+test_listleaf_succ()
+{
+    ctx = ly_ctx_new(TESTS_DIR"/tree_internal/");
+    module = (struct lys_module *) lys_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories.yang", LYS_IN_YANG);
+    root = lyd_parse_path(ctx, TESTS_DIR"/tree_internal/files/mandatories_example.xml", LYD_XML, LYD_OPT_CONFIG | LYD_OPT_STRICT);
+    assert_non_null(root);
+    assert_true(ly_errno == LY_SUCCESS);
+    lyd_free(root);
+    ly_ctx_destroy(ctx, NULL);
+}
+
+/**
+ * @brief Test for function lys_get_sibling()
+ *
+ * Function lys_get_sibling() validates trees mandatory conditions.
+ */
+static void
+test_lyd_check_mandatory_tree(void **state)
+{
+    (void) state; /* unused */
+
+    /* Mandatory leaf is not given. */
+    test_general_mandatory_leaf();
+
+    /* There is a top level mandatory leaf. */
+    test_toplevel_mandatory_leaf();
+
+    /* Minimal number of leaf-list elements is not given. */
+    test_listleaf_min();
+
+    /* Maximal number of leaf-list elements is not given. */
+    test_listleaf_max();
+
+    /* Ordinary case of success. */
+    test_listleaf_succ();
+}
+
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_lyd_check_mandatory_tree),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Hi Radek, 

here is test for mentioned function.
I noticed that in tree_internal.h documentation for that function has four parameters but function takes three. 

Regards,
Antonio

Signed-off-by: Antonio Paunovic <antonio.paunovic@sartura.hr>
Signed-off-by: Mislav Novakovic <mislav.novakovicda@sartura.hr>