### PR TITLE
conformance_tests BUGFIX add proper header for WEXITSTATUS

### DIFF
--- a/tests/conformance/test_sec5_1.c
+++ b/tests/conformance/test_sec5_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec5_5.c
+++ b/tests/conformance/test_sec5_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec6_2.c
+++ b/tests/conformance/test_sec6_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec6_2_1.c
+++ b/tests/conformance/test_sec6_2_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_1.c
+++ b/tests/conformance/test_sec7_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_10.c
+++ b/tests/conformance/test_sec7_10.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_11.c
+++ b/tests/conformance/test_sec7_11.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_12_1.c
+++ b/tests/conformance/test_sec7_12_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_12_2.c
+++ b/tests/conformance/test_sec7_12_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_13_1.c
+++ b/tests/conformance/test_sec7_13_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_13_2.c
+++ b/tests/conformance/test_sec7_13_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_13_3.c
+++ b/tests/conformance/test_sec7_13_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_14.c
+++ b/tests/conformance/test_sec7_14.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_15.c
+++ b/tests/conformance/test_sec7_15.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_16_1.c
+++ b/tests/conformance/test_sec7_16_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_16_2.c
+++ b/tests/conformance/test_sec7_16_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_18_1.c
+++ b/tests/conformance/test_sec7_18_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_18_2.c
+++ b/tests/conformance/test_sec7_18_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_18_3_1.c
+++ b/tests/conformance/test_sec7_18_3_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_18_3_2.c
+++ b/tests/conformance/test_sec7_18_3_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_19_1.c
+++ b/tests/conformance/test_sec7_19_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_19_2.c
+++ b/tests/conformance/test_sec7_19_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_19_5.c
+++ b/tests/conformance/test_sec7_19_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_2.c
+++ b/tests/conformance/test_sec7_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_3.c
+++ b/tests/conformance/test_sec7_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_3_1.c
+++ b/tests/conformance/test_sec7_3_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_3_4.c
+++ b/tests/conformance/test_sec7_3_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_5_2.c
+++ b/tests/conformance/test_sec7_5_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_5_4.c
+++ b/tests/conformance/test_sec7_5_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_5_5.c
+++ b/tests/conformance/test_sec7_5_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_6_2.c
+++ b/tests/conformance/test_sec7_6_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_6_3.c
+++ b/tests/conformance/test_sec7_6_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_6_4.c
+++ b/tests/conformance/test_sec7_6_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_6_5.c
+++ b/tests/conformance/test_sec7_6_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_7_2.c
+++ b/tests/conformance/test_sec7_7_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_7_3.c
+++ b/tests/conformance/test_sec7_7_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_7_4.c
+++ b/tests/conformance/test_sec7_7_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_7_5.c
+++ b/tests/conformance/test_sec7_7_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_8_1.c
+++ b/tests/conformance/test_sec7_8_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_8_2.c
+++ b/tests/conformance/test_sec7_8_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_8_3.c
+++ b/tests/conformance/test_sec7_8_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_9_1.c
+++ b/tests/conformance/test_sec7_9_1.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_9_2.c
+++ b/tests/conformance/test_sec7_9_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_9_3.c
+++ b/tests/conformance/test_sec7_9_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec7_9_4.c
+++ b/tests/conformance/test_sec7_9_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_10.c
+++ b/tests/conformance/test_sec9_10.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_11.c
+++ b/tests/conformance/test_sec9_11.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_12.c
+++ b/tests/conformance/test_sec9_12.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_13.c
+++ b/tests/conformance/test_sec9_13.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_2.c
+++ b/tests/conformance/test_sec9_2.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_3.c
+++ b/tests/conformance/test_sec9_3.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_4_4.c
+++ b/tests/conformance/test_sec9_4_4.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_4_6.c
+++ b/tests/conformance/test_sec9_4_6.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_5.c
+++ b/tests/conformance/test_sec9_5.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_6.c
+++ b/tests/conformance/test_sec9_6.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_7.c
+++ b/tests/conformance/test_sec9_7.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_8.c
+++ b/tests/conformance/test_sec9_8.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"

--- a/tests/conformance/test_sec9_9.c
+++ b/tests/conformance/test_sec9_9.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <cmocka.h>
 #include <string.h>
+#include <sys/wait.h>
 
 #include "../config.h"
 #include "../../src/libyang.h"


### PR DESCRIPTION
This pull request fixes build issues on FreeBSD: WEXITSTATUS is defined in `<sys/wait.h>`