### PR TITLE
Fix range check after decimal64 bugfix

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -684,13 +684,9 @@ upper:
                 goto error;
             }
             c = tail;
-            if (*c == '.') {
+            if (type->base == LY_TYPE_DEC64 && *c == '.' && isdigit(c[1])) {
                 c++;
-                if (type->base == LY_TYPE_UINT64) {
-                    strtoull(c, &tail, 10);
-                } else {
-                    strtoll(c, &tail, 10);
-                }
+                strtoll(c, &tail, 10);
                 if (errno) {
                     goto error;
                 }
@@ -725,13 +721,9 @@ upper:
             goto error;
         }
         c = tail;
-        if (*c == '.') {
-            errno = 0;
-            if (type->base == LY_TYPE_UINT64) {
-                strtoull(c, &tail, 10);
-            } else {
-                strtoll(c, &tail, 10);
-            }
+        if (type->base == LY_TYPE_DEC64 && *c == '.' && isdigit(c[1])) {
+            c++;
+            strtoll(c, &tail, 10);
             if (errno) {
                 /* out of range value */
                 goto error;


### PR DESCRIPTION
Fix range check `lyp_check_length_range` function after #119 committed at 9efcd5b5aa29b2417d3644ea5338981c8b0be7b0.

I got the following error when tried to use ietf-inet-types schema:
```
libyang[1]: Invalid value "0..63" of "range".
libyang[1]: Module "ietf-inet-types" parsing failed.
```