### PR TITLE
Fix tests in Mac OS

### DIFF
--- a/tests/api/test_tree_data.c
+++ b/tests/api/test_tree_data.c
@@ -38,6 +38,8 @@
 #include "../../src/tree_data.h"
 #include "../../src/tree_schema.h"
 
+#define TMP_TEMPLATE "/tmp/libyang-XXXXXX"
+
 struct ly_ctx *ctx = NULL;
 struct lyd_node *root = NULL;
 
@@ -1048,7 +1050,7 @@ test_lyd_print_fd_xml(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -1091,7 +1093,7 @@ test_lyd_print_fd_xml_format(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -1134,7 +1136,7 @@ test_lyd_print_fd_json(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -1178,7 +1180,7 @@ test_lyd_print_file_xml(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -1233,7 +1235,7 @@ test_lyd_print_file_xml_format(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -1288,7 +1290,7 @@ test_lyd_print_file_json(void **state)
     int fd = -1;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {

--- a/tests/api/test_tree_schema.c
+++ b/tests/api/test_tree_schema.c
@@ -28,6 +28,8 @@
 #include "../config.h"
 #include "../../src/libyang.h"
 
+#define TMP_TEMPLATE "/tmp/libyang-XXXXXX"
+
 struct ly_ctx *ctx = NULL;
 struct lyd_node *root = NULL;
 
@@ -805,7 +807,7 @@ test_lys_print_fd_tree(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -857,7 +859,7 @@ test_lys_print_fd_yang(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -909,7 +911,7 @@ test_lys_print_fd_yin(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -961,7 +963,7 @@ test_lys_print_fd_info(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -1014,7 +1016,7 @@ test_lys_print_file_tree(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -1078,7 +1080,7 @@ test_lys_print_file_yin(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -1142,7 +1144,7 @@ test_lys_print_file_yang(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);
@@ -1206,7 +1208,7 @@ test_lys_print_file_info(void **state)
     }
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
 
     fd = mkstemp(file_name);

--- a/tests/api/test_xml.c
+++ b/tests/api/test_xml.c
@@ -36,6 +36,8 @@
 #include "../config.h"
 #include "../../src/libyang.h"
 
+#define TMP_TEMPLATE "/tmp/libyang-XXXXXX"
+
 struct ly_ctx *ctx = NULL;
 struct lyd_node *root = NULL;
 
@@ -192,7 +194,7 @@ test_lyxml_print_fd(void **state)
     int fd;
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {
@@ -248,7 +250,7 @@ test_lyxml_print_file(void **state)
     assert_string_equal("x", xml->name);
 
     memset(file_name, 0, sizeof(file_name));
-    strncpy(file_name, "/tmp/libyang-XXXXXX", 21);
+    strncpy(file_name, TMP_TEMPLATE, strlen(TMP_TEMPLATE));
 
     fd = mkstemp(file_name);
     if (fd < 1) {


### PR DESCRIPTION
Fix three tests that were raising exceptions, replaced string with a more meaning one and length with `strlen`.