### PR TITLE
different data node having attr under list use the first attr value

### DIFF
--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -234,7 +234,7 @@ json_print_leaf_list(struct lyout *out, int level, const struct lyd_node *node, 
             }
             if (list->attr) {
                 ly_print(out, "%*s\"@\":%s{%s", LEVEL, INDENT, (level ? " " : ""), (level ? "\n" : ""));
-                json_print_attrs(out, level + 1, node, NULL);
+                json_print_attrs(out, level + 1, list, NULL);
                 ly_print(out, "%*s}%s", LEVEL, INDENT, list->child ? ",\n" : "");
             }
             json_print_nodes(out, level, list->child, 1, 0, options);


### PR DESCRIPTION
when list node's different data have attr data , using lyd_print_mem method to convert lyd_node to json will quote the first data node's attr.
the example is like the accessory file.
I expect the result is: {"Sub:Root":{"a":[{"@":{  "-operation":"delete"},"name":"aa","value":3},{"@":{  "-operation":"create"},"name":"bb","value":4}]}}
but the actual result is: {"Sub:Root":{"a":[{"@":{  "-operation":"delete"},"name":"aa","value":3},{"@":{  "-operation":"delete"},"name":"bb","value":4}]}}
The request has repair this problem.

Thanks.

[issue.txt](https://github.com/CESNET/libyang/files/523925/issue.txt)