### PR TITLE
lyd_print_mem print string when using boolean or decimal64 type

### DIFF
--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -117,10 +117,8 @@ contentprint:
     case LY_TYPE_ENUM:
     case LY_TYPE_IDENT:
     case LY_TYPE_INST:
-    case LY_TYPE_DEC64:
     case LY_TYPE_INT64:
     case LY_TYPE_UINT64:
-    case LY_TYPE_BOOL:
         json_print_string(out, leaf->value_str);
         break;
 
@@ -130,6 +128,8 @@ contentprint:
     case LY_TYPE_UINT8:
     case LY_TYPE_UINT16:
     case LY_TYPE_UINT32:
+    case LY_TYPE_BOOL:
+    case LY_TYPE_DEC64:
         ly_print(out, "%s", leaf->value_str[0] ? leaf->value_str : "null");
         break;
 


### PR DESCRIPTION
When I run main function, I expect the result is {"Sub:Root":{"a":true,"b":3.14}}.
But the actual result is {"Sub:Root":{"a":"true","b":"3.14"}}.

[issue.txt](https://github.com/CESNET/libyang/files/549467/issue.txt)
