### PR TITLE
cmake: Fix manpage installation target directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ endif()
 if(NOT BIN_INSTALL_DIR)
 	set(BIN_INSTALL_DIR bin)
 endif()
+if(NOT MAN_INSTALL_DIR)
+    set(MAN_INSTALL_DIR share/man/)
+endif()
 
 # set default build type if not specified by user
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
On my cmake 3.6.2, there's no default and therefore this does not even
respect CMAKE_INSTALL_PREFIX.