### PR TITLE
BUGFIX invalid read in models loop

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2343,7 +2343,7 @@ lyp_ctx_add_module(struct lys_module **module)
     to_implement = 0;
     ctx = mod->ctx;
 
-    for (i = 0; ctx->models.list[i]; i++) {
+    for (i = 0; i < ctx->models.used; i++) {
         /* check name (name/revision) and namespace uniqueness */
         if (!strcmp(ctx->models.list[i]->name, mod->name)) {
             if (to_implement) {


### PR DESCRIPTION
Fixes the invalid read that can be reproduce  using sysrepoctl

valgrind src/sysrepoctl -L 4 --init --module=ietf-interfaces --owner=lukas --permissions=644

```
==4976== Invalid read of size 8
==4976==    at 0x522ABDF: lyp_ctx_add_module (parser.c:2346)
==4976==    by 0x526654F: yang_read_module (parser_yang.c:2723)
==4976==    by 0x5268951: lys_parse_mem_ (tree_schema.c:866)
==4976==    by 0x5268F28: lys_parse_fd (tree_schema.c:1001)
==4976==    by 0x5268B70: lys_parse_path (tree_schema.c:928)
==4976==    by 0x4053D7: srctl_init (sysrepoctl.c:1100)
==4976==    by 0x405E18: main (sysrepoctl.c:1368)
==4976==  Address 0x6862170 is 0 bytes after a block of size 128 alloc'd
==4976==    at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4976==    by 0x5208447: ly_ctx_new (context.c:74)
==4976==    by 0x40522C: srctl_init (sysrepoctl.c:1073)
==4976==    by 0x405E18: main (sysrepoctl.c:1368)
```