### PR TITLE
Silence clang-3.9's warning about enum-out-of-range

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -6852,7 +6852,7 @@ resolve_union(struct lyd_node_leaf_list *leaf, struct lys_type *type, int ignore
 
     assert(type->base == LY_TYPE_UNION);
 
-    if ((leaf->value_type == LY_TYPE_UNION) || (leaf->value_type == (LY_TYPE_INST | LY_TYPE_INST_UNRES))) {
+    if ((leaf->value_type == LY_TYPE_UNION) || ((int)leaf->value_type == (LY_TYPE_INST | LY_TYPE_INST_UNRES))) {
         /* either NULL or instid previously converted to JSON */
         json_val = leaf->value.string;
     }


### PR DESCRIPTION
Commit e3886bb9 introduced the following warning:
```
src/resolve.c:6855:66: warning: comparison of constant 136 with expression of type 'LY_DATA_TYPE' is always false
[-Wtautological-constant-out-of-range-compare]
    if ((leaf->value_type == LY_TYPE_UNION) || (leaf->value_type == (LY_TYPE_INST | LY_TYPE_INST_UNRES))) {
                                                ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
There's an open bugreport [1] for this -- it appears to be a wrong case
of diagnostics in C mode (this behavior would be unspecified in C++).

[1] https://llvm.org/bugs/show_bug.cgi?id=16154