### PR TITLE
BUGFIX OpenWrt missing limits.h header file

### DIFF
--- a/src/extensions.c
+++ b/src/extensions.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
+#include <limits.h>
 
 #include "common.h"
 #include "extensions.h"


### PR DESCRIPTION
Missing limits.h header file when building for OpenWrt (NAME_MAX constant).