### PR TITLE
fix the issue that causes the length overwritten.

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1455,7 +1455,6 @@ lyp_parse_value(struct lys_type *type, const char **value_, struct lyxml_elem *x
                     }
                 }
             }
-            unum = u;
         }
 
         if (unum & 3) {


### PR DESCRIPTION
the length of a base64 symbol chunk (unum) is overwritten by the length of original binary with heading/tailing space chunk (u).

Signed-off-by: Jimmy, Chun-Tsung Wang <jimmy.wang@zyxel.com.tw>