### PR TITLE
Add support for multiple search directories in ly_ctx_new()

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -72,7 +72,7 @@ ly_ctx_new(const char *search_dir)
     char *cwd = NULL;
     char *search_dir_list;
     char *sep, *dir;
-    int rc = LY_SUCCESS;
+    int rc = EXIT_SUCCESS;
     int i;
 
     ctx = calloc(1, sizeof *ctx);
@@ -97,17 +97,18 @@ ly_ctx_new(const char *search_dir)
         search_dir_list = strdup(search_dir);
         LY_CHECK_ERR_GOTO(!search_dir_list, LOGMEM, error);
 
-        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL && rc == LY_SUCCESS; dir = sep + 1) {
+        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL && rc == EXIT_SUCCESS; dir = sep + 1) {
             *sep = 0;
             rc = ly_ctx_set_searchdir(ctx, dir);
         }
-        if (*dir && rc == LY_SUCCESS) {
+        if (*dir && rc == EXIT_SUCCESS) {
             rc = ly_ctx_set_searchdir(ctx, dir);
         }
         free(search_dir_list);
         /* If ly_ctx_set_searchdir() failed, the error is already logged. Just exit */
-        if (rc)
+        if (rc != EXIT_SUCCESS) {
             goto error;
+        }
     }
     ctx->models.module_set_id = 1;
 
@@ -251,10 +252,11 @@ ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
     char *cwd = NULL, *new = NULL;
     int index = 0;
     void *r;
-    LY_ERR rc = LY_EMEM;
+    int rc = EXIT_FAILURE;
 
     if (!ctx) {
-        return LY_EINVAL;
+        LOGERR(LY_EINVAL, "Got ctx=NULL", strerror(errno));
+        return EXIT_FAILURE;
     }
 
     if (search_dir) {
@@ -291,7 +293,7 @@ success:
             LOGWRN("Unable to return back to working directory \"%s\" (%s)",
                    cwd, strerror(errno));
         }
-        rc = LY_SUCCESS;
+        rc = EXIT_SUCCESS;
     }
 
 cleanup:

--- a/src/context.c
+++ b/src/context.c
@@ -93,20 +93,18 @@ ly_ctx_new(const char *search_dir)
     ctx->models.used = 0;
     ctx->models.size = 16;
     if (search_dir) {
-        ctx->models.search_paths = malloc(sizeof *ctx->models.search_paths);
-        LY_CHECK_ERR_GOTO(!ctx->models.search_paths, LOGMEM, error);
-        ctx->models.search_paths[0] = NULL;
+        ctx->models.search_paths = NULL;
 
         search_dir_list = strdup(search_dir);
         LY_CHECK_ERR_GOTO(!search_dir_list, LOGMEM, error);
 
-        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL; dir = sep + 1)
-        {
+        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL; dir = sep + 1) {
             *sep = 0;
             ly_ctx_set_searchdir(ctx, dir);
         }
-        if (*dir)
+        if (*dir) {
             ly_ctx_set_searchdir(ctx, dir);
+        }
         free(search_dir_list);
     }
     ctx->models.module_set_id = 1;

--- a/src/context.c
+++ b/src/context.c
@@ -70,6 +70,8 @@ ly_ctx_new(const char *search_dir)
     struct ly_ctx *ctx = NULL;
     struct lys_module *module;
     char *cwd = NULL;
+    char *search_dir_list;
+    char *sep, *dir;
     int i;
 
     ctx = calloc(1, sizeof *ctx);
@@ -91,20 +93,21 @@ ly_ctx_new(const char *search_dir)
     ctx->models.used = 0;
     ctx->models.size = 16;
     if (search_dir) {
-        cwd = get_current_dir_name();
-        if (chdir(search_dir)) {
-            LOGERR(LY_ESYS, "Unable to use search directory \"%s\" (%s)",
-                   search_dir, strerror(errno));
-            goto error;
-        }
-        ctx->models.search_paths = malloc(2 * sizeof *ctx->models.search_paths);
+        ctx->models.search_paths = malloc(sizeof *ctx->models.search_paths);
         LY_CHECK_ERR_GOTO(!ctx->models.search_paths, LOGMEM, error);
-        ctx->models.search_paths[0] = get_current_dir_name();
-        ctx->models.search_paths[1] = NULL;
-        if (chdir(cwd)) {
-            LOGWRN("Unable to return back to working directory \"%s\" (%s)",
-                   cwd, strerror(errno));
+        ctx->models.search_paths[0] = NULL;
+
+        search_dir_list = strdup(search_dir);
+        LY_CHECK_ERR_GOTO(!search_dir_list, LOGMEM, error);
+
+        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL; dir = sep + 1)
+        {
+            *sep = 0;
+            ly_ctx_set_searchdir(ctx, dir);
         }
+        if (*dir)
+            ly_ctx_set_searchdir(ctx, dir);
+        free(search_dir_list);
     }
     ctx->models.module_set_id = 1;
 

--- a/src/context.c
+++ b/src/context.c
@@ -72,6 +72,7 @@ ly_ctx_new(const char *search_dir)
     char *cwd = NULL;
     char *search_dir_list;
     char *sep, *dir;
+    int rc = LY_SUCCESS;
     int i;
 
     ctx = calloc(1, sizeof *ctx);
@@ -93,19 +94,20 @@ ly_ctx_new(const char *search_dir)
     ctx->models.used = 0;
     ctx->models.size = 16;
     if (search_dir) {
-        ctx->models.search_paths = NULL;
-
         search_dir_list = strdup(search_dir);
         LY_CHECK_ERR_GOTO(!search_dir_list, LOGMEM, error);
 
-        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL; dir = sep + 1) {
+        for (dir = search_dir_list; (sep = strchr(dir, ':')) != NULL && rc == LY_SUCCESS; dir = sep + 1) {
             *sep = 0;
-            ly_ctx_set_searchdir(ctx, dir);
+            rc = ly_ctx_set_searchdir(ctx, dir);
         }
-        if (*dir) {
-            ly_ctx_set_searchdir(ctx, dir);
+        if (*dir && rc == LY_SUCCESS) {
+            rc = ly_ctx_set_searchdir(ctx, dir);
         }
         free(search_dir_list);
+        /* If ly_ctx_set_searchdir() failed, the error is already logged. Just exit */
+        if (rc)
+            goto error;
     }
     ctx->models.module_set_id = 1;
 
@@ -243,15 +245,16 @@ ly_ctx_unset_allimplemented(struct ly_ctx *ctx)
     ctx->models.flags &= ~LY_CTX_ALLIMPLEMENTED;
 }
 
-API void
+API int
 ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
 {
     char *cwd = NULL, *new = NULL;
     int index = 0;
     void *r;
+    LY_ERR rc = LY_EMEM;
 
     if (!ctx) {
-        return;
+        return LY_EINVAL;
     }
 
     if (search_dir) {
@@ -288,11 +291,13 @@ success:
             LOGWRN("Unable to return back to working directory \"%s\" (%s)",
                    cwd, strerror(errno));
         }
+        rc = LY_SUCCESS;
     }
 
 cleanup:
     free(cwd);
     free(new);
+    return rc;
 }
 
 API const char * const *

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -1114,8 +1114,9 @@ struct ly_ctx *ly_ctx_new_ylmem(const char *search_dir, const char *data, LYD_FO
  *
  * @param[in] ctx Context to be modified.
  * @param[in] search_dir New search path to add to the current paths previously set in ctx.
+ * @return LY_SUCCESS, LY_EMEM, LY_INVAL.
  */
-void ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir);
+int ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir);
 
 /**
  * @brief Clean the search path(s) from the libyang context

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -1114,7 +1114,7 @@ struct ly_ctx *ly_ctx_new_ylmem(const char *search_dir, const char *data, LYD_FO
  *
  * @param[in] ctx Context to be modified.
  * @param[in] search_dir New search path to add to the current paths previously set in ctx.
- * @return LY_SUCCESS, LY_EMEM, LY_INVAL.
+ * @return EXIT_SUCCESS, EXIT_FAILURE.
  */
 int ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir);
 


### PR DESCRIPTION
This pull request adds support for multiple search directories when creating a context using ly_ctx_new(). "search_dir" parameter accepts a list of ":"-delimited directories. 
As a side effect of this fix, sysrepoctl supports a list of search directories out of the box.