### PR TITLE
Resolve augments before leafref features will be checked

### DIFF
--- a/tests/schema/test_augment.c
+++ b/tests/schema/test_augment.c
@@ -146,6 +146,38 @@ test_leafref(void **state)
 }
 
 static void
+test_leafref_w_feature1(void **state)
+{
+    int length;
+    char *path = *state;
+    const struct lys_module *module;
+
+    ly_ctx_set_searchdir(ctx, path);
+    length = strlen(path);
+    strcpy(path + length, "/leafref_w_feature1-mod3.yang");
+    if (!(module = lys_parse_path(ctx, path, LYS_IN_YANG))) {
+        fail();
+    }
+    lys_print_mem(&yang_modules[YANG_MOD_IDX(0)], module, LYS_OUT_YANG, NULL);
+}
+
+static void
+test_leafref_w_feature2(void **state)
+{
+    int length;
+    char *path = *state;
+    const struct lys_module *module;
+
+    ly_ctx_set_searchdir(ctx, path);
+    length = strlen(path);
+    strcpy(path + length, "/leafref_w_feature2-mod1.yang");
+    if (!(module = lys_parse_path(ctx, path, LYS_IN_YANG))) {
+        fail();
+    }
+    lys_print_mem(&yang_modules[YANG_MOD_IDX(0)], module, LYS_OUT_YANG, NULL);
+}
+
+static void
 test_target_augment(void **state)
 {
     int length;
@@ -291,6 +323,8 @@ main(void)
         cmocka_unit_test_setup_teardown(test_target_include_submodule, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_leafref, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_target_augment, setup_ctx_yin, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_leafref_w_feature1, setup_ctx_yang, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_leafref_w_feature2, setup_ctx_yang, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_unres_augment, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_import_augment_target, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_target_include_submodule, setup_ctx_yang, teardown_ctx),

--- a/tests/schema/test_augment.c
+++ b/tests/schema/test_augment.c
@@ -43,7 +43,7 @@ char *yin_modules[2 * MOD_COUNT] = {0};
 static int
 setup_ctx_yin(void **state)
 {
-    *state = malloc(strlen(TESTS_DIR) + 40);
+    *state = malloc(strlen(TESTS_DIR) + 100);
     assert_non_null(*state);
     memcpy(*state, SCHEMA_FOLDER_YIN, strlen(SCHEMA_FOLDER_YIN) + 1);
 
@@ -58,7 +58,7 @@ setup_ctx_yin(void **state)
 static int
 setup_ctx_yang(void **state)
 {
-    *state = malloc(strlen(TESTS_DIR) + 40);
+    *state = malloc(strlen(TESTS_DIR) + 100);
     assert_non_null(*state);
     memcpy(*state, SCHEMA_FOLDER_YANG, strlen(SCHEMA_FOLDER_YANG) + 1);
 
@@ -158,7 +158,6 @@ test_leafref_w_feature1(void **state)
     if (!(module = lys_parse_path(ctx, path, LYS_IN_YANG))) {
         fail();
     }
-    lys_print_mem(&yang_modules[YANG_MOD_IDX(0)], module, LYS_OUT_YANG, NULL);
 }
 
 static void
@@ -174,7 +173,6 @@ test_leafref_w_feature2(void **state)
     if (!(module = lys_parse_path(ctx, path, LYS_IN_YANG))) {
         fail();
     }
-    lys_print_mem(&yang_modules[YANG_MOD_IDX(0)], module, LYS_OUT_YANG, NULL);
 }
 
 static void
@@ -323,8 +321,6 @@ main(void)
         cmocka_unit_test_setup_teardown(test_target_include_submodule, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_leafref, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_target_augment, setup_ctx_yin, teardown_ctx),
-        cmocka_unit_test_setup_teardown(test_leafref_w_feature1, setup_ctx_yang, teardown_ctx),
-        cmocka_unit_test_setup_teardown(test_leafref_w_feature2, setup_ctx_yang, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_unres_augment, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_import_augment_target, setup_ctx_yin, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_target_include_submodule, setup_ctx_yang, teardown_ctx),
@@ -332,6 +328,8 @@ main(void)
         cmocka_unit_test_setup_teardown(test_target_augment, setup_ctx_yang, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_unres_augment, setup_ctx_yang, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_import_augment_target, setup_ctx_yang, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_leafref_w_feature1, setup_ctx_yang, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_leafref_w_feature2, setup_ctx_yang, teardown_ctx),
         cmocka_unit_test_teardown(compare_output, teardown_output),
     };
 

--- a/tests/schema/yang/files/leafref_w_feature1-mod1.yang
+++ b/tests/schema/yang/files/leafref_w_feature1-mod1.yang
@@ -1,0 +1,13 @@
+module leafref_w_feature1-mod1 {
+
+  namespace "urn:fri:params:xml:ns:yang:leafref_w_feature1-mod1";
+  prefix lr-w-ftr1-m1;
+
+  feature feature1;
+
+  container cont1 {
+    if-feature feature1;
+  }
+}
+
+

--- a/tests/schema/yang/files/leafref_w_feature1-mod2.yang
+++ b/tests/schema/yang/files/leafref_w_feature1-mod2.yang
@@ -1,0 +1,34 @@
+module leafref_w_feature1-mod2 {
+
+  namespace "urn:fri:params:xml:ns:yang:leafref_w_feature1-mod2";
+  prefix lr-w-ftr1-m2;
+
+  import leafref_w_feature1-mod1 {
+    prefix lr-w-ftr1-m1;
+  }
+
+  typedef list2-ref {
+    type leafref {
+      path "/lr-w-ftr1-m1:cont1"
+         + "/lr-w-ftr1-m2:cont2"
+         + "/lr-w-ftr1-m2:list2"
+         + "/lr-w-ftr1-m2:name";
+    }
+  }
+
+  augment "/lr-w-ftr1-m1:cont1" {
+
+    description "mod2's cont1 augment";
+
+    container cont2 {
+      list list2 {
+        key name;
+        leaf name {
+          type string;
+        }
+      }
+    }
+  }
+}
+
+

--- a/tests/schema/yang/files/leafref_w_feature1-mod3.yang
+++ b/tests/schema/yang/files/leafref_w_feature1-mod3.yang
@@ -1,0 +1,33 @@
+module leafref_w_feature1-mod3 {
+
+  namespace "urn:fri:params:xml:ns:yang:leafref_w_feature1-mod3";
+  prefix lr-w-ftr1-m3;
+
+  import leafref_w_feature1-mod1 {
+    prefix lr-w-ftr1-m1;
+  }
+  import leafref_w_feature1-mod2 {
+    prefix lr-w-ftr1-m2;
+  }
+
+  augment "/lr-w-ftr1-m1:cont1" {
+
+    description "mod3's cont1 augment";
+
+    container cont3 {
+      list list3 {
+        key name;
+        leaf name {
+          type string;
+        }
+        choice choice3 {
+          case case3 {
+            leaf-list llist3 {
+              type lr-w-ftr1-m2:list2-ref;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/schema/yang/files/leafref_w_feature2-mod1.yang
+++ b/tests/schema/yang/files/leafref_w_feature2-mod1.yang
@@ -1,0 +1,45 @@
+module leafref_w_feature2-mod1 {
+
+  namespace "urn:fri:params:xml:ns:yang:leafref_w_feature2-mod1";
+  prefix lr-w-ftr2-m1;
+
+  feature feature2;
+
+  container cont1 {
+    if-feature feature2;
+  }
+
+  augment "/cont1" {
+
+    container cont11 {
+
+      list list11 {
+        key name;
+
+        leaf name {
+          type string;
+        }
+      }
+    }
+  }
+
+  augment "/cont1" {
+
+    container cont12 {
+
+      list list12 {
+        key name;
+
+        leaf name {
+          type string;
+        }
+
+        leaf-list llist12 {
+          type leafref {
+            path "/cont1/cont11/list11/name";
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi,
I have added 2 unit tests, which trigger in two different ways that the yang parser won't be able to resolve features of leafrefs, because they are part of an augment and the feature is part of the augmented tree. Both test cases address different branches in source code and have to be considered both for the possible solution.

In general, this is a problem of the parsing sequence (and might work the other way round). I have  added a suggestion how to solve this problem. Please have a look at the solution. 

Regards,
Frank