### PR TITLE
cmake: Do not write to the source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,14 +48,15 @@ else()
     set(ENABLE_CACHE_MACRO "/**\n * @brief Cache of some temporary information will not be used.\n */")
 endif()
 
-configure_file(${PROJECT_SOURCE_DIR}/src/libyang.h.in ${PROJECT_SOURCE_DIR}/src/libyang.h @ONLY)
+include_directories(${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR}/src)
+configure_file(${PROJECT_SOURCE_DIR}/src/libyang.h.in ${PROJECT_BINARY_DIR}/src/libyang.h @ONLY)
 
 if(PLUGINS_DIR)
     set(LIBYANG_EXT_PLUGINS_DIR ${PLUGINS_DIR})
 else()
     set(LIBYANG_EXT_PLUGINS_DIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libyang)
 endif()
-configure_file(${PROJECT_SOURCE_DIR}/src/extensions_config.h.in ${PROJECT_SOURCE_DIR}/src/extensions_config.h)
+configure_file(${PROJECT_SOURCE_DIR}/src/extensions_config.h.in ${PROJECT_BINARY_DIR}/src/extensions_config.h)
 
 # include custom Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
@@ -84,7 +85,7 @@ else()
     else ()
         set(EMPTYDIR "%empty")
     endif()
-    configure_file(${PROJECT_SOURCE_DIR}/src/yang.y.in ${PROJECT_SOURCE_DIR}/src/yang.y)
+    configure_file(${PROJECT_SOURCE_DIR}/src/yang.y.in ${PROJECT_BINARY_DIR}/src/yang.y)
     add_custom_target(bison
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/src
         COMMAND bison -l -o parser_yang_bis.c --defines=parser_yang_bis.h yang.y
@@ -199,7 +200,6 @@ set(yang2yinsrc
     tools/yang2yin/main.c)
 
 set(headers
-    src/libyang.h
     src/tree_schema.h
     src/tree_data.h
     src/extensions.h
@@ -229,7 +229,7 @@ include_directories(${PCRE_INCLUDE_DIRS})
 target_link_libraries(yang ${PCRE_LIBRARIES})
 
 install(TARGETS yang DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libyang)
+install(FILES ${headers} ${PROJECT_BINARY_DIR}/src/libyang.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libyang)
 
 find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,7 +39,8 @@ foreach(test_name IN LISTS api_tests data_tests schema_yin_tests schema_tests co
     set_property(TEST ${test_name} APPEND PROPERTY ENVIRONMENT "MALLOC_CHECK_=3")
 endforeach(test_name)
 
-configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_SOURCE_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
+configure_file("${PROJECT_SOURCE_DIR}/tests/config.h.in" "${PROJECT_BINARY_DIR}/tests/config.h" ESCAPE_QUOTES @ONLY)
+include_directories(${PROJECT_BINARY_DIR})
 
 if(ENABLE_VALGRIND_TESTS)
     find_program(valgrind_FOUND valgrind)

--- a/tests/api/test_dict.c
+++ b/tests/api/test_dict.c
@@ -27,8 +27,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct ly_ctx *ctx = NULL;
 

--- a/tests/api/test_diff.c
+++ b/tests/api/test_diff.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/api/test_libyang.c
+++ b/tests/api/test_libyang.c
@@ -28,8 +28,8 @@
 #include <string.h>
 #include <limits.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 /* include private header to be able to check internal values */
 #include "../../src/context.h"

--- a/tests/api/test_tree_data.c
+++ b/tests/api/test_tree_data.c
@@ -27,8 +27,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 #include "../../src/tree_data.h"
 #include "../../src/tree_schema.h"
 

--- a/tests/api/test_tree_data_dup.c
+++ b/tests/api/test_tree_data_dup.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx1;

--- a/tests/api/test_tree_data_merge.c
+++ b/tests/api/test_tree_data_merge.c
@@ -20,8 +20,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx1;

--- a/tests/api/test_tree_schema.c
+++ b/tests/api/test_tree_schema.c
@@ -25,8 +25,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TMP_TEMPLATE "/tmp/libyang-XXXXXX"
 

--- a/tests/api/test_xml.c
+++ b/tests/api/test_xml.c
@@ -27,8 +27,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TMP_TEMPLATE "/tmp/libyang-XXXXXX"
 

--- a/tests/api/test_xpath.c
+++ b/tests/api/test_xpath.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/api/test_xpath_1.1.c
+++ b/tests/api/test_xpath_1.1.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/callgrind/create_data.c
+++ b/tests/callgrind/create_data.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 #define SCHEMA "files/ietf-interfaces.yang"
 #define SCHEMA2 "files/ietf-ip.yang"

--- a/tests/callgrind/list_manipulation.c
+++ b/tests/callgrind/list_manipulation.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 #define SCHEMA "files/lists.yang"
 #define DATA1 "files/lists.xml"

--- a/tests/callgrind/validate.c
+++ b/tests/callgrind/validate.c
@@ -1,6 +1,6 @@
 #include <stdlib.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 int
 main(int argc, char **argv)

--- a/tests/conformance/test_sec5_1.c
+++ b/tests/conformance/test_sec5_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec5_1"
 #define TEST_NAME test_sec5_1

--- a/tests/conformance/test_sec5_5.c
+++ b/tests/conformance/test_sec5_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec5_5"
 #define TEST_NAME test_sec5_5

--- a/tests/conformance/test_sec6_1_1.c
+++ b/tests/conformance/test_sec6_1_1.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_NAME test_sec6_1_1
 #define TEST_SCHEMA "sec6_1_1/mod.yang"

--- a/tests/conformance/test_sec6_1_3.c
+++ b/tests/conformance/test_sec6_1_3.c
@@ -20,8 +20,8 @@
 #include <cmocka.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec6_1_3"
 #define TEST_NAME test_sec6_1_3

--- a/tests/conformance/test_sec6_2.c
+++ b/tests/conformance/test_sec6_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec6_2"
 #define TEST_NAME test_sec6_2

--- a/tests/conformance/test_sec6_2_1.c
+++ b/tests/conformance/test_sec6_2_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec6_2_1"
 #define TEST_NAME test_sec6_2_1

--- a/tests/conformance/test_sec7_1.c
+++ b/tests/conformance/test_sec7_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_1"
 #define TEST_NAME test_sec7_1

--- a/tests/conformance/test_sec7_10.c
+++ b/tests/conformance/test_sec7_10.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_10"
 #define TEST_NAME test_sec7_10

--- a/tests/conformance/test_sec7_11.c
+++ b/tests/conformance/test_sec7_11.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_11"
 #define TEST_NAME test_sec7_11

--- a/tests/conformance/test_sec7_12_1.c
+++ b/tests/conformance/test_sec7_12_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_12_1"
 #define TEST_NAME test_sec7_12_1

--- a/tests/conformance/test_sec7_12_2.c
+++ b/tests/conformance/test_sec7_12_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_12_2"
 #define TEST_NAME test_sec7_12_2

--- a/tests/conformance/test_sec7_13_1.c
+++ b/tests/conformance/test_sec7_13_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_13_1"
 #define TEST_NAME test_sec7_13_1

--- a/tests/conformance/test_sec7_13_2.c
+++ b/tests/conformance/test_sec7_13_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_13_2"
 #define TEST_NAME test_sec7_13_2

--- a/tests/conformance/test_sec7_13_3.c
+++ b/tests/conformance/test_sec7_13_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_13_3"
 #define TEST_NAME test_sec7_13_3

--- a/tests/conformance/test_sec7_14.c
+++ b/tests/conformance/test_sec7_14.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_14"
 #define TEST_NAME test_sec7_14

--- a/tests/conformance/test_sec7_15.c
+++ b/tests/conformance/test_sec7_15.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_15"
 #define TEST_NAME test_sec7_15

--- a/tests/conformance/test_sec7_16_1.c
+++ b/tests/conformance/test_sec7_16_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_16_1"
 #define TEST_NAME test_sec7_16_1

--- a/tests/conformance/test_sec7_16_2.c
+++ b/tests/conformance/test_sec7_16_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_16_2"
 #define TEST_NAME test_sec7_16_2

--- a/tests/conformance/test_sec7_18_1.c
+++ b/tests/conformance/test_sec7_18_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_18_1"
 #define TEST_NAME test_sec7_18_1

--- a/tests/conformance/test_sec7_18_2.c
+++ b/tests/conformance/test_sec7_18_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_18_2"
 #define TEST_NAME test_sec7_18_2

--- a/tests/conformance/test_sec7_18_3_1.c
+++ b/tests/conformance/test_sec7_18_3_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_18_3_1"
 #define TEST_NAME test_sec7_18_3_1

--- a/tests/conformance/test_sec7_18_3_2.c
+++ b/tests/conformance/test_sec7_18_3_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_18_3_2"
 #define TEST_NAME test_sec7_18_3_2

--- a/tests/conformance/test_sec7_19_1.c
+++ b/tests/conformance/test_sec7_19_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_19_1"
 #define TEST_NAME test_sec7_19_1

--- a/tests/conformance/test_sec7_19_2.c
+++ b/tests/conformance/test_sec7_19_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_19_2"
 #define TEST_NAME test_sec7_19_2

--- a/tests/conformance/test_sec7_19_5.c
+++ b/tests/conformance/test_sec7_19_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_19_5"
 #define TEST_NAME test_sec7_19_5

--- a/tests/conformance/test_sec7_2.c
+++ b/tests/conformance/test_sec7_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_2"
 #define TEST_NAME test_sec7_2

--- a/tests/conformance/test_sec7_3.c
+++ b/tests/conformance/test_sec7_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_3"
 #define TEST_NAME test_sec7_3

--- a/tests/conformance/test_sec7_3_1.c
+++ b/tests/conformance/test_sec7_3_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_3_1"
 #define TEST_NAME test_sec7_3_1

--- a/tests/conformance/test_sec7_3_4.c
+++ b/tests/conformance/test_sec7_3_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_3_4"
 #define TEST_NAME test_sec7_3_4

--- a/tests/conformance/test_sec7_5_2.c
+++ b/tests/conformance/test_sec7_5_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_5_2"
 #define TEST_NAME test_sec7_5_2

--- a/tests/conformance/test_sec7_5_4.c
+++ b/tests/conformance/test_sec7_5_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_5_4"
 #define TEST_NAME test_sec7_5_4

--- a/tests/conformance/test_sec7_5_5.c
+++ b/tests/conformance/test_sec7_5_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_5_5"
 #define TEST_NAME test_sec7_5_5

--- a/tests/conformance/test_sec7_6_2.c
+++ b/tests/conformance/test_sec7_6_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_6_2"
 #define TEST_NAME test_sec7_6_2

--- a/tests/conformance/test_sec7_6_3.c
+++ b/tests/conformance/test_sec7_6_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_6_3"
 #define TEST_NAME test_sec7_6_3

--- a/tests/conformance/test_sec7_6_4.c
+++ b/tests/conformance/test_sec7_6_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_6_4"
 #define TEST_NAME test_sec7_6_4

--- a/tests/conformance/test_sec7_6_5.c
+++ b/tests/conformance/test_sec7_6_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_6_5"
 #define TEST_NAME test_sec7_6_5

--- a/tests/conformance/test_sec7_7_2.c
+++ b/tests/conformance/test_sec7_7_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_7_2"
 #define TEST_NAME test_sec7_7_2

--- a/tests/conformance/test_sec7_7_3.c
+++ b/tests/conformance/test_sec7_7_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_7_3"
 #define TEST_NAME test_sec7_7_3

--- a/tests/conformance/test_sec7_7_4.c
+++ b/tests/conformance/test_sec7_7_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_7_4"
 #define TEST_NAME test_sec7_7_4

--- a/tests/conformance/test_sec7_7_5.c
+++ b/tests/conformance/test_sec7_7_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_7_5"
 #define TEST_NAME test_sec7_7_5

--- a/tests/conformance/test_sec7_8_1.c
+++ b/tests/conformance/test_sec7_8_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_8_1"
 #define TEST_NAME test_sec7_8_1

--- a/tests/conformance/test_sec7_8_2.c
+++ b/tests/conformance/test_sec7_8_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_8_2"
 #define TEST_NAME test_sec7_8_2

--- a/tests/conformance/test_sec7_8_3.c
+++ b/tests/conformance/test_sec7_8_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_8_3"
 #define TEST_NAME test_sec7_8_3

--- a/tests/conformance/test_sec7_9_1.c
+++ b/tests/conformance/test_sec7_9_1.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_9_1"
 #define TEST_NAME test_sec7_9_1

--- a/tests/conformance/test_sec7_9_2.c
+++ b/tests/conformance/test_sec7_9_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_9_2"
 #define TEST_NAME test_sec7_9_2

--- a/tests/conformance/test_sec7_9_3.c
+++ b/tests/conformance/test_sec7_9_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_9_3"
 #define TEST_NAME test_sec7_9_3

--- a/tests/conformance/test_sec7_9_4.c
+++ b/tests/conformance/test_sec7_9_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec7_9_4"
 #define TEST_NAME test_sec7_9_4

--- a/tests/conformance/test_sec9_10.c
+++ b/tests/conformance/test_sec9_10.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_10"
 #define TEST_NAME test_sec9_10

--- a/tests/conformance/test_sec9_11.c
+++ b/tests/conformance/test_sec9_11.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_11"
 #define TEST_NAME test_sec9_11

--- a/tests/conformance/test_sec9_12.c
+++ b/tests/conformance/test_sec9_12.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_12"
 #define TEST_NAME test_sec9_12

--- a/tests/conformance/test_sec9_13.c
+++ b/tests/conformance/test_sec9_13.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_13"
 #define TEST_NAME test_sec9_13

--- a/tests/conformance/test_sec9_2.c
+++ b/tests/conformance/test_sec9_2.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_2"
 #define TEST_NAME test_sec7_9_2

--- a/tests/conformance/test_sec9_3.c
+++ b/tests/conformance/test_sec9_3.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_3"
 #define TEST_NAME test_sec9_3

--- a/tests/conformance/test_sec9_4_4.c
+++ b/tests/conformance/test_sec9_4_4.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_4_4"
 #define TEST_NAME test_sec7_9_4_4

--- a/tests/conformance/test_sec9_4_6.c
+++ b/tests/conformance/test_sec9_4_6.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_4_6"
 #define TEST_NAME test_sec9_4_6

--- a/tests/conformance/test_sec9_5.c
+++ b/tests/conformance/test_sec9_5.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_5"
 #define TEST_NAME test_sec9_5

--- a/tests/conformance/test_sec9_6.c
+++ b/tests/conformance/test_sec9_6.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_6"
 #define TEST_NAME test_sec9_6

--- a/tests/conformance/test_sec9_7.c
+++ b/tests/conformance/test_sec9_7.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_7"
 #define TEST_NAME test_sec9_7

--- a/tests/conformance/test_sec9_8.c
+++ b/tests/conformance/test_sec9_8.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_8"
 #define TEST_NAME test_sec9_8

--- a/tests/conformance/test_sec9_9.c
+++ b/tests/conformance/test_sec9_9.c
@@ -21,8 +21,8 @@
 #include <string.h>
 #include <sys/wait.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 #define TEST_DIR "sec9_9"
 #define TEST_NAME test_sec9_9

--- a/tests/data/test_autodel.c
+++ b/tests/data/test_autodel.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_data_initialization.c
+++ b/tests/data/test_data_initialization.c
@@ -25,8 +25,8 @@
 #include <unistd.h>
 #include <string.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct ly_ctx *ctx = NULL;
 struct lyd_node *root = NULL;

--- a/tests/data/test_defaults.c
+++ b/tests/data/test_defaults.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_emptycont.c
+++ b/tests/data/test_emptycont.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_instid_remove.c
+++ b/tests/data/test_instid_remove.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_json.c
+++ b/tests/data/test_json.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_keys.c
+++ b/tests/data/test_keys.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_leafref_remove.c
+++ b/tests/data/test_leafref_remove.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_mandatory.c
+++ b/tests/data/test_mandatory.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_metadata.c
+++ b/tests/data/test_metadata.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_must_1.1.c
+++ b/tests/data/test_must_1.1.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_parse_print.c
+++ b/tests/data/test_parse_print.c
@@ -22,8 +22,8 @@
 #include <string.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_unique.c
+++ b/tests/data/test_unique.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_values.c
+++ b/tests/data/test_values.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_when.c
+++ b/tests/data/test_when.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/data/test_when_1.1.c
+++ b/tests/data/test_when_1.1.c
@@ -17,8 +17,8 @@
 #include <setjmp.h>
 #include <cmocka.h>
 
-#include "../config.h"
-#include "../../src/libyang.h"
+#include "tests/config.h"
+#include "libyang.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/schema/test_augment.c
+++ b/tests/schema/test_augment.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/files"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"

--- a/tests/schema/test_conformance.c
+++ b/tests/schema/test_conformance.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/conformance"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/conformance"

--- a/tests/schema/test_deviation.c
+++ b/tests/schema/test_deviation.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"
 

--- a/tests/schema/test_extensions.c
+++ b/tests/schema/test_extensions.c
@@ -26,8 +26,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/files"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"

--- a/tests/schema/test_feature.c
+++ b/tests/schema/test_feature.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/files"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"

--- a/tests/schema/test_ietf.c
+++ b/tests/schema/test_ietf.c
@@ -28,9 +28,9 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 #include "../../src/context.h"
-#include "../config.h"
+#include "tests/config.h"
 
 #define SCHEMA_COUNT 17
 

--- a/tests/schema/test_import.c
+++ b/tests/schema/test_import.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/files"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"

--- a/tests/schema/test_include.c
+++ b/tests/schema/test_include.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YIN TESTS_DIR"/schema/yin/files"
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"

--- a/tests/schema/test_leaflist.c
+++ b/tests/schema/test_leaflist.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 static int
 setup_ctx(void **state)

--- a/tests/schema/test_refine.c
+++ b/tests/schema/test_refine.c
@@ -25,8 +25,8 @@
 
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 #define SCHEMA_FOLDER_YANG TESTS_DIR"/schema/yang/files"
 

--- a/tests/schema/test_status.c
+++ b/tests/schema/test_status.c
@@ -25,8 +25,8 @@
 #include <stdarg.h>
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/schema/test_typedef.c
+++ b/tests/schema/test_typedef.c
@@ -25,8 +25,8 @@
 #include <stdarg.h>
 #include <cmocka.h>
 
-#include "../../src/libyang.h"
-#include "../config.h"
+#include "libyang.h"
+#include "tests/config.h"
 
 struct state {
     struct ly_ctx *ctx;

--- a/tests/schema/yin/test_print_transform.c
+++ b/tests/schema/yin/test_print_transform.c
@@ -27,8 +27,8 @@
 
 #include <cmocka.h>
 
-#include "../../../src/libyang.h"
-#include "../../config.h"
+#include "libyang.h"
+#include "../tests/config.h"
 
 #define SCHEMA_FOLDER TESTS_DIR"/schema/yin/files"
 

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -24,7 +24,7 @@
 #include <libgen.h>
 
 #include "commands.h"
-#include "../../src/libyang.h"
+#include "libyang.h"
 #include "../../src/tree_schema.h"
 #include "../../src/tree_data.h"
 #include "../../src/xpath.h"

--- a/tools/lint/commands.h
+++ b/tools/lint/commands.h
@@ -23,7 +23,7 @@
 
 #include <stdlib.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 #define PROMPT "> "
 

--- a/tools/lint/completion.c
+++ b/tools/lint/completion.c
@@ -21,7 +21,7 @@
 
 #include "commands.h"
 #include "../../linenoise/linenoise.h"
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 extern struct ly_ctx *ctx;
 

--- a/tools/lint/main.c
+++ b/tools/lint/main.c
@@ -22,7 +22,7 @@
 #include "configuration.h"
 #include "completion.h"
 #include "../../linenoise/linenoise.h"
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 int done;
 struct ly_ctx *ctx = NULL;

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -25,7 +25,7 @@
 #include <unistd.h>
 
 #include "commands.h"
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 volatile int verbose = 0;
 

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -23,7 +23,7 @@
 #include <getopt.h>
 #include <unistd.h>
 
-#include "../../src/libyang.h"
+#include "libyang.h"
 
 void
 help(void)


### PR DESCRIPTION
We're including libyang as a git submodule in our downstream project.
Once we perform the build for the first time, `git status` in our
internal integration repository starts showing the libyang submodule as
"dirty" because libyang's build places files into the source directory.

This commit ensures that the original, source directory remains
unmodified.