### PR TITLE
readdir: d_type might be always DT_UNKNOWN

### DIFF
--- a/src/extensions.c
+++ b/src/extensions.c
@@ -110,11 +110,6 @@ lyext_load_plugins(void)
     pthread_mutex_lock(&ext_lock);
 
     while ((file = readdir(dir))) {
-        if (file->d_type != DT_REG && file->d_type != DT_LNK) {
-            /* other files than regular and symbolic links are ignored */
-            continue;
-        }
-
         /* required format of the filename is *LYEXT_PLUGIN_SUFFIX */
         len = strlen(file->d_name);
         if (len < LYEXT_PLUGIN_SUFFIX_LEN + 1 ||


### PR DESCRIPTION
Since 894cc3aa (or f114b809) libyang skips plugins for which `readdir`
returns `DT_UNKNOWN` in their `d_type`. That's apparently wrong, here's
what my manpage says:

> Currently, only some filesystems (among them: Btrfs, ext2, ext3, and
> ext4) have full support for returning the file type in d_type.  All
> applications must properly handle a return of `DT_UNKNOWN`.

It seems that RHEL7 returns `DT_UNKNOWN` for all files on XFS. At least
that's what I'm seeing on a random CentOS7 instance with kernel
3.10.0-123.6.3.el7.x86_64. This paywalled link [1] might be relevant.
For added extra fun, I'm *not* seeing that behavior on vanilla 4.13.2.

It seems that this check is there just as some possibly irrelevant
performance optimization (do we expect to ever have extra files in that
directory?). Given that this code used to work fine when it always
evaluated as false, it seems safe to remove it completely.

[1] https://access.redhat.com/solutions/2322911