### PR TITLE
add C++ exceptions (and Python) to C++ language bindings

### DIFF
--- a/swig/cpp/src/Internal.cpp
+++ b/swig/cpp/src/Internal.cpp
@@ -24,6 +24,14 @@ extern "C" {
 #include "tree_schema.h"
 }
 
+void check_libyang_error() {
+    const char *errmsg = ly_errmsg();
+
+    if (errmsg) {
+        throw std::runtime_error(errmsg);
+    }
+};
+
 Deleter::Deleter(ly_ctx *ctx, S_Deleter parent):
     t(Free_Type::CONTEXT),
     parent(parent),

--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -143,6 +143,8 @@ extern "C" {
 #include "libyang.h"
 }
 
+void check_libyang_error();
+
 /* defined */
 class Deleter;
 

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -289,3 +289,8 @@ int Set::rm(S_Schema_Node node) {
 int Set::rm_index(unsigned int index) {
     return ly_set_rm_index(set, index);
 }
+
+/* API for wrapping struct ly_ctx from libnetconf2 python bindings */
+S_Context create_new_Context(struct ly_ctx *new_ctx) {
+    return new_ctx ? std::make_shared<Context>(new_ctx, nullptr) : nullptr;
+}

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -105,6 +105,8 @@ private:
     S_Deleter deleter;
 };
 
+S_Context create_new_Context(struct ly_ctx *ctx);
+
 class Set
 {
 public:

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -73,7 +73,7 @@ public:
     Context(const char *search_dir, const char *path, LYD_FORMAT format, int options = 0);
     Context(const char *search_dir, LYD_FORMAT format, const char *data, int options = 0);
     ~Context();
-    int set_searchdir(const char *search_dir) {return ly_ctx_set_searchdir(ctx, search_dir);};
+    int set_searchdir(const char *search_dir);
     void unset_searchdirs(int idx) {return ly_ctx_unset_searchdirs(ctx, idx);};
     std::vector<std::string> *get_searchdirs();
     void set_allimplemented() {return ly_ctx_set_allimplemented(ctx);};

--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -117,11 +117,11 @@ public:
     S_Data_Node first_sibling();
     int validate(int options, S_Context var_arg);
     int validate(int options, S_Data_Node var_arg);
-    int validate_value(const char *value) {return lyd_validate_value(node->schema, value);};
+    int validate_value(const char *value);
     S_Difflist diff(S_Data_Node second, int options);
     S_Data_Node new_path(S_Context ctx, const char *path, void *value, LYD_ANYDATA_VALUETYPE value_type, int options);
-    unsigned int list_pos() {return lyd_list_pos(node);};
-    int unlink() {return lyd_unlink(node);};
+    unsigned int list_pos();
+    int unlink();
     S_Attr insert_attr(S_Module module, const char *name, const char *value);
     S_Module node_module();
     std::string print_mem(LYD_FORMAT format, int options);

--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -204,6 +204,7 @@ S_Schema_Node Schema_Node::prev() LY_NEW(node, prev, Schema_Node);
 S_Set Schema_Node::find_xpath(const char *path) {
     struct ly_set *set = lys_find_path(node->module, node, path);
     if (!set) {
+        check_libyang_error();
         return nullptr;
     }
 
@@ -213,6 +214,7 @@ S_Set Schema_Node::find_xpath(const char *path) {
 S_Set Schema_Node::xpath_atomize(enum lyxp_node_type ctx_node_type, const char *expr, int options) {
     struct ly_set *set = lys_xpath_atomize(node, ctx_node_type, expr, options);
     if (!set) {
+        check_libyang_error();
         return nullptr;
     }
 
@@ -221,6 +223,7 @@ S_Set Schema_Node::xpath_atomize(enum lyxp_node_type ctx_node_type, const char *
 S_Set Schema_Node::xpath_atomize(int options) {
     struct ly_set *set = lys_node_xpath_atomize(node, options);
     if (!set) {
+        check_libyang_error();
         return nullptr;
     }
 

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -49,7 +49,6 @@
 %shared_ptr(Set);
 %newobject Set::dup;
 
-
 /* Tree_Data.hpp */
 %newobject create_new_Data_Node;
 

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -49,6 +49,8 @@
 %shared_ptr(Set);
 %newobject Set::dup;
 
+%newobject create_new_Context;
+
 /* Tree_Data.hpp */
 %newobject create_new_Data_Node;
 


### PR DESCRIPTION
This is the first version of the C++ exception refactoring.

@rkrejci please can you check if this patch works in your use case.