### PR TITLE
Use absolute paths in includes for generated libyang.h file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ else()
 endif()
 
 include_directories(${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR}/src)
+
+set(LIBYANG_SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 configure_file(${PROJECT_SOURCE_DIR}/src/libyang.h.in ${PROJECT_BINARY_DIR}/src/libyang.h @ONLY)
 
 if(PLUGINS_DIR)

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -21,10 +21,10 @@
 
 @ENABLE_LATEST_REVISIONS_MACRO@
 
-#include "tree_schema.h"
-#include "tree_data.h"
-#include "xml.h"
-#include "dict.h"
+#include "@LIBYANG_SOURCE_DIR@/tree_schema.h"
+#include "@LIBYANG_SOURCE_DIR@/tree_data.h"
+#include "@LIBYANG_SOURCE_DIR@/xml.h"
+#include "@LIBYANG_SOURCE_DIR@/dict.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
I work on a project that uses the libyang library,
and to do so I need to include the generated 'libyang.h' file
in my source code.

However, because the includes inside 'libyang.h' use relative paths,
I need to include both the libyang source and build directories:

    include_directories(${PROJECT_BINARY_DIR}/libyang/src ${PROJECT_SOURCE_DIR}/libyang/src)

With this change, only the binary directory must be included,
making it easier to use libyang.

