### PR TITLE
Python: set install path based on CMAKE_INSTALL_PREFIX

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -16,10 +16,13 @@ execute_process(COMMAND ${SWIG_EXECUTABLE} -python -external-runtime ${CMAKE_CUR
 
 file(COPY "examples" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-execute_process(COMMAND
-    ${PYTHON_EXECUTABLE} -c
-    "from distutils.sysconfig import get_python_lib; print(get_python_lib())"
-OUTPUT_VARIABLE PYTHON_MODULE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}'))"
+                OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+                OUTPUT_STRIP_TRAILING_WHITESPACE )
+
+get_filename_component(_ABS_PYTHON_MODULE_PATH ${_ABS_PYTHON_MODULE_PATH} ABSOLUTE)
+file(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
+set(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
 
 install( FILES "${CMAKE_CURRENT_BINARY_DIR}/_${PYTHON_SWIG_BINDING}.so" DESTINATION ${PYTHON_MODULE_PATH})
 install( FILES "${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_SWIG_BINDING}.py" DESTINATION ${PYTHON_MODULE_PATH})


### PR DESCRIPTION
With this pull request the Python bindings can be installed at "/usr/local/lib/python*" also, it depends on the cmake variable CMAKE_INSTALL_PREFIX.