### PR TITLE
Python: change name from libyang to yang

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(PYTHON_SWIG_BINDING libyang)
+set(PYTHON_SWIG_BINDING yang)
 include_directories(${PYTHON_INCLUDE_PATH})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -6,7 +6,7 @@ set(CMAKE_SWIG_FLAGS "-c++")
 set(CMAKE_SWIG_FLAGS "-I${PROJECT_SOURCE_DIR}")
 set(CMAKE_SWIG_OUTDIR ${CMAKE_CURRENT_BINARY_DIR})
 
-set_source_files_properties(${PYTHON_SWIG_BINDING}.i PROPERTIES CPLUSPLUS ON)
+set_source_files_properties(${PYTHON_SWIG_BINDING}.i PROPERTIES CPLUSPLUS ON PREFIX "")
 
 swig_add_module(${PYTHON_SWIG_BINDING} python ${PYTHON_SWIG_BINDING}.i)
 swig_link_libraries(${PYTHON_SWIG_BINDING} ${PYTHON_LIBRARIES} libyang_cpp)

--- a/swig/python/examples/context.py
+++ b/swig/python/examples/context.py
@@ -2,7 +2,7 @@ __author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
 __copyright__ = "Copyright 2017, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
-import libyang as ly
+import yang as ly
 
 try:
     ctx = ly.Context("/etc/sysrepo2/yang")

--- a/swig/python/examples/process_tree.py
+++ b/swig/python/examples/process_tree.py
@@ -2,7 +2,7 @@ __author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
 __copyright__ = "Copyright 2017, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
-import libyang as ly
+import yang as ly
 
 try:
     ctx = ly.Context("/etc/sysrepo/yang")

--- a/swig/python/examples/subtype.py
+++ b/swig/python/examples/subtype.py
@@ -2,7 +2,7 @@ __author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
 __copyright__ = "Copyright 2017, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
-import libyang as ly
+import yang as ly
 
 try:
     ctx = ly.Context("/etc/sysrepo/yang")

--- a/swig/python/examples/xpath.py
+++ b/swig/python/examples/xpath.py
@@ -2,7 +2,7 @@ __author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
 __copyright__ = "Copyright 2017, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
-import libyang as ly
+import yang as ly
 
 try:
     ctx = ly.Context("/etc/sysrepo/yang")

--- a/swig/python/yang.i
+++ b/swig/python/yang.i
@@ -1,4 +1,4 @@
-%module libyang
+%module yang
 
 %{
     extern "C" {


### PR DESCRIPTION
Changed the libyang Python bindings from "libyang" to "yang".