### PR TITLE
parser: correct compilation error on Mac OS X <= 10.10

### DIFF
--- a/src/parser.h
+++ b/src/parser.h
@@ -23,7 +23,9 @@
 #include "tree_internal.h"
 
 #ifdef __APPLE__
-#define MAP_ANONYMOUS MAP_ANON
+# ifndef MAP_ANONYMOUS
+#  define MAP_ANONYMOUS MAP_ANON
+# endif
 #endif
 
 /**

--- a/src/parser.h
+++ b/src/parser.h
@@ -22,6 +22,10 @@
 #include "tree_schema.h"
 #include "tree_internal.h"
 
+#ifdef __APPLE__
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+
 /**
  * @defgroup yin YIN format support
  * @{


### PR DESCRIPTION
On these systems, only the (deprecated) POSIX MAP_ANON definition is
provided; MAP_ANONYMOUS is not provided. Thus this change provides the
alias on Apple systems to correct this compilation error:

  .../libyang/src/parser.c:286:75: error: use of undeclared identifier 'MAP_ANONYMOUS'
        *addr = mmap(NULL, *length, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
                                                                          ^
  1 error generated.

(Corrects #443)