### PR TITLE
Python: use fixed path for module path search

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -16,13 +16,9 @@ execute_process(COMMAND ${SWIG_EXECUTABLE} -python -external-runtime ${CMAKE_CUR
 
 file(COPY "examples" DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(plat_specific=True, prefix='${CMAKE_INSTALL_PREFIX}'))"
-                OUTPUT_VARIABLE _ABS_PYTHON_MODULE_PATH
+execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True))"
+                OUTPUT_VARIABLE PYTHON_MODULE_PATH
                 OUTPUT_STRIP_TRAILING_WHITESPACE )
-
-get_filename_component(_ABS_PYTHON_MODULE_PATH ${_ABS_PYTHON_MODULE_PATH} ABSOLUTE)
-file(RELATIVE_PATH _REL_PYTHON_MODULE_PATH ${CMAKE_INSTALL_PREFIX} ${_ABS_PYTHON_MODULE_PATH})
-set(PYTHON_MODULE_PATH ${_REL_PYTHON_MODULE_PATH})
 
 install( TARGETS _${PYTHON_SWIG_BINDING} DESTINATION ${PYTHON_MODULE_PATH})
 install( FILES "${CMAKE_CURRENT_BINARY_DIR}/${PYTHON_SWIG_BINDING}.py" DESTINATION ${PYTHON_MODULE_PATH})


### PR DESCRIPTION
Fixed the issue where the python module path would be searched based on the CMAKE_INSTALL_PREFIX. Now the PYTHON_MODULE_PATH is set to /usr/lib/python[2|3]/dist-packages.

One issue remains, python does not look for libyang-cpp in /usr/local, so the python bindings will work only when CMAKE_INSTALL_PREFIX is set to "/usr".

I'm trying to fix this issue in swig.