### PR TITLE
Python: Add unit tests

### DIFF
--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -304,13 +304,13 @@ LY_LOG_LEVEL set_log_verbosity(LY_LOG_LEVEL level)
 }
 
 Set::Set() {
-    struct ly_set *set = ly_set_new();
-    if (!set) {
+    struct ly_set *set_new = ly_set_new();
+    if (!set_new) {
         check_libyang_error(nullptr);
     }
 
-    set = set;
-    deleter = std::make_shared<Deleter>(set);
+    set = set_new;
+    deleter = std::make_shared<Deleter>(set_new);
 }
 Set::Set(struct ly_set *set, S_Deleter deleter):
     set(set),

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -206,6 +206,31 @@ S_Data_Node Context::parse_fd(int fd, LYD_FORMAT format, int options) {
     S_Deleter new_deleter = std::make_shared<Deleter>(new_node, deleter);
     return std::make_shared<Data_Node>(new_node, new_deleter);
 }
+
+S_Module Context::parse_module_mem(const char *data, LYS_INFORMAT format) {
+    struct lys_module *module = nullptr;
+
+    module = (struct lys_module *) lys_parse_mem(ctx, data, format);
+    if (!module) {
+        check_libyang_error(ctx);
+        return nullptr;
+    }
+
+    S_Deleter new_deleter = std::make_shared<Deleter>(module, deleter);
+    return std::make_shared<Module>(module, new_deleter);
+}
+S_Module Context::parse_module_fd(int fd, LYS_INFORMAT format) {
+    struct lys_module *module = nullptr;
+
+    module = (struct lys_module *) lys_parse_fd(ctx, fd, format);
+    if (!module) {
+        check_libyang_error(ctx);
+        return nullptr;
+    }
+
+    S_Deleter new_deleter = std::make_shared<Deleter>(module, deleter);
+    return std::make_shared<Module>(module, new_deleter);
+}
 S_Module Context::parse_path(const char *path, LYS_INFORMAT format) {
     struct lys_module *module = nullptr;
 

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -182,7 +182,7 @@ std::vector<S_Schema_Node> *Context::data_instantiables(int options) {
 
     return s_vector;
 }
-S_Data_Node Context::parse_mem(const char *data, LYD_FORMAT format, int options) {
+S_Data_Node Context::parse_data_mem(const char *data, LYD_FORMAT format, int options) {
     struct lyd_node *new_node = nullptr;
 
     new_node = lyd_parse_mem(ctx, data, format, options);
@@ -194,7 +194,7 @@ S_Data_Node Context::parse_mem(const char *data, LYD_FORMAT format, int options)
     S_Deleter new_deleter = std::make_shared<Deleter>(new_node, deleter);
     return std::make_shared<Data_Node>(new_node, new_deleter);
 }
-S_Data_Node Context::parse_fd(int fd, LYD_FORMAT format, int options) {
+S_Data_Node Context::parse_data_fd(int fd, LYD_FORMAT format, int options) {
     struct lyd_node *new_node = nullptr;
 
     new_node = lyd_parse_fd(ctx, fd, format, options);
@@ -231,7 +231,7 @@ S_Module Context::parse_module_fd(int fd, LYS_INFORMAT format) {
     S_Deleter new_deleter = std::make_shared<Deleter>(module, deleter);
     return std::make_shared<Module>(module, new_deleter);
 }
-S_Module Context::parse_path(const char *path, LYS_INFORMAT format) {
+S_Module Context::parse_module_path(const char *path, LYS_INFORMAT format) {
     struct lys_module *module = nullptr;
 
     module = (struct lys_module *) lys_parse_path(ctx, path, format);
@@ -255,7 +255,7 @@ S_Data_Node Context::parse_data_path(const char *path, LYD_FORMAT format, int op
     S_Deleter new_deleter = std::make_shared<Deleter>(new_node, deleter);
     return std::make_shared<Data_Node>(new_node, new_deleter);
 }
-S_Data_Node Context::parse_xml(S_Xml_Elem elem, int options) {
+S_Data_Node Context::parse_data_xml(S_Xml_Elem elem, int options) {
     struct lyd_node *new_node = nullptr;
 
     new_node = lyd_parse_xml(ctx, &elem->elem, options);

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -72,6 +72,8 @@ public:
     S_Data_Node parse_fd(int fd, LYD_FORMAT format, int options = 0);
     S_Data_Node parse_data_path(const char *path, LYD_FORMAT format, int options = 0);
     S_Data_Node parse_xml(S_Xml_Elem elem, int options = 0);
+    S_Module parse_module_mem(const char *data, LYS_INFORMAT format);
+    S_Module parse_module_fd(int fd, LYS_INFORMAT format);
     S_Module parse_path(const char *path, LYS_INFORMAT format);
 
     friend std::vector<S_Error> *get_ly_errors(S_Context context);

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -68,13 +68,13 @@ public:
     void clean();
 
     /* functions */
-    S_Data_Node parse_mem(const char *data, LYD_FORMAT format, int options = 0);
-    S_Data_Node parse_fd(int fd, LYD_FORMAT format, int options = 0);
+    S_Data_Node parse_data_mem(const char *data, LYD_FORMAT format, int options = 0);
+    S_Data_Node parse_data_fd(int fd, LYD_FORMAT format, int options = 0);
     S_Data_Node parse_data_path(const char *path, LYD_FORMAT format, int options = 0);
-    S_Data_Node parse_xml(S_Xml_Elem elem, int options = 0);
+    S_Data_Node parse_data_xml(S_Xml_Elem elem, int options = 0);
     S_Module parse_module_mem(const char *data, LYS_INFORMAT format);
     S_Module parse_module_fd(int fd, LYS_INFORMAT format);
-    S_Module parse_path(const char *path, LYS_INFORMAT format);
+    S_Module parse_module_path(const char *path, LYS_INFORMAT format);
 
     friend std::vector<S_Error> *get_ly_errors(S_Context context);
     friend Data_Node;

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -44,6 +44,7 @@ if(ENABLE_BUILD_TESTS)
     endmacro(ADD_PYTHON_TEST)
 
     ADD_PYTHON_TEST(test_libyang)
+    ADD_PYTHON_TEST(test_tree_data)
 
     add_custom_command(TARGET ${SWIG_MODULE_${PYTHON_SWIG_BINDING}_REAL_NAME} POST_BUILD
         COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/_${PYTHON_SWIG_BINDING}.so" ${PY2_SWIG_DIR}/tests

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -45,6 +45,7 @@ if(ENABLE_BUILD_TESTS)
 
     ADD_PYTHON_TEST(test_libyang)
     ADD_PYTHON_TEST(test_tree_data)
+    ADD_PYTHON_TEST(test_tree_schema)
 
     add_custom_command(TARGET ${SWIG_MODULE_${PYTHON_SWIG_BINDING}_REAL_NAME} POST_BUILD
         COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/_${PYTHON_SWIG_BINDING}.so" ${PY2_SWIG_DIR}/tests

--- a/swig/python/tests/test_libyang.py
+++ b/swig/python/tests/test_libyang.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-__author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
+__author__ = "Matija Amidzic <matija.amidzic@sartura.hr>"
 __copyright__ = "Copyright 2018, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
@@ -147,6 +147,7 @@ class TestUM(unittest.TestCase):
             # Tests
             info = ctx.info()
             self.assertIsNotNone(info)
+            self.assertEqual(ly.LYD_VAL_OK, info.validity())
 
         except Exception as e:
             self.fail(e)

--- a/swig/python/tests/test_libyang.py
+++ b/swig/python/tests/test_libyang.py
@@ -23,12 +23,23 @@ import sys
 
 import config
 
+class UnexpectedError(Exception):
+    """Exception raised for errors that are not expected.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message):
+        self.message = message
+
 class TestUM(unittest.TestCase):
     def test_ly_ctx_new(self):
-        print(config.TESTS_DIR)
         yang_folder1 = config.TESTS_DIR + "/data/files"
         yang_folder2 = config.TESTS_DIR + "/data:" + config.TESTS_DIR + "/data/files"
+
         try:
+            # Tests
             ctx = ly.Context(yang_folder1)
             self.assertIsNotNone(ctx)
             list = ctx.get_searchdirs()
@@ -42,18 +53,397 @@ class TestUM(unittest.TestCase):
             self.assertEqual(2, len(list))
 
         except Exception as e:
-            print(e)
-            sys.exit()
+            self.fail(e)
 
     def test_ly_ctx_new_invalid(self):
-        print(config.TESTS_DIR)
         yang_folder = "INVALID_PATH"
+
         try:
             ctx = ly.Context(yang_folder)
-            self.fail("exception not thrown")
+            raise UnexpectedError("exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
 
         except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_get_searchdirs(self):
+        yang_folder = config.TESTS_DIR + "/data/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            list = ctx.get_searchdirs()
+            self.assertEqual(1, len(list))
+            self.assertEqual(yang_folder, list[0])
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_set_searchdir(self):
+        yang_folder = config.TESTS_DIR + "/data/files"
+        new_yang_folder = config.TESTS_DIR + "/schema/yin"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            list = ctx.get_searchdirs()
+            self.assertEqual(1, len(list))
+            self.assertEqual(yang_folder, list[0])
+
+            ctx.set_searchdir(new_yang_folder)
+            list = ctx.get_searchdirs()
+            self.assertEqual(2, len(list))
+            self.assertEqual(new_yang_folder, list[1])
+
+            ctx.unset_searchdirs(0)
+            list = ctx.get_searchdirs()
+            self.assertEqual(1, len(list))
+            self.assertEqual(new_yang_folder, list[0])
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_set_searchdir_invalid(self):
+        yang_folder = config.TESTS_DIR + "/data/files"
+        new_yang_folder = "INVALID_PATH"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            ctx.set_searchdir(new_yang_folder)
+            raise UnexpectedError("exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
             return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_info(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            info = ctx.info()
+            self.assertIsNotNone(info)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_load_module_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.load_module("invalid", None)
+            raise UnexpectedError("exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_load_get_module(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        name1 = "a"
+        name2 = "b"
+        revision = "2016-03-01"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.get_module("invalid")
+            self.assertIsNone(module)
+
+            # module needs to be loaded first
+            module = ctx.get_module(name1)
+            self.assertIsNone(module)
+
+            module = ctx.load_module(name1)
+            self.assertIsNotNone(module)
+            self.assertEqual(name1, module.name(), "Module names don't match")
+
+            module = ctx.load_module(name2, revision)
+            self.assertIsNotNone(module)
+            self.assertEqual(name2, module.name(), "Module names don't match")
+            self.assertEqual(revision, module.rev().date(), "Module revisions don't match")
+
+            module = ctx.get_module(name2, "INVALID_REVISION")
+            self.assertIsNone(module)
+
+            module = ctx.get_module(name1)
+            self.assertIsNotNone(module)
+            self.assertEqual(name1, module.name(), "Module names don't match")
+
+            module = ctx.get_module(name2, revision)
+            self.assertIsNotNone(module)
+            self.assertEqual(name2, module.name(), "Module names don't match")
+            self.assertEqual(revision, module.rev().date(), "Module revisions don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_get_module_older(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        name = "b"
+        revision = "2016-03-01"
+        revision_older = "2015-01-01"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.load_module("c")
+            self.assertIsNotNone(module)
+            self.assertEqual("c", module.name(), "Module names don't match")
+
+            module = ctx.load_module(name, revision)
+            self.assertIsNotNone(module)
+            self.assertEqual(name, module.name(), "Module names don't match")
+            self.assertEqual(revision, module.rev().date(), "Module revisions don't match")
+
+            module_older = ctx.get_module_older(module)
+            self.assertIsNotNone(module_older)
+            self.assertEqual(name, module_older.name(), "Module names don't match")
+            self.assertEqual(revision_older, module_older.rev().date(), "Module revisions don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_get_module_by_ns(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        module_name = "a"
+        ns = "urn:a"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.load_module(module_name)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name, module.name(), "Module names don't match")
+
+            # Tests
+            module = ctx.get_module_by_ns(ns)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name, module.name(), "Module names don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_clean(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        module_name = "a"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.load_module(module_name)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name, module.name(), "Module names don't match")
+
+            # Tests
+            # confirm module is loaded
+            module = ctx.get_module(module_name)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name, module.name(), "Module names don't match")
+
+            ctx.clean()
+
+            # confirm ctx is cleaned
+            module = ctx.get_module(module_name)
+            self.assertIsNone(module)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        yang_file = config.TESTS_DIR + "/api/files/b.yang"
+        module_name1 = "a"
+        module_name2 = "b"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name1, module.name(), "Module names don't match")
+
+            module = ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name2, module.name(), "Module names don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_path_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.parse_path("INVALID_YANG_FILE", ly.LYS_IN_YANG)
+            raise UnexpectedError("exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_get_submodule(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        module_name = "a"
+        sub_name = "asub"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+
+            # Tests
+            submodule = ctx.get_submodule(module_name, None, sub_name, None)
+            self.assertIsNotNone(submodule)
+            self.assertEqual(sub_name, submodule.name(), "Module names don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_get_submodule2(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        sub_name = "asub"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+            self.assertIsNotNone(root.schema().module())
+
+            # Tests
+            submodule = ctx.get_submodule2(root.schema().module(), sub_name)
+            self.assertIsNotNone(submodule)
+            self.assertEqual(sub_name, submodule.name(), "Module names don't match")
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_find_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        yang_file = config.TESTS_DIR + "/api/files/b.yang"
+        schema_path1 = "/b:x/b:bubba"
+        schema_path2 = "/a:x/a:bubba"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            set = ctx.find_path(schema_path1)
+            self.assertIsNotNone(set)
+
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            set = ctx.find_path(schema_path2)
+            self.assertIsNotNone(set)
+            ly.Set()
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_set(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            set = ly.Set()
+            self.assertIsNotNone(set)
+            self.assertEqual(0, set.number())
+
+            set.add(root.child().schema())
+            self.assertEqual(1, set.number())
+
+            set.add(root.schema())
+            self.assertEqual(2, set.number())
+
+            set.rm(root.schema())
+            self.assertEqual(1, set.number())
+
+            set.add(root.schema())
+            self.assertEqual(2, set.number())
+
+            set.rm_index(1)
+            self.assertEqual(1, set.number())
+
+            set.clean()
+            self.assertEqual(0, set.number())
+
+        except Exception as e:
+            self.fail(e)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/swig/python/tests/test_libyang.py
+++ b/swig/python/tests/test_libyang.py
@@ -293,7 +293,7 @@ class TestUM(unittest.TestCase):
         except Exception as e:
             self.fail(e)
 
-    def test_ly_ctx_parse_path(self):
+    def test_ly_ctx_parse_module_path(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         yin_file = config.TESTS_DIR + "/api/files/a.yin"
         yang_file = config.TESTS_DIR + "/api/files/b.yang"
@@ -306,18 +306,18 @@ class TestUM(unittest.TestCase):
             self.assertIsNotNone(ctx)
 
             # Tests
-            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            module = ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             self.assertIsNotNone(module)
             self.assertEqual(module_name1, module.name(), "Module names don't match")
 
-            module = ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            module = ctx.parse_module_path(yang_file, ly.LYS_IN_YANG)
             self.assertIsNotNone(module)
             self.assertEqual(module_name2, module.name(), "Module names don't match")
 
         except Exception as e:
             self.fail(e)
 
-    def test_ly_ctx_parse_path_invalid(self):
+    def test_ly_ctx_parse_module_path_invalid(self):
         yang_folder = config.TESTS_DIR + "/api/files"
 
         try:
@@ -326,7 +326,7 @@ class TestUM(unittest.TestCase):
             self.assertIsNotNone(ctx)
 
             # Tests
-            module = ctx.parse_path("INVALID_YANG_FILE", ly.LYS_IN_YANG)
+            module = ctx.parse_module_path("INVALID_YANG_FILE", ly.LYS_IN_YANG)
             raise UnexpectedError("exception not thrown")
 
         except UnexpectedError as e:
@@ -348,7 +348,7 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
 
             # Tests
             submodule = ctx.get_submodule(module_name, None, sub_name, None)
@@ -368,7 +368,7 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
             self.assertIsNotNone(root)
             self.assertIsNotNone(root.schema().module())
@@ -394,11 +394,11 @@ class TestUM(unittest.TestCase):
             self.assertIsNotNone(ctx)
 
             # Tests
-            ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            ctx.parse_module_path(yang_file, ly.LYS_IN_YANG)
             set = ctx.find_path(schema_path1)
             self.assertIsNotNone(set)
 
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             set = ctx.find_path(schema_path2)
             self.assertIsNotNone(set)
             ly.Set()
@@ -415,7 +415,7 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
             self.assertIsNotNone(root)
 

--- a/swig/python/tests/test_tree_data.py
+++ b/swig/python/tests/test_tree_data.py
@@ -149,7 +149,7 @@ class UnexpectedError(Exception):
         self.message = message
 
 class TestUM(unittest.TestCase):
-    def test_ly_ctx_parse_mem(self):
+    def test_ly_ctx_parse_data_mem(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         yin_file = config.TESTS_DIR + "/api/files/a.yin"
 
@@ -157,17 +157,17 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
 
             # Tests
-            root = ctx.parse_mem(a_data_xml, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
+            root = ctx.parse_data_mem(a_data_xml, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
             self.assertIsNotNone(root)
             self.assertEqual("x", root.schema().name())
 
         except Exception as e:
             self.fail(e)
 
-    def test_ly_ctx_parse_fd(self):
+    def test_ly_ctx_parse_data_fd(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         yin_file = config.TESTS_DIR + "/api/files/a.yin"
         config_file = config.TESTS_DIR + "/api/files/a.xml"
@@ -175,12 +175,12 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
 
             # Tests
             f = open(config_file, 'r')
             fd = f.fileno()
-            root = ctx.parse_fd(fd, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
+            root = ctx.parse_data_fd(fd, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
             self.assertIsNotNone(root)
             self.assertEqual("x", root.schema().name())
 
@@ -200,7 +200,7 @@ class TestUM(unittest.TestCase):
             # Setup
             ctx = ly.Context(yang_folder)
             self.assertIsNotNone(ctx)
-            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            module = ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             self.assertIsNotNone(module)
             self.assertEqual(module_name, module.name(), "Module names don't match")
 

--- a/swig/python/tests/test_tree_data.py
+++ b/swig/python/tests/test_tree_data.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+__author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
+__copyright__ = "Copyright 2018, Deutsche Telekom AG"
+__license__ = "BSD 3-Clause"
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yang as ly
+import unittest
+import sys
+
+import config
+
+lys_module_a = \
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>           \
+<module name=\"a\"                                    \
+        xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\"   \
+        xmlns:md=\"urn:ietf:params:xml:ns:yang:ietf-yang-metadata\"\
+        xmlns:a=\"urn:a\">                            \
+  <namespace uri=\"urn:a\"/>                          \
+  <prefix value=\"a_mod\"/>                           \
+  <include module=\"asub\"/>                          \
+  <include module=\"atop\"/>                          \
+  <import module=\"ietf-yang-metadata\">              \
+    <prefix value=\"md\"/>                            \
+  </import>                                           \
+  <feature name=\"foo\"/>                             \
+  <grouping name=\"gg\">                              \
+    <leaf name=\"bar-gggg\">                          \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </grouping>                                         \
+  <md:annotation name=\"test\">                       \
+    <type name=\"string\"/>                           \
+  </md:annotation>                                    \
+  <container name=\"x\">                              \
+    <leaf name=\"bar-leaf\">                          \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <uses name=\"gg\">                                \
+    </uses>                                           \
+    <leaf name=\"baz\">                               \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <leaf name=\"bubba\">                             \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <leaf name=\"number32\">                          \
+      <type name=\"int32\"/>                          \
+    </leaf>                                           \
+    <leaf name=\"number64\">                          \
+      <type name=\"int64\"/>                          \
+    </leaf>                                           \
+    <leaf name=\"def-leaf\">                          \
+      <type name=\"string\"/>                         \
+      <default value=\"def\"/>                        \
+    </leaf>                                           \
+  </container>                                        \
+  <leaf name=\"y\"><type name=\"string\"/></leaf>     \
+  <anyxml name=\"any\"/>                              \
+  <augment target-node=\"/x\">                        \
+    <container name=\"bar-y\"/>                       \
+  </augment>                                          \
+  <rpc name=\"bar-rpc\">                              \
+  </rpc>                                              \
+  <rpc name=\"foo-rpc\">                              \
+  </rpc>                                              \
+  <rpc name=\"rpc1\">                                 \
+    <input>                                           \
+      <leaf name=\"input-leaf1\">                     \
+        <type name=\"string\"/>                       \
+      </leaf>                                         \
+      <container name=\"x\">                          \
+        <leaf name=\"input-leaf2\">                   \
+          <type name=\"string\"/>                     \
+        </leaf>                                       \
+      </container>                                    \
+    </input>                                          \
+    <output>                                          \
+      <leaf name=\"output-leaf1\">                    \
+        <type name=\"string\"/>                       \
+      </leaf>                                         \
+      <leaf name=\"output-leaf2\">                    \
+        <type name=\"string\"/>                       \
+      </leaf>                                         \
+      <container name=\"rpc-container\">              \
+        <leaf name=\"output-leaf3\">                  \
+          <type name=\"string\"/>                     \
+        </leaf>                                       \
+      </container>                                    \
+    </output>                                         \
+  </rpc>                                              \
+  <list name=\"l\">                                   \
+    <key value=\"key1 key2\"/>                        \
+    <leaf name=\"key1\">                              \
+      <type name=\"uint8\"/>                          \
+    </leaf>                                           \
+    <leaf name=\"key2\">                              \
+      <type name=\"uint8\"/>                          \
+    </leaf>                                           \
+    <leaf name=\"value\">                             \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </list>                                             \
+</module>                                             \
+"
+
+a_data_xml = "\
+<x xmlns=\"urn:a\">\n\
+  <bubba>test</bubba>\n\
+  </x>\n"
+
+result_xml = "<x xmlns=\"urn:a\"><bubba>test</bubba></x>"
+
+result_xml_format ="\
+<x xmlns=\"urn:a\">\n\
+  <bubba>test</bubba>\n\
+</x>\n\
+"
+
+result_json = "\
+{\n\
+  \"a:x\": {\n\
+    \"bubba\": \"test\"\n\
+  }\n\
+}\n\
+"
+
+class UnexpectedError(Exception):
+    """Exception raised for errors that are not expected.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+class TestUM(unittest.TestCase):
+    def test_ly_ctx_parse_mem(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+
+            # Tests
+            root = ctx.parse_mem(a_data_xml, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+            self.assertEqual("x", root.schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_fd(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+
+            # Tests
+            f = open(config_file, 'r')
+            fd = f.fileno()
+            root = ctx.parse_fd(fd, ly.LYD_XML, ly.LYD_OPT_NOSIBLINGS | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+            self.assertEqual("x", root.schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+        finally:
+            f.close()
+
+    def test_ly_ctx_parse_data_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        module_name = "a"
+        schema_name = "x"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            self.assertEqual(module_name, module.name(), "Module names don't match")
+
+            # Tests
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+            self.assertEqual(schema_name, root.schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_data_path_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            root = ctx.parse_data_path("INVALID_PATH", ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            raise UnexpectedError("exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            new_node = ly.Data_Node(root, root.child().schema().module(), "bar-y")
+            self.assertIsNotNone(new_node)
+            new_node = ly.Data_Node(root, root.schema().module(), "number32", "100")
+            self.assertIsNotNone(new_node)
+            dup_node = new_node.dup(0)
+            self.assertIsNotNone(dup_node)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_new_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            mod = ctx.get_module("a", None, 1)
+            self.assertIsNotNone(mod)
+
+            # Tests
+            root = ly.Data_Node(ctx, "/a:x/bar-gggg", "a", 0, 0)
+            self.assertIsNotNone(root)
+            self.assertEqual("x", root.schema().name())
+            self.assertEqual("bar-gggg", root.child().schema().name())
+
+            node = root.new_path(ctx, "def-leaf", "def", 0, ly.LYD_PATH_OPT_DFLT)
+            self.assertIsNotNone(node)
+            self.assertEqual("def-leaf", node.schema().name())
+            self.assertEqual(1, node.dflt())
+
+            node = root.new_path(ctx, "def-leaf", "def", 0, 0)
+            self.assertIsNotNone(node)
+            self.assertEqual("def-leaf", node.schema().name())
+            self.assertEqual(0, node.dflt())
+
+            node = root.new_path(ctx, "bubba", "b", 0, 0)
+            self.assertIsNotNone(node)
+            self.assertEqual("bubba", node.schema().name())
+
+            node = root.new_path(ctx, "/a:x/number32", "3", 0, 0)
+            self.assertIsNotNone(node)
+            self.assertEqual("number32", node.schema().name())
+
+            node = root.new_path(ctx, "/a:l[key1='1'][key2='2']/value", None, 0, 0)
+            self.assertIsNotNone(node)
+            self.assertEqual("l", node.schema().name())
+            self.assertEqual("key1", node.child().schema().name())
+            self.assertEqual("key2", node.child().next().schema().name())
+            self.assertEqual("value", node.child().next().next().schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_insert(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            new_node = ly.Data_Node(root, root.schema().module(), "number32", "200")
+            self.assertIsNotNone(new_node)
+            rc = root.insert(new_node)
+            self.assertEqual(0, rc)
+            self.assertEqual("number32", root.child().prev().schema().name())
+
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_insert_sibling(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            last = root.prev()
+            new_node = ly.Data_Node(None, root.schema().module(), "y", "test")
+            self.assertIsNotNone(new_node)
+            rc = root.insert_sibling(new_node)
+            self.assertEqual(0, rc)
+            self.assertNotEqual(last.schema().name(), root.prev().schema().name())
+            self.assertEqual("y", root.prev().schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_insert_before(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            last = root.prev()
+            new_node = ly.Data_Node(None, root.schema().module(), "y", "test")
+            self.assertIsNotNone(new_node)
+            rc = root.insert_before(new_node)
+            self.assertEqual(0, rc)
+            self.assertNotEqual(last.schema().name(), root.prev().schema().name())
+            self.assertEqual("y", root.prev().schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_insert_after(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            last = root.next()
+            new_node = ly.Data_Node(None, root.schema().module(), "y", "test")
+            self.assertIsNotNone(new_node)
+            rc = root.insert_after(new_node)
+            self.assertEqual(0, rc)
+            self.assertNotEqual(last.schema().name(), root.next().schema().name())
+            self.assertEqual("y", root.next().schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_schema_sort(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            mod = ctx.get_module("a", None, 1)
+            self.assertIsNotNone(mod)
+
+            # Tests
+            root = ly.Data_Node(None, mod, "l")
+            self.assertIsNotNone(root)
+            node = ly.Data_Node(root, mod, "key1", "1")
+            self.assertIsNotNone(node)
+            node = ly.Data_Node(root, mod, "key2", "2")
+            self.assertIsNotNone(node)
+
+            node = ly.Data_Node(None, mod, "x")
+            self.assertIsNotNone(node)
+            rc = root.insert_after(node)
+            self.assertEqual(0, rc)
+
+            node2 = ly.Data_Node(node, mod, "bubba", "a")
+            self.assertIsNotNone(node2)
+            node2 = ly.Data_Node(node, mod, "bar-gggg", "b")
+            self.assertIsNotNone(node2)
+            node2 = ly.Data_Node(node, mod, "number64", "64")
+            self.assertIsNotNone(node2)
+            node2 = ly.Data_Node(node, mod, "number32", "32")
+            self.assertIsNotNone(node2)
+
+            rc = root.schema_sort(1)
+            self.assertEqual(0, rc)
+
+            root = node
+            self.assertEqual("x", root.schema().name())
+            self.assertEqual("l", root.next().schema().name())
+
+            self.assertEqual("bar-gggg", root.child().schema().name())
+            self.assertEqual("bubba", root.child().next().schema().name())
+            self.assertEqual("number32", root.child().next().next().schema().name())
+            self.assertEqual("number64", root.child().next().next().next().schema().name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_find_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            node = root.child()
+            self.assertIsNotNone(node)
+            set = node.find_path("/a:x/bubba")
+            self.assertIsNotNone(set)
+            self.assertEqual(1, set.number())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_find_instance(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            node = root.child()
+            self.assertIsNotNone(node)
+            set = node.find_instance(node.schema())
+            self.assertIsNotNone(set)
+            self.assertEqual(1, set.number())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_validate(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            rc = root.validate(ly.LYD_OPT_CONFIG, ctx)
+            self.assertEqual(0, rc)
+            new = ly.Data_Node(root, root.schema().module(), "number32", "1")
+            self.assertIsNotNone(new)
+            rc = root.insert(new)
+            self.assertEqual(0, rc)
+            rc = root.validate(ly.LYD_OPT_CONFIG, ctx)
+            self.assertEqual(0, rc)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_unlink(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            node = root.child()
+            new = ly.Data_Node(root, node.schema().module(), "number32", "1")
+            self.assertIsNotNone(new)
+            rc = root.insert(new)
+            self.assertEqual(0, rc)
+
+            schema = node.prev().schema()
+            if (ly.LYS_LEAF == schema.nodetype() or ly.LYS_LEAFLIST == schema.nodetype()):
+                casted = node.prev().subtype()
+                self.assertEqual("1", casted.value_str())
+            else:
+                self.fail()
+
+            rc = node.prev().unlink()
+            self.assertEqual(0, rc)
+            schema = node.prev().schema()
+            if (ly.LYS_LEAF == schema.nodetype() or ly.LYS_LEAFLIST == schema.nodetype()):
+                self.fail()
+            else:
+                return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_print_mem(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            result = root.print_mem(ly.LYD_XML, 0)
+            self.assertEqual(result_xml, result)
+            result = root.print_mem(ly.LYD_XML, ly.LYP_FORMAT)
+            self.assertEqual(result_xml_format, result)
+            result = root.print_mem(ly.LYD_JSON, ly.LYP_FORMAT)
+            self.assertEqual(result_json, result)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
+            str = root.path()
+            self.assertIsNotNone(str)
+            self.assertEqual("/a:x", str)
+            str = root.child().path()
+            self.assertIsNotNone(str)
+            self.assertEqual("/a:x/bubba", str)
+
+        except Exception as e:
+            self.fail(e)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/swig/python/tests/test_tree_data.py
+++ b/swig/python/tests/test_tree_data.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
-__author__ = "Mislav Novakovic <mislav.novakovic@sartura.hr>"
+__author__ = "Matija Amidzic <matija.amidzic@sartura.hr>"
 __copyright__ = "Copyright 2018, Deutsche Telekom AG"
 __license__ = "BSD 3-Clause"
 
@@ -548,7 +548,7 @@ class TestUM(unittest.TestCase):
         except Exception as e:
             self.fail(e)
 
-    def test_ly_data_node_print_mem(self):
+    def test_ly_data_node_print_mem_xml(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         config_file = config.TESTS_DIR + "/api/files/a.xml"
         try:
@@ -562,8 +562,41 @@ class TestUM(unittest.TestCase):
             # Tests
             result = root.print_mem(ly.LYD_XML, 0)
             self.assertEqual(result_xml, result)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_print_mem_xml_format(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
             result = root.print_mem(ly.LYD_XML, ly.LYP_FORMAT)
             self.assertEqual(result_xml_format, result)
+
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_data_node_print_mem_json(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        config_file = config.TESTS_DIR + "/api/files/a.xml"
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            root = ctx.parse_data_path(config_file, ly.LYD_XML, ly.LYD_OPT_CONFIG | ly.LYD_OPT_STRICT)
+            self.assertIsNotNone(root)
+
+            # Tests
             result = root.print_mem(ly.LYD_JSON, ly.LYP_FORMAT)
             self.assertEqual(result_json, result)
 

--- a/swig/python/tests/test_tree_schema.py
+++ b/swig/python/tests/test_tree_schema.py
@@ -407,7 +407,7 @@ class TestUM(unittest.TestCase):
         finally:
             f.close()
 
-    def test_ly_ctx_parse_path(self):
+    def test_ly_ctx_parse_module_path(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         yin_file = config.TESTS_DIR + "/api/files/a.yin"
         yang_file = config.TESTS_DIR + "/api/files/b.yang"
@@ -418,18 +418,18 @@ class TestUM(unittest.TestCase):
             self.assertIsNotNone(ctx)
 
             # Tests
-            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            module = ctx.parse_module_path(yin_file, ly.LYS_IN_YIN)
             self.assertIsNotNone(module)
             self.assertEqual("a", module.name())
 
-            module = ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            module = ctx.parse_module_path(yang_file, ly.LYS_IN_YANG)
             self.assertIsNotNone(module)
             self.assertEqual("b", module.name())
 
         except Exception as e:
             self.fail(e)
 
-    def test_ly_ctx_parse_path_invalid(self):
+    def test_ly_ctx_parse_module_path_invalid(self):
         yang_folder = config.TESTS_DIR + "/api/files"
         yin_file = config.TESTS_DIR + "/api/files/a.yin"
 
@@ -440,7 +440,7 @@ class TestUM(unittest.TestCase):
 
             # Tests
             # parsing with wrong format should raise runtime exception
-            module = ctx.parse_path(yin_file, ly.LYS_IN_YANG)
+            module = ctx.parse_module_path(yin_file, ly.LYS_IN_YANG)
             raise UnexpectedError("Exception not thrown")
 
         except UnexpectedError as e:

--- a/swig/python/tests/test_tree_schema.py
+++ b/swig/python/tests/test_tree_schema.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+__author__ = "Matija Amidzic <matija.amidzic@sartura.hr>"
+__copyright__ = "Copyright 2018, Deutsche Telekom AG"
+__license__ = "BSD 3-Clause"
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yang as ly
+import unittest
+import sys
+
+import config
+
+lys_module_a = \
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>           \
+<module name=\"a\"                                    \
+        xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\"   \
+        xmlns:a=\"urn:a\">                            \
+  <namespace uri=\"urn:a\"/>                          \
+  <prefix value=\"a_mod\"/>                           \
+  <include module=\"asub\"/>                          \
+  <include module=\"atop\"/>                          \
+  <revision date=\"2015-01-01\">                      \
+    <description>                                     \
+      <text>version 1</text>                          \
+    </description>                                    \
+    <reference>                                       \
+      <text>RFC XXXX</text>                           \
+    </reference>                                      \
+  </revision>                                         \
+  <feature name=\"foo\"/>                             \
+  <grouping name=\"gg\">                              \
+    <leaf name=\"bar-gggg\">                          \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </grouping>                                         \
+  <container name=\"x\">                              \
+    <leaf name=\"bar-leaf\">                          \
+      <if-feature name=\"bar\"/>                      \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <uses name=\"gg\">                                \
+      <if-feature name=\"bar\"/>                      \
+    </uses>                                           \
+    <leaf name=\"baz\">                               \
+      <if-feature name=\"foo\"/>                      \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <leaf name=\"bubba\">                             \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </container>                                        \
+  <augment target-node=\"/x\">                        \
+    <if-feature name=\"bar\"/>                        \
+    <container name=\"bar-y\">                        \
+      <leaf name=\"ll\">                              \
+        <type name=\"string\"/>                       \
+      </leaf>                                         \
+    </container>                                      \
+  </augment>                                          \
+  <rpc name=\"bar-rpc\">                              \
+    <if-feature name=\"bar\"/>                        \
+  </rpc>                                              \
+  <rpc name=\"foo-rpc\">                              \
+    <if-feature name=\"foo\"/>                        \
+  </rpc>                                              \
+</module>                                             \
+"
+
+lys_module_b = \
+"module b {\
+    namespace \"urn:b\";\
+    prefix b_mod;\
+    include bsub;\
+    include btop;\
+    feature foo;\
+    grouping gg {\
+        leaf bar-gggg {\
+            type string;\
+        }\
+    }\
+    container x {\
+        leaf bar-leaf {\
+            if-feature \"bar\";\
+            type string;\
+        }\
+        uses gg {\
+            if-feature \"bar\";\
+        }\
+        leaf baz {\
+            if-feature \"foo\";\
+            type string;\
+        }\
+        leaf bubba {\
+            type string;\
+        }\
+    }\
+    augment \"/x\" {\
+        if-feature \"bar\";\
+        container bar-y;\
+    }\
+    rpc bar-rpc {\
+        if-feature \"bar\";\
+    }\
+    rpc foo-rpc {\
+        if-feature \"foo\";\
+    }\
+}"
+
+lys_module_a_with_typo = \
+"<?xml version=\"1.0\" encoding=\"UTF-8\"?>           \
+<module_typo name=\"a\"                                    \
+        xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\"   \
+        xmlns:a=\"urn:a\">                            \
+  <namespace uri=\"urn:a\"/>                          \
+  <prefix value=\"a_mod\"/>                           \
+  <include module=\"asub\"/>                          \
+  <include module=\"atop\"/>                          \
+  <feature name=\"foo\"/>                             \
+  <grouping name=\"gg\">                              \
+    <leaf name=\"bar-gggg\">                          \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </grouping>                                         \
+  <container name=\"x\">                              \
+    <leaf name=\"bar-leaf\">                          \
+      <if-feature name=\"bar\"/>                      \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <uses name=\"gg\">                                \
+      <if-feature name=\"bar\"/>                      \
+    </uses>                                           \
+    <leaf name=\"baz\">                               \
+      <if-feature name=\"foo\"/>                      \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+    <leaf name=\"bubba\">                             \
+      <type name=\"string\"/>                         \
+    </leaf>                                           \
+  </container>                                        \
+  <augment target-node=\"/x\">                        \
+    <if-feature name=\"bar\"/>                        \
+    <container name=\"bar-y\">                        \
+      <leaf name=\"ll\">                              \
+        <type name=\"string\"/>                       \
+      </leaf>                                         \
+    </container>                                      \
+  </augment>                                          \
+  <rpc name=\"bar-rpc\">                              \
+    <if-feature name=\"bar\"/>                        \
+  </rpc>                                              \
+  <rpc name=\"foo-rpc\">                              \
+    <if-feature name=\"foo\"/>                        \
+  </rpc>                                              \
+</module>                                             \
+"
+
+result_tree = "\
+module: a\n\
+  +--rw top\n\
+  |  +--rw bar-sub2\n\
+  +--rw x\n\
+     +--rw bubba?      string\n"
+
+result_yang = "\
+module a {\n\
+  namespace \"urn:a\";\n\
+  prefix a_mod;\n\
+\n\
+  include \"asub\";\n\
+\n\
+  include \"atop\";\n\
+\n\
+  revision 2015-01-01 {\n\
+    description\n\
+      \"version 1\";\n\
+    reference\n\
+      \"RFC XXXX\";\n\
+  }\n\
+\n\
+  feature foo;\n\
+\n\
+  grouping gg {\n\
+    leaf bar-gggg {\n\
+      type string;\n\
+    }\n\
+  }\n\
+\n\
+  container x {\n\
+    leaf bar-leaf {\n\
+      if-feature \"bar\";\n\
+      type string;\n\
+    }\n\n\
+    uses gg {\n\
+      if-feature \"bar\";\n\
+    }\n\n\
+    leaf baz {\n\
+      if-feature \"foo\";\n\
+      type string;\n\
+    }\n\n\
+    leaf bubba {\n\
+      type string;\n\
+    }\n\
+  }\n\
+\n\
+  augment \"/x\" {\n\
+    if-feature \"bar\";\n\
+    container bar-y {\n\
+      leaf ll {\n\
+        type string;\n\
+      }\n\
+    }\n\
+  }\n\
+\n\
+  rpc bar-rpc {\n\
+    if-feature \"bar\";\n\
+  }\n\
+\n\
+  rpc foo-rpc {\n\
+    if-feature \"foo\";\n\
+  }\n\
+}\n"
+
+result_yin = "\
+<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<module name=\"a\"\n\
+        xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\"\n\
+        xmlns:a_mod=\"urn:a\">\n\
+  <namespace uri=\"urn:a\"/>\n\
+  <prefix value=\"a_mod\"/>\n\
+  <include module=\"asub\"/>\n\
+  <include module=\"atop\"/>\n\
+  <revision date=\"2015-01-01\">\n\
+    <description>\n\
+      <text>version 1</text>\n\
+    </description>\n\
+    <reference>\n\
+      <text>RFC XXXX</text>\n\
+    </reference>\n\
+  </revision>\n\
+  <feature name=\"foo\"/>\n\
+  <grouping name=\"gg\">\n\
+    <leaf name=\"bar-gggg\">\n\
+      <type name=\"string\"/>\n\
+    </leaf>\n\
+  </grouping>\n\
+  <container name=\"x\">\n\
+    <leaf name=\"bar-leaf\">\n\
+      <if-feature name=\"bar\"/>\n\
+      <type name=\"string\"/>\n\
+    </leaf>\n\
+    <uses name=\"gg\">\n\
+      <if-feature name=\"bar\"/>\n\
+    </uses>\n\
+    <leaf name=\"baz\">\n\
+      <if-feature name=\"foo\"/>\n\
+      <type name=\"string\"/>\n\
+    </leaf>\n\
+    <leaf name=\"bubba\">\n\
+      <type name=\"string\"/>\n\
+    </leaf>\n\
+  </container>\n\
+  <augment target-node=\"/x\">\n\
+    <if-feature name=\"bar\"/>\n\
+    <container name=\"bar-y\">\n\
+      <leaf name=\"ll\">\n\
+        <type name=\"string\"/>\n\
+      </leaf>\n\
+    </container>\n\
+  </augment>\n\
+  <rpc name=\"bar-rpc\">\n\
+    <if-feature name=\"bar\"/>\n\
+  </rpc>\n\
+  <rpc name=\"foo-rpc\">\n\
+    <if-feature name=\"foo\"/>\n\
+  </rpc>\n\
+</module>\n"
+
+result_info ="\
+Feature:   foo\n\
+Module:    a\n\
+Desc:      \n\
+Reference: \n\
+Status:    current\n\
+Enabled:   no\n\
+If-feats:  \n"
+
+class UnexpectedError(Exception):
+    """Exception raised for errors that are not expected.
+
+    Attributes:
+        message -- explanation of the error
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+class TestUM(unittest.TestCase):
+    def test_ly_ctx_parse_module_mem(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            self.assertEqual("a", module.name())
+
+            module = ctx.parse_module_mem(lys_module_b, ly.LYS_IN_YANG)
+            self.assertIsNotNone(module)
+            self.assertEqual("b", module.name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_module_mem_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            ctx.parse_module_mem(lys_module_a_with_typo, ly.LYS_IN_YIN)
+            raise UnexpectedError("Exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_module_fd(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        yang_file = config.TESTS_DIR + "/api/files/b.yang"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            f = open(yin_file, 'r')
+            fd = f.fileno()
+            module = ctx.parse_module_fd(fd, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            self.assertEqual("a", module.name())
+
+            f.close()
+            f = open(yang_file, 'r')
+            fd = f.fileno()
+            module = ctx.parse_module_fd(fd, ly.LYS_IN_YANG)
+            self.assertIsNotNone(module)
+            self.assertEqual("b", module.name())
+
+        except Exception as e:
+            self.fail(e)
+
+        finally:
+            f.close()
+
+    def test_ly_ctx_parse_module_fd_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            f = open(yin_file, 'r')
+            fd = f.fileno()
+            # parsing with wrong format should raise runtime exception
+            module = ctx.parse_module_fd(fd, ly.LYS_IN_YANG)
+            raise UnexpectedError("Exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+        finally:
+            f.close()
+
+    def test_ly_ctx_parse_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+        yang_file = config.TESTS_DIR + "/api/files/b.yang"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            module = ctx.parse_path(yin_file, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            self.assertEqual("a", module.name())
+
+            module = ctx.parse_path(yang_file, ly.LYS_IN_YANG)
+            self.assertIsNotNone(module)
+            self.assertEqual("b", module.name())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_ctx_parse_path_invalid(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+        yin_file = config.TESTS_DIR + "/api/files/a.yin"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+
+            # Tests
+            # parsing with wrong format should raise runtime exception
+            module = ctx.parse_path(yin_file, ly.LYS_IN_YANG)
+            raise UnexpectedError("Exception not thrown")
+
+        except UnexpectedError as e:
+            self.fail(e)
+
+        except RuntimeError as e:
+            return
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_module_print_mem_tree(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+
+            # Tests
+            result = module.print_mem(ly.LYS_OUT_TREE, 0)
+            self.assertEqual(result_tree, result)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_module_print_mem_yang(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+
+            # Tests
+            result = module.print_mem(ly.LYS_OUT_YANG, 0)
+            self.assertEqual(result_yang, result)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_module_print_mem_yin(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+
+            # Tests
+            result = module.print_mem(ly.LYS_OUT_YIN, 0)
+            self.assertEqual(result_yin, result)
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_schema_node_find_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            schema_node = module.data()
+            self.assertIsNotNone(schema_node)
+
+            # Tests
+            set = schema_node.find_path("/a:x/*")
+            self.assertIsNotNone(set)
+            self.assertEqual(5, set.number())
+            set = schema_node.find_path("/a:x//*")
+            self.assertIsNotNone(set)
+            self.assertEqual(6, set.number())
+            set = schema_node.find_path("/a:x//.")
+            self.assertIsNotNone(set)
+            self.assertEqual(7, set.number())
+
+        except Exception as e:
+            self.fail(e)
+
+    def test_ly_schema_node_path(self):
+        yang_folder = config.TESTS_DIR + "/api/files"
+
+        try:
+            # Setup
+            ctx = ly.Context(yang_folder)
+            self.assertIsNotNone(ctx)
+            module = ctx.parse_module_mem(lys_module_a, ly.LYS_IN_YIN)
+            self.assertIsNotNone(module)
+            schema_node = module.data()
+            self.assertIsNotNone(schema_node)
+
+            # Tests
+            template = "/a:x/a:bar-gggg"
+            set = schema_node.find_path(template)
+            self.assertIsNotNone(set)
+            schema = set.schema()[0]
+            path = schema.path(0)
+            self.assertEqual(template, path)
+
+        except Exception as e:
+            self.fail(e)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Add Python unit tests based on C unit tests, specifically test_libyang.c, test_tree_data.c and test_tree_schema.c. 

Also fixes C++ implementation of 'Set' and implements C++ versions of lys_parse_mem and lys_parse_fd functions.

Generated Python tests:
python_test_libyang
python_test_tree_data
python_test_tree_schema