### PR TITLE
fix crash in lyd_free_value()

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -5067,7 +5067,7 @@ lyd_insert_attr(struct lyd_node *parent, const struct lys_module *mod, const cha
 void
 lyd_free_value(lyd_val value, uint16_t value_type, struct lys_type *type)
 {
-    if (value_type & LY_TYPE_USER) {
+    if (value_type != (uint16_t)(LY_TYPE_ERR) && (value_type & LY_TYPE_USER)) {
         assert(type->der && type->der->module);
         lytype_free(type->der->module, type->der->name, value);
     } else {

--- a/tests/data/test_metadata.c
+++ b/tests/data/test_metadata.c
@@ -1426,6 +1426,40 @@ test_nc_editconfig17_json(void **state)
     assert_int_equal(ly_vecode(st->ctx), LYVE_INATTR);
 }
 
+/*
+ * correctness of parsing and printing NETCONF's edit-config's attributes
+ * - operation delete with an empty XML tag
+ */
+static void
+test_nc_editconfig18_xml(void **state)
+{
+    struct state *st = (*state);
+    const char *yang = "module x {"
+                    "  namespace urn:x;"
+                    "  prefix x;"
+                    "  leaf a { type string; }"
+                    "}";
+    const struct lys_module *mod;
+    const char *input =
+        "<a xmlns=\"urn:x\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\" "
+            "nc:operation=\"delete\"></a>";
+
+    /* load ietf-netconf schema */
+    assert_ptr_not_equal(lys_parse_path(st->ctx, TESTS_DIR"/schema/yang/ietf/ietf-netconf.yang", LYS_IN_YANG), NULL);
+
+    /* load schema */
+    mod = lys_parse_mem(st->ctx, yang, LYS_IN_YANG);
+    assert_ptr_not_equal(mod, NULL);
+
+    st->data = lyd_parse_mem(st->ctx, input, LYD_XML, LYD_OPT_EDIT , NULL);
+    assert_ptr_not_equal(st->data, NULL);
+    assert_ptr_not_equal(st->data->attr, NULL);
+    assert_ptr_not_equal(st->data->attr->name, NULL);
+    assert_ptr_not_equal(st->data->attr->value_str, NULL);
+    assert_string_equal(st->data->attr->name, "operation");
+    assert_string_equal(st->data->attr->value_str, "delete");
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1473,6 +1507,7 @@ int main(void)
                     cmocka_unit_test_setup_teardown(test_nc_editconfig16_json, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_nc_editconfig17_xml, setup_f, teardown_f),
                     cmocka_unit_test_setup_teardown(test_nc_editconfig17_json, setup_f, teardown_f),
+                    cmocka_unit_test_setup_teardown(test_nc_editconfig18_xml, setup_f, teardown_f),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Hi,

this pull request contains 
- a fix for crashes in lyd_free_value() in error scenarios when the value_type is set to LY_TYPE_ERR, but it's nothing to be freed. 
- a test case to verify the correction.

Regards,
Frank