### PR TITLE
data tree BUGFIX return node when updating leaf with same value

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1140,9 +1140,8 @@ lyd_new_path_update(struct lyd_node *node, void *value, LYD_ANYDATA_VALUETYPE va
             if ((r < 0) || (r == 1)) {
                 return NULL;
             }
-            return node;
         }
-        break;
+        return node;
     case LYS_ANYXML:
     case LYS_ANYDATA:
         /* the nodes are the same if:

--- a/tests/api/test_tree_data.c
+++ b/tests/api/test_tree_data.c
@@ -526,6 +526,10 @@ test_lyd_new_path(void **state)
     assert_non_null(node);
     assert_string_equal(node->schema->name, "bubba");
 
+    node = lyd_new_path(root, NULL, "bubba", "b", 0, LYD_PATH_OPT_UPDATE);
+    assert_non_null(node);
+    assert_string_equal(node->schema->name, "bubba");
+
     node = lyd_new_path(root, NULL, "/a:x/number32", "3", 0, 0);
     assert_non_null(node);
     assert_string_equal(node->schema->name, "number32");


### PR DESCRIPTION
According to the documentation of LYD_PATH_OPT_UPDATE:

  If the target node exists and is a leaf, it is updated with the new
  value and returned. If the target node exists and is not a leaf, NULL
  is returned and no error set.