### PR TITLE
correction (+test case) in yin output for ordered-by-user statements

### DIFF
--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -1290,6 +1290,7 @@ yin_print_list(struct lyout *out, int level, const struct lys_node *node)
         yin_print_unsigned(out, level, LYEXT_SUBSTMT_MAX, 0, node->module, node->ext, node->ext_size, list->max);
     }
     if (list->flags & LYS_USERORDERED) {
+        yin_print_close_parent(out, &content);
         yin_print_substmt(out, level, LYEXT_SUBSTMT_ORDEREDBY, 0, "user",
                           node->module, node->ext, node->ext_size);
     } else if (lys_ext_iter(node->ext, node->ext_size, 0, LYEXT_SUBSTMT_ORDEREDBY) != -1) {

--- a/tests/schema/yin/files/compname-int-unit-test-output.yang
+++ b/tests/schema/yin/files/compname-int-unit-test-output.yang
@@ -1,0 +1,30 @@
+module compname-int-unit-test {
+  namespace "http://www.compname.com/ns/yang/compname-int-unit-test";
+  prefix compname-int-unit-test;
+
+  revision 2018-01-01 {
+    description
+      "Initial revision.";
+    reference
+      "None.";
+  }
+
+  rpc events {
+    input {
+    }
+
+    output {
+      leaf-list info {
+        type string;
+        ordered-by user;
+      }
+
+      list critical-events {
+        ordered-by user;
+        leaf category {
+          type string;
+        }
+      }
+    }
+  }
+}

--- a/tests/schema/yin/files/compname-int-unit-test-output.yin
+++ b/tests/schema/yin/files/compname-int-unit-test-output.yin
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module name="compname-int-unit-test"
+        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
+        xmlns:compname-int-unit-test="http://www.compname.com/ns/yang/compname-int-unit-test">
+  <namespace uri="http://www.compname.com/ns/yang/compname-int-unit-test"/>
+  <prefix value="compname-int-unit-test"/>
+  <revision date="2018-01-01">
+    <description>
+      <text>Initial revision.</text>
+    </description>
+    <reference>
+      <text>None.</text>
+    </reference>
+  </revision>
+  <rpc name="events">
+    <input>
+    </input>
+    <output>
+      <leaf-list name="info">
+        <type name="string"/>
+        <ordered-by value="user"/>
+      </leaf-list>
+      <list name="critical-events">
+        <ordered-by value="user"/>
+        <leaf name="category">
+          <type name="string"/>
+        </leaf>
+      </list>
+    </output>
+  </rpc>
+</module>

--- a/tests/schema/yin/files/compname-int-unit-test.yang
+++ b/tests/schema/yin/files/compname-int-unit-test.yang
@@ -1,0 +1,30 @@
+module compname-int-unit-test {
+  namespace "http://www.compname.com/ns/yang/compname-int-unit-test";
+  prefix compname-int-unit-test;
+
+  revision 2018-01-01 {
+    description
+      "Initial revision.";
+    reference
+      "None.";
+  }
+
+  rpc events {
+    input {
+    }
+
+    output {
+      leaf-list info {
+        type string;
+        ordered-by user;
+      }
+
+      list critical-events {
+        ordered-by user;
+        leaf category {
+          type string;
+        }
+      }
+    }
+  }
+}

--- a/tests/schema/yin/test_print_transform.c
+++ b/tests/schema/yin/test_print_transform.c
@@ -83,7 +83,10 @@ teardown_ctx(void **state)
 }
 
 static void
-test_modules(void **state)
+execute_test_with_filenames(void **state,
+                            char *module_name,
+                            char *yang_file,
+                            char *yin_file)
 {
     struct ly_ctx *ctx = *state;
     const struct lys_module *module;
@@ -91,14 +94,14 @@ test_modules(void **state)
     FILE *file;
     int ret;
 
-    module = ly_ctx_load_module(ctx, "d2", NULL);
+    module = ly_ctx_load_module(ctx, module_name, NULL);
     assert_non_null(module);
 
     /* YANG */
     ret = lys_print_mem(&new, module, LYS_OUT_YANG, NULL, 0, 0);
     assert_int_equal(ret, 0);
 
-    file = fopen(SCHEMA_FOLDER"/d2_output.yang", "r");
+    file = fopen(yang_file, "r");
     assert_non_null(file);
 
     ret = diff(new, file);
@@ -110,7 +113,7 @@ test_modules(void **state)
     ret = lys_print_mem(&new, module, LYS_OUT_YIN, NULL, 0, 0);
     assert_int_equal(ret, 0);
 
-    file = fopen(SCHEMA_FOLDER"/d2_output.yin", "r");
+    file = fopen(yin_file, "r");
     assert_non_null(file);
 
     ret = diff(new, file);
@@ -119,11 +122,30 @@ test_modules(void **state)
     assert_int_equal(ret, 0);
 }
 
+static void
+test_modules(void **state)
+{
+execute_test_with_filenames(state,
+                            "d2",
+                            SCHEMA_FOLDER"/d2_output.yang",
+                            SCHEMA_FOLDER"/d2_output.yin");
+}
+
+static void
+test_modules_2(void **state)
+{
+execute_test_with_filenames(state,
+                            "compname-int-unit-test",
+                            SCHEMA_FOLDER"/compname-int-unit-test-output.yang",
+                            SCHEMA_FOLDER"/compname-int-unit-test-output.yin");
+}
+
 int
 main(void)
 {
     const struct CMUnitTest cmut[] = {
-        cmocka_unit_test_setup_teardown(test_modules, setup_ctx, teardown_ctx)
+        cmocka_unit_test_setup_teardown(test_modules, setup_ctx, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_modules_2, setup_ctx, teardown_ctx)
     };
 
     return cmocka_run_group_tests(cmut, NULL, NULL);


### PR DESCRIPTION
Hi,
we have created a correction (and a test case) for a problem in the yin print functionality of lists (a missing closing '>' of the parent statement).

Regards,
Frank