### PR TITLE
data tree BUGFIX update set number in ly_set_merge

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -5716,6 +5716,7 @@ ly_set_merge(struct ly_set *trg, struct ly_set *src, int options)
     /* copy contents from src into trg */
     memcpy(trg->set.g + trg->number, src->set.g, src->number * sizeof *(src->set.g));
     ret = src->number;
+    trg->number += ret;
 
     /* cleanup */
     ly_set_free(src);


### PR DESCRIPTION
The target set should have its number updated after the merge
operation.

Fixes: 563cfeaa32a9 ("data tree CHANGE new function lyd_set_merge")