### PR TITLE
Initialize prev_ly_errno to prevent corruption.

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -7983,7 +7983,7 @@ resolve_unres_data(struct ly_ctx *ctx, struct unres_data *unres, struct lyd_node
     int rc, progress, ignore_fail;
     enum int_log_opts prev_ilo;
     struct ly_err_item *prev_eitem;
-    LY_ERR prev_ly_errno;
+    LY_ERR prev_ly_errno = ly_errno;
     struct lyd_node *parent;
     struct lys_when *when;
 
@@ -8005,7 +8005,6 @@ resolve_unres_data(struct ly_ctx *ctx, struct unres_data *unres, struct lyd_node
     LOGVRB("Resolving unresolved data nodes and their constraints...");
     if (!ignore_fail) {
         /* remember logging state only if errors are generated and valid */
-        prev_ly_errno = ly_errno;
         ly_ilo_change(ctx, ILO_STORE, &prev_ilo, &prev_eitem);
     }
 


### PR DESCRIPTION
Earlier if a option of LYD_OPT_NOEXTDEPS | LYD_OPT_TRUSTED was passed to lyd_parse_mem, ignore_fail was 2.
So prev_ly_errno was left uninitialized as code didn't reach line 8008.

And we updated this junk value of prev_ly_errno back to ly_errno at line 8153.

As a result of which lyd_parse_mem returned NULL as ly_errno was set to some junk value.