### PR TITLE
Fix issue where removing an empty container could lose data in tree

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -4422,9 +4422,9 @@ lyd_validate(struct lyd_node **node, int options, void *var_arg)
 
         if (to_free) {
             if ((*node) == to_free) {
-                *node = NULL;
+                *node = to_free->next;
                 if (data_tree == to_free) {
-                    data_tree = NULL;
+                    data_tree = to_free->next;
                 }
             }
             lyd_free(to_free);

--- a/tests/api/test_tree_data.c
+++ b/tests/api/test_tree_data.c
@@ -90,6 +90,11 @@ const char *lys_module_a = \
       <default value=\"def\"/>                        \
     </leaf>                                           \
   </container>                                        \
+  <container name=\"z\">                              \
+    <leaf name=\"number-z\">                          \
+      <type name=\"int64\"/>                          \
+    </leaf>                                           \
+  </container>                                        \
   <leaf name=\"y\"><type name=\"string\"/></leaf>     \
   <anyxml name=\"any\"/>                              \
   <augment target-node=\"/x\">                        \
@@ -1567,6 +1572,27 @@ test_lyd_leaf_type(void **state)
     lyd_free_withsiblings(data);
 }
 
+static void
+test_lyd_validation_remove_empty_containers(void **state)
+{
+    (void) state; /* unused */
+    struct lyd_node *new = NULL;
+    struct lyd_node *old = root;
+    struct lyd_node *node = root;
+    struct lyd_node_leaf_list *result;
+
+    new = lyd_new(NULL, old->schema->module, "z");
+    lyd_insert_before(old, new);
+    node = new;
+
+    assert_int_equal(lyd_validate(&node, LYD_OPT_CONFIG, ctx), 0);
+    assert_ptr_not_equal(node, NULL);
+    assert_ptr_equal(node, old);
+    assert_ptr_not_equal(node->child, NULL);
+    result = (struct lyd_node_leaf_list *) node->child;
+    assert_string_equal("test", result->value_str);
+}
+
 int main(void)
 {
     const struct CMUnitTest tests[] = {
@@ -1607,6 +1633,7 @@ int main(void)
         cmocka_unit_test_setup_teardown(test_lyd_print_clb_json, setup_f, teardown_f),
         cmocka_unit_test_setup_teardown(test_lyd_path, setup_f, teardown_f),
         cmocka_unit_test_setup_teardown(test_lyd_leaf_type, setup_f2, teardown_f2),
+        cmocka_unit_test_setup_teardown(test_lyd_validation_remove_empty_containers, setup_f, teardown_f),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This issue occurs when an empty non-presence container is present as the first node in a data tree that is passed to lyd_validate. In that case the other nodes in the original tree are lost, and only defaults etc. will be populated into the new tree.

This pull request contains a unit test demonstrating the problem and a source code change that fixes the problem.