### PR TITLE
Resolving issue with yang and yin printers regarding typedefs in submodules

### DIFF
--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -461,7 +461,7 @@ yang_print_type(struct lyout *out, int level, const struct lys_module *module, c
 
     if (!lys_type_is_local(type)) {
         ly_print(out, "%*stype %s:%s", LEVEL, INDENT,
-                 transform_module_name2import_prefix(module, type->der->module->name), type->der->name);
+                 transform_module_name2import_prefix(module, lys_main_module(type->der->module)->name), type->der->name);
     } else {
         ly_print(out, "%*stype %s", LEVEL, INDENT, type->der->name);
     }

--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -438,7 +438,7 @@ yin_print_type(struct lyout *out, int level, const struct lys_module *module, co
 
     if (!lys_type_is_local(type)) {
         ly_print(out, "%*s<type name=\"%s:%s\"", LEVEL, INDENT,
-                 transform_module_name2import_prefix(module, type->der->module->name), type->der->name);
+                 transform_module_name2import_prefix(module, lys_main_module(type->der->module)->name), type->der->name);
     } else {
         yin_print_open(out, level, NULL, "type", "name", type->der->name, content);
     }

--- a/tests/schema/test_printer.c
+++ b/tests/schema/test_printer.c
@@ -334,6 +334,64 @@ test_parse_yang_with_unique(void **state)
     free(schema);
 }
 
+static void
+test_parse_yin_with_submodule_types(void **state)
+{
+    (void)state;
+    char *schema = NULL;
+    const struct lys_module *modyang = NULL, *modyang2 = NULL;
+    struct ly_ctx *ctx2 = NULL;
+    int ret = 0;
+
+    modyang = ly_ctx_load_module(ctx, "e", NULL);
+    assert_non_null(modyang);
+
+    ret = lys_print_mem(&schema, modyang, LYS_OUT_YIN, NULL, 0, 0);
+    assert_int_equal(ret, 0);
+    assert_non_null(schema);
+
+    ctx2 = ly_ctx_new(NULL, 0);
+    ly_ctx_set_searchdir(ctx2, SCHEMA_FOLDER_YANG);
+    modyang = ly_ctx_load_module(ctx2, "d", NULL);
+    assert_non_null(modyang);
+    ly_ctx_unset_searchdirs(ctx2, -1);
+
+    modyang2 = lys_parse_mem(ctx2, schema, LYS_IN_YIN);
+    assert_non_null(modyang2);
+    ly_ctx_destroy(ctx2, NULL);
+
+    free(schema);
+}
+
+static void
+test_parse_yang_with_submodule_types(void **state)
+{
+    (void) state;
+    char *schema = NULL;
+    const struct lys_module *modyang = NULL, *modyang2 = NULL;
+    struct ly_ctx *ctx2 = NULL;
+    int ret = 0;
+
+    modyang = ly_ctx_load_module(ctx, "e", NULL);
+    assert_non_null(modyang);
+
+    ret = lys_print_mem(&schema, modyang, LYS_OUT_YANG, NULL, 0, 0);
+    assert_int_equal(ret, 0);
+    assert_non_null(schema);
+
+    ctx2 = ly_ctx_new(NULL, 0);
+    ly_ctx_set_searchdir(ctx2, SCHEMA_FOLDER_YANG);
+    modyang = ly_ctx_load_module(ctx2, "d", NULL);
+    assert_non_null(modyang);
+    ly_ctx_unset_searchdirs(ctx2, -1);
+
+    modyang2 = lys_parse_mem(ctx2, schema, LYS_IN_YANG);
+    assert_non_null(modyang2);
+    ly_ctx_destroy(ctx2, NULL);
+
+    free(schema);
+}
+
 int
 main(void)
 {
@@ -343,6 +401,8 @@ main(void)
         cmocka_unit_test_setup_teardown(test_tree_rfc_line_length, setup_ctx, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_parse_yin_with_unique, setup_ctx, teardown_ctx),
         cmocka_unit_test_setup_teardown(test_parse_yang_with_unique, setup_ctx, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_parse_yin_with_submodule_types, setup_ctx, teardown_ctx),
+        cmocka_unit_test_setup_teardown(test_parse_yang_with_submodule_types, setup_ctx, teardown_ctx),
     };
 
     return cmocka_run_group_tests(cmut, NULL, NULL);

--- a/tests/schema/yang/files/d.yang
+++ b/tests/schema/yang/files/d.yang
@@ -1,0 +1,6 @@
+module d {
+  namespace "urn:d";
+  prefix d_mod;
+
+  include dsub;
+}

--- a/tests/schema/yang/files/dsub.yang
+++ b/tests/schema/yang/files/dsub.yang
@@ -1,0 +1,9 @@
+submodule dsub {
+  belongs-to d {
+    prefix d_mod;
+  }
+
+  typedef d_type {
+      type string;
+  }
+}

--- a/tests/schema/yang/files/e.yang
+++ b/tests/schema/yang/files/e.yang
@@ -1,0 +1,14 @@
+module e {
+  namespace "urn:e";
+  prefix e_mod;
+
+  import d {
+      prefix d_mod;
+  }
+
+  container top {
+    leaf leaf {
+      type d_mod:d_type;
+    }
+  }
+}


### PR DESCRIPTION
There is an issue with the yin and yang printer when a leaf uses a type defined in a submodule of an imported module. Without the patch, the printer would try to find the prefix of the submodule, instead of finding the prefix of the submodule’s main module.

The suggested fix ensures that the printer always attempts to get the prefix of the main module. The accompanying unit test uses a yang model that demonstrates the original issue.

### Resolves #501 