### PR TITLE
Fix issue when defaults aren't stored in canonical form

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -5610,7 +5610,7 @@ resolve_identref(struct lys_type *type, const char *ident_name, struct lyd_node 
     int need_implemented = 0;
     unsigned int i, j;
     struct lys_ident *der, *cur;
-    struct lys_module *imod = NULL, *m;
+    struct lys_module *imod = NULL, *m, *tmod;
     struct ly_ctx *ctx;
 
     assert(type && ident_name && node && mod);
@@ -5640,6 +5640,17 @@ resolve_identref(struct lys_type *type, const char *ident_name, struct lyd_node 
             if (!strncmp(mod_name, mod->imp[i].module->name, mod_name_len) && !mod->imp[i].module->name[mod_name_len]) {
                 imod = mod->imp[i].module;
                 break;
+            }
+        }
+
+        /* We may need to pull it from the module that the typedef came from */
+        if (!imod && type && type->der) {
+            tmod = type->der->module;
+            for (i = 0; i < tmod->imp_size; i++) {
+                if (!strncmp(mod_name, tmod->imp[i].module->name, mod_name_len) && !tmod->imp[i].module->name[mod_name_len]) {
+                    imod = tmod->imp[i].module;
+                    break;
+                }
             }
         }
     } else {

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1184,7 +1184,7 @@ _lyd_new_leaf(struct lyd_node *parent, const struct lys_node *schema, const char
 
     /* resolve the type correctly (after it was connected to parent cause of log) */
     if (!lyp_parse_value(&((struct lys_node_leaf *)ret->schema)->type, &((struct lyd_node_leaf_list *)ret)->value_str,
-                         NULL, (struct lyd_node_leaf_list *)ret, NULL, NULL, 1, 0)) {
+                         NULL, (struct lyd_node_leaf_list *)ret, NULL, NULL, 1, dflt)) {
         lyd_free(ret);
         return NULL;
     }


### PR DESCRIPTION
Sometimes the `dflt` value on a type isn't stored in canonical form (for example, storing '0xa' instead of '10'). This isn't a problem by itself, but it makes it important that functions that create default values
properly pass-on the `dflt` flag.

This commit also addresses a secondary issue that stems from the primary fix. Because the `dflt` flag is now being propagated properly in more circumstances, an issue crops up when a default value for an
identityref is given in a typedef from a separate module. The fix is to also search the typedef-defining module to find the module that defines the specific identity instance.