### PR TITLE
Fix build of C++ tests

### DIFF
--- a/swig/cpp/tests/test_libyang.cpp
+++ b/swig/cpp/tests/test_libyang.cpp
@@ -28,7 +28,7 @@
 #include "libyang.h"
 
 /* include private header to be able to check internal values */
-#include "../../src/context.h"
+#include "../../../src/context.h"
 
 #include "microtest.h"
 


### PR DESCRIPTION
I do not really understand how come that Travis did not check this. When I check the corresponding [build log](https://travis-ci.org/CESNET/libyang/jobs/383749441), I see that the C++ tests are being built, but not executed for some reason. I've verified that they *are* executed when I build this locally with cmake 3.9.6.