### PR TITLE
fix build on OmniOS/Solaris

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.12)
 project(libyang C)
 
 include(GNUInstallDirs)
+include(CheckSymbolExists)
 
 set(LIBYANG_DESCRIPTION "libyang is YANG data modelling language parser and toolkit written (and providing API) in C.")
 
@@ -231,6 +232,11 @@ set(headers
     src/user_types.h
     src/xml.h
     src/dict.h)
+
+check_symbol_exists(vdprintf stdio.h HAVE_VDPRINTF)
+if(HAVE_VDPRINTF)
+    add_definitions(-DHAVE_VDPRINTF)
+endif(HAVE_VDPRINTF)
 
 # create static libyang library
 if(ENABLE_STATIC)

--- a/src/printer.c
+++ b/src/printer.c
@@ -79,12 +79,23 @@ ly_print(struct lyout *out, const char *format, ...)
     int count = 0;
     char *msg = NULL, *aux;
     va_list ap;
+#ifndef HAVE_VDPRINTF
+    FILE *stream;
+#endif
 
     va_start(ap, format);
 
     switch(out->type) {
     case LYOUT_FD:
+#ifdef HAVE_VDPRINTF
         count = vdprintf(out->method.fd, format, ap);
+#else
+        stream = fdopen(dup(out->method.fd), "a+");
+        if (stream) {
+            count = vfprintf(stream, format, ap);
+            fclose(stream);
+        }
+#endif
         break;
     case LYOUT_STREAM:
         count = vfprintf(out->method.f, format, ap);

--- a/src/user_types/user_date_and_time.c
+++ b/src/user_types/user_date_and_time.c
@@ -11,7 +11,6 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _XOPEN_SOURCE
 #define _GNU_SOURCE
 
 #include <stdlib.h>

--- a/src/user_types/user_ipv4.c
+++ b/src/user_types/user_ipv4.c
@@ -15,6 +15,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
+#include <sys/socket.h>
 
 #include "../user_types.h"
 


### PR DESCRIPTION
1 - OmniOS doesn't have vdprintf(), use fdopen()+vfprintf() to
    workaround this problem;
2 - Remove the _XOPEN_SOURCE definition in src/user_types/user_date_and_time.c
    to fix this compiler error: "Compiler or options invalid for pre-UNIX 03
    X/Open applications and pre-2001 POSIX applications". This change doesn't
    affect libyang build on Debian 9.3 and OpenBSD 6.3.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>