### PR TITLE
Fix when dumping Leaf Elements

### DIFF
--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -636,7 +636,7 @@ xml_print_data(struct lyout *out, const struct lyd_node *root, int options)
         }
 
         if (node) {
-            if (node->child) {
+            if (!(node->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST)) && node->child) {
                 for (parent = lys_parent(node->child->schema); parent && (parent->nodetype == LYS_USES); parent = lys_parent(parent));
             }
             if (parent && (parent->nodetype == LYS_OUTPUT)) {


### PR DESCRIPTION
We were accessing child info for a lyd_node_leaf_list type node and it was resulting in a crash. Added a check and it's working fine now.