### PR TITLE
Fix warnings in C++ bindings

### DIFF
--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -89,13 +89,13 @@
 #define LY_NEW(data, element, class)\
     {\
         return data->element ? std::make_shared<class>(data->element, deleter) : nullptr;\
-    };
+    }
 
 #define LY_NEW_CASTED(cast, data, element, class)\
     {\
         cast *casted = (struct cast *) data;\
         return casted->element ? std::make_shared<class>(casted->element, deleter) : nullptr;\
-    };
+    }
 
 #define LY_NEW_LIST(data, element, size, class)\
     {\
@@ -107,13 +107,13 @@
             s_vector->push_back(std::make_shared<class>(&data->element[i], deleter));\
         }\
         return s_vector;\
-    };
+    }
 
 #define LY_NEW_LIST_CASTED(cast, data, element, size, class)\
     {\
         struct cast *casted = (struct cast *) data;\
         LY_NEW_LIST(casted, element, size, class);\
-    };
+    }
 
 #define LY_NEW_P_LIST(data, element, size, class)\
     {\
@@ -125,13 +125,13 @@
             s_vector->push_back(std::make_shared<class>(data->element[i], deleter));\
         }\
         return s_vector;\
-    };
+    }
 
 #define LY_NEW_P_LIST_CASTED(cast, data, element, size, class)\
     {\
         struct cast *casted = (struct cast *) data;\
         LY_NEW_P_LIST(casted, element, size, class);\
-    };
+    }
 
 #define LY_NEW_STRING_LIST(data, element, size)\
     {\
@@ -143,7 +143,7 @@
             s_vector->push_back(std::string(data->element[i]));\
         }\
         return s_vector;\
-    };
+    }
 
 #include <iostream>
 #include <memory>

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -409,7 +409,7 @@ class Schema_Node
 {
 public:
     Schema_Node(lys_node *node, S_Deleter deleter);
-    ~Schema_Node();
+    virtual ~Schema_Node();
     const char *name() {return node->name;};
     const char *dsc() {return node->dsc;};
     const char *ref() {return node->ref;};

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -541,7 +541,7 @@ public:
     S_Type type();
     const char *units() {return ((struct lys_node_leaf *)node)->units;};
     const char *dflt() {return ((struct lys_node_leaf *)node)->dflt;};
-    S_Schema_Node child() {return nullptr;};
+    S_Schema_Node child() override {return nullptr;};
     int is_key();
 
 private:
@@ -577,7 +577,7 @@ public:
     std::vector<std::string> *dflt();
     uint32_t min() {return ((struct lys_node_leaflist *)node)->min;};
     uint32_t max() {return ((struct lys_node_leaflist *)node)->max;};
-    S_Schema_Node child() {return nullptr;};
+    S_Schema_Node child() override {return nullptr;};
 
 private:
     struct lys_node *node;


### PR DESCRIPTION
The extra semicolons are not compatible with -pedantic, and the missing
`override` keyword breaks `-Wsuggest-override` on GCC 8.