### PR TITLE
C++: Do not use CFLAGS as flags for the C++ compiler

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -1,3 +1,5 @@
+project(libyang-cpp)
+
 set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
@@ -5,8 +7,6 @@ set(CMAKE_CXX_FLAGS_DEBUG   "-g -O0")
 
 # temporary bugfix
 add_compile_options(-std=c++11)
-
-project(libyang-cpp)
 
 # find SWIG package
 if(GEN_LANGUAGE_BINDINGS)

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_CXX_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=c++11")
+set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_DEBUG   "-g -O0")


### PR DESCRIPTION
The `CXXFLAGS` and `CFLAGS` are different variables even though they happen to accept a common subset of options. It is always wrong to mix them like this.

This particular usage breaks builds with clang's libc++:

- the build environment specifies `CXXFLAGS=-stdlib=libc++`
- libyang silently ignores that variable and produces a C++ library which uses symbol names from GCC's STL
- a user application which links with libyang's C++ binginds fails to build because it epects, e.g., a `std::__1::shared_ptr<Deleter>`.

This patch ensures that `CXXFLAGS` are not ignored, and that the `CFLAGS` are not accidentaly passed to the C++ compiler. On exotic setups, this might require setting `CXXFLAGS` in addition to `CFLAGS` if `CFLAGS` contains hand-crafted options such as include paths which bypass the regular
cmake package discovery, etc. If the developer wants to pass some custom optimization options, the correct approach is to set them in both `CFLAGS` and `CXXFLAGS`.

*Note: I checked sysrepo and the SWIG setup in there appears to be OK.*