### PR TITLE
Fix dangling parsing_sub_modules pointer

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -2630,6 +2630,10 @@ yang_read_module(struct ly_ctx *ctx, const char* data, unsigned int size, const 
     ret = yang_parse_mem(module, NULL, unres, data, size, &node);
     if (ret == -1) {
         if (ly_vecode(ctx) == LYVE_SUBMODULE) {
+            /* Remove this module from the list of processed modules,
+               as we're about to free it */
+            lyp_check_circmod_pop(module);
+
             free(module);
             module = NULL;
         } else {

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -2632,7 +2632,7 @@ yang_read_module(struct ly_ctx *ctx, const char* data, unsigned int size, const 
         if (ly_vecode(ctx) == LYVE_SUBMODULE) {
             /* Remove this module from the list of processed modules,
                as we're about to free it */
-            lyp_check_circmod_pop(module);
+            lyp_check_circmod_pop(ctx);
 
             free(module);
             module = NULL;


### PR DESCRIPTION
This change fixes a dangling pointer and memory leak introduced by the refactor in 78ef03a.

In 78ef03a, the call to `lyp_check_circmod_pop()` (under the `error` label) was moved to after the early `if (!module)` return. This meant that if `module` had been freed above due to an error (see line 2637) and we entered the early return, `lyp_check_circmod_pop()` would not be called. `ctx->models->parsing_sub_modules` would now contain a danging pointer to a module whose memory had been freed. Subsequent attempts to use the list could result in undefined behavior, including a segmentation fault.

The fix is to pop the module off the list before we free it.