### PR TITLE
prevent libyang crashes on invalid xpath

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -8684,7 +8684,7 @@ int
 lyxp_node_atomize(const struct lys_node *node, struct lyxp_set *set, int set_ext_dep_flags)
 {
     struct lys_node *parent, *elem;
-    const struct lys_node *ctx_snode;
+    const struct lys_node *ctx_snode = NULL;
     struct lyxp_set tmp_set;
     uint8_t must_size = 0;
     uint32_t i, j;


### PR DESCRIPTION
Uninitialized ctx_snode can lead to invalid memory dereference and crash in case of invalid
xpath expression in "must" (my usual error is using c-style == for equality). 
