### PR TITLE
C++: allocate std::vector on stack instead of heap

### DIFF
--- a/swig/cpp/examples/context.cpp
+++ b/swig/cpp/examples/context.cpp
@@ -28,8 +28,8 @@ int main() {
         ctx = S_Context(new Context("/etc/sysrepo2/yang"));
     } catch( const std::exception& e ) {
         std::cout << e.what() << std::endl;
-        auto errors = std::shared_ptr<std::vector<S_Error>>(get_ly_errors(ctx));
-        for(auto error = errors->begin() ; error != errors->end() ; ++error) {
+        auto errors = get_ly_errors(ctx);
+        for(auto error = errors.begin() ; error != errors.end() ; ++error) {
             std::cout << "err: " << (*error)->err() << std::endl;
             std::cout << "vecode: " << (*error)->vecode() << std::endl;
             std::cout << "errmsg: " << (*error)->errmsg() << std::endl;
@@ -44,8 +44,8 @@ int main() {
         std::cout << e.what() << std::endl;
     }
 
-    auto folders = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-    for(auto elem = folders->begin() ; elem != folders->end() ; ++elem) {
+    auto folders = ctx->get_searchdirs();
+    for(auto elem = folders.begin() ; elem != folders.end() ; ++elem) {
         std::cout << (*elem) << std::endl;
     }
     std::cout << std::endl;
@@ -60,8 +60,8 @@ int main() {
         }
     }
 
-    auto modules = std::shared_ptr<std::vector<S_Module>>(ctx->get_module_iter());
-    for(auto mod = modules->begin() ; mod != modules->end() ; ++mod) {
+    auto modules = ctx->get_module_iter();
+    for(auto mod = modules.begin() ; mod != modules.end() ; ++mod) {
         std::cout << "module " << (*mod)->name() << " prefix " << (*mod)->prefix() << " type " << (*mod)->type() << std::endl;
     }
 

--- a/swig/cpp/examples/process_tree.cpp
+++ b/swig/cpp/examples/process_tree.cpp
@@ -28,8 +28,8 @@ int main() {
         ctx = S_Context(new Context("/etc/sysrepo/yang"));
     } catch( const std::exception& e ) {
         std::cout << e.what() << std::endl;
-        auto errors = std::shared_ptr<std::vector<S_Error>>(get_ly_errors(ctx));
-        for(auto error = errors->begin() ; error != errors->end() ; ++error) {
+        auto errors = get_ly_errors(ctx);
+        for(auto error = errors.begin() ; error != errors.end() ; ++error) {
             std::cout << "err: " << (*error)->err() << std::endl;
             std::cout << "vecode: " << (*error)->vecode() << std::endl;
             std::cout << "errmsg: " << (*error)->errmsg() << std::endl;
@@ -57,8 +57,8 @@ int main() {
         std::cout << "parse_path did not return any nodes" << std::endl;
     } else {
         std::cout << "tree_dfs\n" << std::endl;
-        auto data_list = std::shared_ptr<std::vector<S_Data_Node>>(node->tree_dfs());
-        for(auto elem = data_list->begin() ; elem != data_list->end() ; ++elem) {
+        auto data_list = node->tree_dfs();
+        for(auto elem = data_list.begin() ; elem != data_list.end() ; ++elem) {
             std::cout << "name: " << (*elem)->schema()->name() << " type: " << (*elem)->schema()->nodetype() << std::endl;
         }
 
@@ -66,14 +66,14 @@ int main() {
 
         std::cout << "tree_for\n" << std::endl;
 
-        data_list = std::shared_ptr<std::vector<S_Data_Node>>(node->child()->child()->tree_dfs());
-        for(auto elem = data_list->begin() ; elem != data_list->end() ; ++elem) {
+        data_list = node->child()->child()->tree_dfs();
+        for(auto elem = data_list.begin() ; elem != data_list.end() ; ++elem) {
             std::cout << "child of " << node->child()->schema()->name() << " is: " << (*elem)->schema()->name() << " type: " << (*elem)->schema()->nodetype() << std::endl;
         }
 
         std::cout << "\n schema tree_dfs\n" << std::endl;
-        auto schema_list = std::shared_ptr<std::vector<S_Schema_Node>>(node->schema()->tree_dfs());
-        for(auto elem = schema_list->begin() ; elem != schema_list->end() ; ++elem) {
+        auto schema_list = node->schema()->tree_dfs();
+        for(auto elem = schema_list.begin() ; elem != schema_list.end() ; ++elem) {
             std::cout << "schema name " << (*elem)->name() << " type " << (*elem)->nodetype() << std::endl;
             if  (LYS_LEAF == (*elem)->nodetype()) {
                 auto leaf = Schema_Node_Leaf(*elem);

--- a/swig/cpp/examples/xpath.cpp
+++ b/swig/cpp/examples/xpath.cpp
@@ -36,15 +36,15 @@ int main() {
             return -1;
         }
 
-        auto list = std::shared_ptr<std::vector<S_Data_Node>>(node_set->data());
-        for(auto data_set = list->begin() ; data_set != list->end() ; ++data_set) {
+        auto list = node_set->data();
+        for(auto data_set = list.begin() ; data_set != list.end() ; ++data_set) {
             std::cout << "name: " << (*data_set)->schema()->name() << " type: " << (*data_set)->schema()->nodetype() << " path: " << (*data_set)->path() << std::endl;
         }
     } catch( const std::exception& e ) {
         std::cout << "test" << std::endl;
         std::cout << e.what() << std::endl;
-        auto errors = std::shared_ptr<std::vector<S_Error>>(get_ly_errors(ctx));
-        for(auto error = errors->begin() ; error != errors->end() ; ++error) {
+        auto errors = get_ly_errors(ctx);
+        for(auto error = errors.begin() ; error != errors.end() ; ++error) {
             std::cout << "err: " << (*error)->err() << std::endl;
             std::cout << "vecode: " << (*error)->vecode() << std::endl;
             std::cout << "errmsg: " << (*error)->errmsg() << std::endl;

--- a/swig/cpp/src/Internal.hpp
+++ b/swig/cpp/src/Internal.hpp
@@ -99,12 +99,12 @@
 
 #define LY_NEW_LIST(data, element, size, class)\
     {\
-        auto s_vector = new std::vector<S_##class>;\
+        std::vector<S_##class> s_vector;\
         if (0 >= data->size) {\
             return s_vector;\
         }\
         for (uint8_t i = 0; i < data->size; i++) {\
-            s_vector->push_back(std::make_shared<class>(&data->element[i], deleter));\
+            s_vector.push_back(std::make_shared<class>(&data->element[i], deleter));\
         }\
         return s_vector;\
     }
@@ -117,12 +117,12 @@
 
 #define LY_NEW_P_LIST(data, element, size, class)\
     {\
-        auto s_vector = new std::vector<S_##class>;\
+        std::vector<S_##class> s_vector;\
         if (0 >= data->size) {\
             return s_vector;\
         }\
         for (uint8_t i = 0; i < data->size; i++) {\
-            s_vector->push_back(std::make_shared<class>(data->element[i], deleter));\
+            s_vector.push_back(std::make_shared<class>(data->element[i], deleter));\
         }\
         return s_vector;\
     }
@@ -135,12 +135,12 @@
 
 #define LY_NEW_STRING_LIST(data, element, size)\
     {\
-        auto s_vector = new std::vector<std::string>;\
+        std::vector<std::string> s_vector;\
         if (0 >= data->size) {\
             return s_vector;\
         }\
         for (uint8_t i = 0; i < data->size; i++) {\
-            s_vector->push_back(std::string(data->element[i]));\
+            s_vector.push_back(std::string(data->element[i]));\
         }\
         return s_vector;\
     }

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -92,32 +92,32 @@ S_Module Context::get_module_by_ns(const char *ns, const char *revision, int imp
     const struct lys_module *module = ly_ctx_get_module_by_ns(ctx, ns, revision, implemented);
     return module ? std::make_shared<Module>((lys_module *) module, deleter) : nullptr;
 }
-std::vector<S_Module> *Context::get_module_iter() {
+std::vector<S_Module> Context::get_module_iter() {
     const struct lys_module *mod = nullptr;
     uint32_t i = 0;
 
-    auto s_vector = new std::vector<S_Module>;
+    std::vector<S_Module> s_vector;
 
     while ((mod = ly_ctx_get_module_iter(ctx, &i))) {
         if (mod == nullptr) {
             break;
         }
-        s_vector->push_back(std::make_shared<Module>((lys_module *) mod, deleter));
+        s_vector.push_back(std::make_shared<Module>((lys_module *) mod, deleter));
     }
 
     return s_vector;
 }
-std::vector<S_Module> *Context::get_disabled_module_iter() {
+std::vector<S_Module> Context::get_disabled_module_iter() {
     const struct lys_module *mod = nullptr;
     uint32_t i = 0;
 
-    auto s_vector = new std::vector<S_Module>;
+    std::vector<S_Module> s_vector;
 
     while ((mod = ly_ctx_get_disabled_module_iter(ctx, &i))) {
         if (mod == nullptr) {
             break;
         }
-        s_vector->push_back(std::make_shared<Module>((lys_module *) mod, deleter));
+        s_vector.push_back(std::make_shared<Module>((lys_module *) mod, deleter));
     }
 
     return s_vector;
@@ -125,8 +125,8 @@ std::vector<S_Module> *Context::get_disabled_module_iter() {
 void Context::clean() {
     return ly_ctx_clean(ctx, nullptr);
 }
-std::vector<std::string> *Context::get_searchdirs() {
-    auto s_vector = new std::vector<std::string>;
+std::vector<std::string> Context::get_searchdirs() {
+    std::vector<std::string> s_vector;
     const char * const *data = ly_ctx_get_searchdirs(ctx);
     if (!data) {
         return s_vector;
@@ -137,7 +137,7 @@ std::vector<std::string> *Context::get_searchdirs() {
         if (data[size] == nullptr) {
             break;
         }
-        s_vector->push_back(std::string(data[size]));
+        s_vector.push_back(std::string(data[size]));
         size++;
     }
 
@@ -173,14 +173,14 @@ S_Set Context::find_path(const char *schema_path) {
     S_Deleter new_deleter = std::make_shared<Deleter>(set, deleter);
     return std::make_shared<Set>(set, new_deleter);
 }
-std::vector<S_Schema_Node> *Context::data_instantiables(int options) {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Context::data_instantiables(int options) {
+    std::vector<S_Schema_Node> s_vector;
     struct lys_node *iter = NULL;
     int i;
 
     for (i = 0; i < ctx->models.used; i++) {
         while ((iter = (struct lys_node *)lys_getnext(iter, NULL, ctx->models.list[i], options))) {
-            s_vector->push_back(std::make_shared<Schema_Node>(iter, deleter));
+            s_vector.push_back(std::make_shared<Schema_Node>(iter, deleter));
         }
     }
 
@@ -276,9 +276,9 @@ Error::Error(struct ly_err_item *eitem):
 	eitem(eitem)
 {};
 
-std::vector<S_Error> *get_ly_errors(S_Context context)
+std::vector<S_Error> get_ly_errors(S_Context context)
 {
-    auto s_vector = new std::vector<S_Error>;
+    std::vector<S_Error> s_vector;
     if (!context) {
         return s_vector;
     }
@@ -290,7 +290,7 @@ std::vector<S_Error> *get_ly_errors(S_Context context)
 
     struct ly_err_item *eitem = first_eitem;
     while (eitem) {
-        s_vector->push_back(std::make_shared<Error>(eitem));
+        s_vector.push_back(std::make_shared<Error>(eitem));
         eitem = eitem->next;
     }
 
@@ -321,22 +321,22 @@ Set::Set(struct ly_set *set, S_Deleter deleter):
     deleter(deleter)
 {};
 Set::~Set() {}
-std::vector<S_Data_Node> *Set::data() {
-    auto s_vector = new std::vector<S_Data_Node>;
+std::vector<S_Data_Node> Set::data() {
+    std::vector<S_Data_Node> s_vector;
 
     unsigned int i;
     for (i = 0; i < set->number; i++){
-        s_vector->push_back(std::make_shared<Data_Node>(set->set.d[i], deleter));
+        s_vector.push_back(std::make_shared<Data_Node>(set->set.d[i], deleter));
     }
 
     return s_vector;
 };
-std::vector<S_Schema_Node> *Set::schema() {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Set::schema() {
+    std::vector<S_Schema_Node> s_vector;
 
     unsigned int i;
     for (i = 0; i < set->number; i++){
-        s_vector->push_back(std::make_shared<Schema_Node>(set->set.s[i], deleter));
+        s_vector.push_back(std::make_shared<Schema_Node>(set->set.s[i], deleter));
     }
 
     return s_vector;

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -68,7 +68,7 @@ public:
     /** wrapper for [ly_ctx_unset_searchdirs](@ref ly_ctx_unset_searchdirs) */
     void unset_searchdirs(int idx) {return ly_ctx_unset_searchdirs(ctx, idx);};
     /** wrapper for [ly_ctx_get_searchdirs](@ref ly_ctx_get_searchdirs) */
-    std::vector<std::string> *get_searchdirs();
+    std::vector<std::string> get_searchdirs();
     /** wrapper for [ly_ctx_set_allimplemented](@ref ly_ctx_set_allimplemented) */
     void set_allimplemented() {return ly_ctx_set_allimplemented(ctx);};
     /** wrapper for [ly_ctx_unset_allimplemented](@ref ly_ctx_unset_allimplemented) */
@@ -76,9 +76,9 @@ public:
     /** wrapper for [ly_ctx_info](@ref ly_ctx_info) */
     S_Data_Node info();
     /** wrapper for [ly_ctx_get_module_iter](@ref ly_ctx_get_module_iter) */
-    std::vector<S_Module> *get_module_iter();
+    std::vector<S_Module> get_module_iter();
     /** wrapper for [ly_ctx_get_disabled_module_iter](@ref ly_ctx_get_disabled_module_iter) */
-    std::vector<S_Module> *get_disabled_module_iter();
+    std::vector<S_Module> get_disabled_module_iter();
     /** wrapper for [ly_ctx_get_module](@ref ly_ctx_get_module) */
     S_Module get_module(const char *name, const char *revision = nullptr, int implemented = 0);
     /** wrapper for [ly_ctx_get_module_older](@ref ly_ctx_get_module_older) */
@@ -94,7 +94,7 @@ public:
     /** wrapper for [ly_ctx_get_node](@ref ly_ctx_get_node) */
     S_Schema_Node get_node(S_Schema_Node start, const char *data_path, int output = 0);
     /** wrapper for [lys_getnext](@ref lys_getnext) */
-    std::vector<S_Schema_Node> *data_instantiables(int options);
+    std::vector<S_Schema_Node> data_instantiables(int options);
     /** wrapper for [ly_ctx_find_path](@ref ly_ctx_find_path) */
     S_Set find_path(const char *schema_path);
     /** wrapper for [ly_ctx_clean](@ref ly_ctx_clean) */
@@ -116,7 +116,7 @@ public:
     /** wrapper for [lys_parse_path](@ref lys_parse_path) */
     S_Module parse_module_path(const char *path, LYS_INFORMAT format);
 
-    friend std::vector<S_Error> *get_ly_errors(S_Context context);
+    friend std::vector<S_Error> get_ly_errors(S_Context context);
     friend Data_Node;
     friend Deleter;
     friend Error;
@@ -152,7 +152,7 @@ private:
 	struct ly_err_item *eitem;
 };
 
-std::vector<S_Error> *get_ly_errors(S_Context context);
+std::vector<S_Error> get_ly_errors(S_Context context);
 int set_log_options(int options);
 LY_LOG_LEVEL set_log_verbosity(LY_LOG_LEVEL level);
 
@@ -172,9 +172,9 @@ public:
     /** get number variable from [ly_set](@ref ly_set)*/
     unsigned int number() {return set->number;};
     /** get d variable from [ly_set_set](@ref ly_set_set)*/
-    std::vector<S_Data_Node> *data();
+    std::vector<S_Data_Node> data();
     /** get s variable from [ly_set_set](@ref ly_set_set)*/
-    std::vector<S_Schema_Node> *schema();
+    std::vector<S_Schema_Node> schema();
 
     /* functions */
     /** wrapper for [ly_set_dup](@ref ly_set_dup) */

--- a/swig/cpp/src/Tree_Data.cpp
+++ b/swig/cpp/src/Tree_Data.cpp
@@ -433,22 +433,22 @@ std::string Data_Node::print_mem(LYD_FORMAT format, int options) {
     return s_strp;
 
 }
-std::vector<S_Data_Node> *Data_Node::tree_for() {
-    auto s_vector = new std::vector<S_Data_Node>;
+std::vector<S_Data_Node> Data_Node::tree_for() {
+    std::vector<S_Data_Node> s_vector;
 
     struct lyd_node *elem = nullptr;
     LY_TREE_FOR(node, elem) {
-        s_vector->push_back(std::make_shared<Data_Node>(elem, deleter));
+        s_vector.push_back(std::make_shared<Data_Node>(elem, deleter));
     }
 
     return s_vector;
 }
-std::vector<S_Data_Node> *Data_Node::tree_dfs() {
-    auto s_vector = new std::vector<S_Data_Node>;
+std::vector<S_Data_Node> Data_Node::tree_dfs() {
+    std::vector<S_Data_Node> s_vector;
 
     struct lyd_node *elem = nullptr, *next = nullptr;
     LY_TREE_DFS_BEGIN(node, next, elem) {
-        s_vector->push_back(std::make_shared<Data_Node>(elem, deleter));
+        s_vector.push_back(std::make_shared<Data_Node>(elem, deleter));
         LY_TREE_DFS_END(node, next, elem)
     }
 
@@ -525,8 +525,8 @@ Difflist::Difflist(struct lyd_difflist *diff, S_Deleter deleter) {
     deleter = std::make_shared<Deleter>(diff, deleter);
 }
 Difflist::~Difflist() {};
-std::vector<S_Data_Node> *Difflist::first() {
-    auto s_vector = new std::vector<S_Data_Node>;
+std::vector<S_Data_Node> Difflist::first() {
+    std::vector<S_Data_Node> s_vector;
     unsigned int i = 0;
 
     if (!*diff->first) {
@@ -534,13 +534,13 @@ std::vector<S_Data_Node> *Difflist::first() {
     }
 
     for(i = 0; i < sizeof(*diff->first); i++) {
-        s_vector->push_back(std::make_shared<Data_Node>(*diff->first, deleter));
+        s_vector.push_back(std::make_shared<Data_Node>(*diff->first, deleter));
     }
 
     return s_vector;
 }
-std::vector<S_Data_Node> *Difflist::second() {
-    auto s_vector = new std::vector<S_Data_Node>;
+std::vector<S_Data_Node> Difflist::second() {
+    std::vector<S_Data_Node> s_vector;
     unsigned int i = 0;
 
     if (!*diff->second) {
@@ -548,7 +548,7 @@ std::vector<S_Data_Node> *Difflist::second() {
     }
 
     for(i = 0; i < sizeof(*diff->second); i++) {
-        s_vector->push_back(std::make_shared<Data_Node>(*diff->second, deleter));
+        s_vector.push_back(std::make_shared<Data_Node>(*diff->second, deleter));
     }
 
     return s_vector;

--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -210,9 +210,9 @@ public:
 
     /* emulate TREE macro's */
     /** wrapper for macro [LY_TREE_FOR](@ref LY_TREE_FOR) */
-    std::vector<S_Data_Node> *tree_for();
+    std::vector<S_Data_Node> tree_for();
     /** wrapper for macro [LY_TREE_DFS_BEGIN](@ref LY_TREE_DFS_BEGIN) and [LY_TREE_DFS_END](@ref LY_TREE_DFS_END) */
-    std::vector<S_Data_Node> *tree_dfs();
+    std::vector<S_Data_Node> tree_dfs();
 
     /** SWIG related wrappers, for internal use only */
     struct lyd_node *swig_node() {return node;};
@@ -331,9 +331,9 @@ public:
     /** get type variable from [lyd_difflist](@ref lyd_difflist)*/
     LYD_DIFFTYPE *type() {return diff->type;};
     /** get first variable from [lyd_difflist](@ref lyd_difflist)*/
-    std::vector<S_Data_Node> *first();
+    std::vector<S_Data_Node> first();
     /** get second variable from [lyd_difflist](@ref lyd_difflist)*/
-    std::vector<S_Data_Node> *second();
+    std::vector<S_Data_Node> second();
 
 private:
     struct lyd_difflist *diff;

--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -32,17 +32,17 @@ Module::Module(struct lys_module *module, S_Deleter deleter):
 {};
 Module::~Module() {};
 S_Revision Module::rev() LY_NEW(module, rev, Revision);
-std::vector<S_Deviation> *Module::deviation() LY_NEW_LIST(module, deviation, deviation_size, Deviation);
+std::vector<S_Deviation> Module::deviation() LY_NEW_LIST(module, deviation, deviation_size, Deviation);
 Submodule::Submodule(struct lys_submodule *submodule, S_Deleter deleter):
     submodule(submodule),
     deleter(deleter)
 {};
-std::vector<S_Schema_Node> *Module::data_instantiables(int options) {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Module::data_instantiables(int options) {
+    std::vector<S_Schema_Node> s_vector;
     struct lys_node *iter = NULL;
 
     while ((iter = (struct lys_node *)lys_getnext(iter, NULL, module, options))) {
-        s_vector->push_back(std::make_shared<Schema_Node>(iter, deleter));
+        s_vector.push_back(std::make_shared<Schema_Node>(iter, deleter));
     }
 
     return s_vector;
@@ -77,7 +77,7 @@ std::string Module::print_mem(LYS_OUTFORMAT format, const char *target, int opti
 }
 Submodule::~Submodule() {};
 S_Revision Submodule::rev() LY_NEW(submodule, rev, Revision);
-std::vector<S_Deviation> *Submodule::deviation() LY_NEW_LIST(submodule, deviation, deviation_size, Deviation);
+std::vector<S_Deviation> Submodule::deviation() LY_NEW_LIST(submodule, deviation, deviation_size, Deviation);
 
 Type_Info_Binary::Type_Info_Binary(struct lys_type_info_binary *info_binary, S_Deleter deleter):
     info_binary(info_binary),
@@ -91,15 +91,15 @@ Type_Bit::Type_Bit(struct lys_type_bit *info_bit, S_Deleter deleter):
     deleter(deleter)
 {};
 Type_Bit::~Type_Bit() {};
-std::vector<S_Ext_Instance> *Type_Bit::ext() LY_NEW_P_LIST(info_bit, ext, ext_size, Ext_Instance);
-std::vector<S_Iffeature> *Type_Bit::iffeature() LY_NEW_LIST(info_bit, iffeature, iffeature_size, Iffeature);
+std::vector<S_Ext_Instance> Type_Bit::ext() LY_NEW_P_LIST(info_bit, ext, ext_size, Ext_Instance);
+std::vector<S_Iffeature> Type_Bit::iffeature() LY_NEW_LIST(info_bit, iffeature, iffeature_size, Iffeature);
 
 Type_Info_Bits::Type_Info_Bits(struct lys_type_info_bits *info_bits, S_Deleter deleter):
     info_bits(info_bits),
     deleter(deleter)
 {};
 Type_Info_Bits::~Type_Info_Bits() {};
-std::vector<S_Type_Bit> *Type_Info_Bits::bit() LY_NEW_LIST(info_bits, bit, count, Type_Bit);
+std::vector<S_Type_Bit> Type_Info_Bits::bit() LY_NEW_LIST(info_bits, bit, count, Type_Bit);
 
 Type_Info_Dec64::Type_Info_Dec64(struct lys_type_info_dec64 *info_dec64, S_Deleter deleter):
     info_dec64(info_dec64),
@@ -113,22 +113,22 @@ Type_Enum::Type_Enum(struct lys_type_enum *info_enum, S_Deleter deleter):
     deleter(deleter)
 {};
 Type_Enum::~Type_Enum() {};
-std::vector<S_Ext_Instance> *Type_Enum::ext() LY_NEW_P_LIST(info_enum, ext, ext_size, Ext_Instance);
-std::vector<S_Iffeature> *Type_Enum::iffeature() LY_NEW_LIST(info_enum, iffeature, iffeature_size, Iffeature);
+std::vector<S_Ext_Instance> Type_Enum::ext() LY_NEW_P_LIST(info_enum, ext, ext_size, Ext_Instance);
+std::vector<S_Iffeature> Type_Enum::iffeature() LY_NEW_LIST(info_enum, iffeature, iffeature_size, Iffeature);
 
 Type_Info_Enums::Type_Info_Enums(struct lys_type_info_enums *info_enums, S_Deleter deleter):
     info_enums(info_enums),
     deleter(deleter)
 {};
 Type_Info_Enums::~Type_Info_Enums() {};
-std::vector<S_Type_Enum> *Type_Info_Enums::enm() LY_NEW_LIST(info_enums, enm, count, Type_Enum);
+std::vector<S_Type_Enum> Type_Info_Enums::enm() LY_NEW_LIST(info_enums, enm, count, Type_Enum);
 
 Type_Info_Ident::Type_Info_Ident(struct lys_type_info_ident *info_ident, S_Deleter deleter):
     info_ident(info_ident),
     deleter(deleter)
 {};
 Type_Info_Ident::~Type_Info_Ident() {};
-std::vector<S_Ident> *Type_Info_Ident::ref() LY_NEW_P_LIST(info_ident, ref, count, Ident);
+std::vector<S_Ident> Type_Info_Ident::ref() LY_NEW_P_LIST(info_ident, ref, count, Ident);
 
 Type_Info_Inst::Type_Info_Inst(struct lys_type_info_inst *info_inst, S_Deleter deleter):
     info_inst(info_inst),
@@ -163,7 +163,7 @@ Type_Info_Union::Type_Info_Union(lys_type_info_union *info_union, S_Deleter dele
     deleter(deleter)
 {};
 Type_Info_Union::~Type_Info_Union() {};
-std::vector<S_Type> *Type_Info_Union::types() LY_NEW_LIST(info_union, types, count, Type);
+std::vector<S_Type> Type_Info_Union::types() LY_NEW_LIST(info_union, types, count, Type);
 
 Type_Info::Type_Info(union lys_type_info info, LY_DATA_TYPE *type, uint8_t flags, S_Deleter deleter):
     info(info),
@@ -194,7 +194,7 @@ Type::Type(struct lys_type *type, S_Deleter deleter):
     deleter(deleter)
 {};
 Type::~Type() {};
-std::vector<S_Ext_Instance> *Type::ext() LY_NEW_P_LIST(type, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Type::ext() LY_NEW_P_LIST(type, ext, ext_size, Ext_Instance);
 S_Tpdf Type::der() {return type->der ? std::make_shared<Tpdf>(type->der, deleter) : nullptr;};
 S_Tpdf Type::parent() {return type->parent ? std::make_shared<Tpdf>(type->parent, deleter) : nullptr;};
 S_Type_Info Type::info() {return std::make_shared<Type_Info>(type->info, &type->base, type->value_flags, deleter);};
@@ -204,24 +204,23 @@ Iffeature::Iffeature(struct lys_iffeature *iffeature, S_Deleter deleter):
     deleter(deleter)
 {};
 Iffeature::~Iffeature() {};
-std::vector<S_Feature> *Iffeature::features() {
-    auto s_vector = new std::vector<S_Feature>;
+std::vector<S_Feature> Iffeature::features() {
+    std::vector<S_Feature> s_vector;
 
-    //TODO check if sizeof can be used
     for (size_t i = 0; i < sizeof(*iffeature->features); i++) {
-        s_vector->push_back(std::make_shared<Feature>(iffeature->features[i], deleter));
+        s_vector.push_back(std::make_shared<Feature>(iffeature->features[i], deleter));
     }
 
     return s_vector;
 };
-std::vector<S_Ext_Instance> *Iffeature::ext() LY_NEW_P_LIST(iffeature, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Iffeature::ext() LY_NEW_P_LIST(iffeature, ext, ext_size, Ext_Instance);
 
 Ext_Instance::Ext_Instance(lys_ext_instance *ext_instance, S_Deleter deleter):
     ext_instance(ext_instance),
     deleter(deleter)
 {};
 Ext_Instance::~Ext_Instance() {};
-std::vector<S_Ext_Instance> *Ext_Instance::ext() LY_NEW_P_LIST(ext_instance, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Ext_Instance::ext() LY_NEW_P_LIST(ext_instance, ext, ext_size, Ext_Instance);
 
 Revision::Revision(lys_revision *revision, S_Deleter deleter):
     revision(revision),
@@ -234,7 +233,7 @@ Schema_Node::Schema_Node(struct lys_node *node, S_Deleter deleter):
     deleter(deleter)
 {};
 Schema_Node::~Schema_Node() {};
-std::vector<S_Ext_Instance> *Schema_Node::ext() LY_NEW_P_LIST(node, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Schema_Node::ext() LY_NEW_P_LIST(node, ext, ext_size, Ext_Instance);
 S_Module Schema_Node::module() LY_NEW(node, module, Module);
 S_Schema_Node Schema_Node::parent() LY_NEW(node, parent, Schema_Node);
 S_Schema_Node Schema_Node::child() LY_NEW(node, child, Schema_Node);
@@ -252,12 +251,12 @@ std::string Schema_Node::path(int options) {
     free(path);
     return s_path;
 }
-std::vector<S_Schema_Node> *Schema_Node::child_instantiables(int options) {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Schema_Node::child_instantiables(int options) {
+    std::vector<S_Schema_Node> s_vector;
     struct lys_node *iter = NULL;
 
     while ((iter = (struct lys_node *)lys_getnext(iter, node, node->module, options))) {
-        s_vector->push_back(std::make_shared<Schema_Node>(iter, deleter));
+        s_vector.push_back(std::make_shared<Schema_Node>(iter, deleter));
     }
 
     return s_vector;
@@ -291,22 +290,22 @@ S_Set Schema_Node::xpath_atomize(int options) {
 
     return std::make_shared<Set>(set, deleter);
 }
-std::vector<S_Schema_Node> *Schema_Node::tree_for() {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Schema_Node::tree_for() {
+    std::vector<S_Schema_Node> s_vector;
 
     struct lys_node *elem = nullptr;
     LY_TREE_FOR(node, elem) {
-        s_vector->push_back(std::make_shared<Schema_Node>(elem, deleter));
+        s_vector.push_back(std::make_shared<Schema_Node>(elem, deleter));
     }
 
     return s_vector;
 }
-std::vector<S_Schema_Node> *Schema_Node::tree_dfs() {
-    auto s_vector = new std::vector<S_Schema_Node>;
+std::vector<S_Schema_Node> Schema_Node::tree_dfs() {
+    std::vector<S_Schema_Node> s_vector;
 
     struct lys_node *elem = nullptr, *next = nullptr;
     LY_TREE_DFS_BEGIN(node, next, elem) {
-        s_vector->push_back(std::make_shared<Schema_Node>(elem, deleter));
+        s_vector.push_back(std::make_shared<Schema_Node>(elem, deleter));
         LY_TREE_DFS_END(node, next, elem)
     }
 
@@ -345,44 +344,44 @@ S_Schema_Node_List Schema_Node_Leaf::is_key() {
 Schema_Node_Leaflist::~Schema_Node_Leaflist() {};
 S_Set Schema_Node_Leaflist::backlinks() LY_NEW_CASTED(lys_node_leaflist, node, backlinks, Set);
 S_When Schema_Node_Leaflist::when() LY_NEW_CASTED(lys_node_leaflist, node, when, When);
-std::vector<std::string> *Schema_Node_Leaflist::dflt() {
+std::vector<std::string> Schema_Node_Leaflist::dflt() {
     struct lys_node_leaflist *node_leaflist = (struct lys_node_leaflist *)node;
     LY_NEW_STRING_LIST(node_leaflist, dflt, dflt_size);
 }
-std::vector<S_Restr> *Schema_Node_Leaflist::must() LY_NEW_LIST_CASTED(lys_node_leaflist, node, must, must_size, Restr);
+std::vector<S_Restr> Schema_Node_Leaflist::must() LY_NEW_LIST_CASTED(lys_node_leaflist, node, must, must_size, Restr);
 S_Type Schema_Node_Leaflist::type() {return std::make_shared<Type>(&((struct lys_node_leaflist *)node)->type, deleter);}
 
 Schema_Node_List::~Schema_Node_List() {};
 S_When Schema_Node_List::when() LY_NEW_CASTED(lys_node_list, node, when, When);
-std::vector<S_Restr> *Schema_Node_List::must() LY_NEW_LIST_CASTED(lys_node_list, node, must, must_size, Restr);
-std::vector<S_Tpdf> *Schema_Node_List::tpdf() LY_NEW_LIST_CASTED(lys_node_list, node, tpdf, tpdf_size, Tpdf);
-std::vector<S_Schema_Node_Leaf> *Schema_Node_List::keys() {
+std::vector<S_Restr> Schema_Node_List::must() LY_NEW_LIST_CASTED(lys_node_list, node, must, must_size, Restr);
+std::vector<S_Tpdf> Schema_Node_List::tpdf() LY_NEW_LIST_CASTED(lys_node_list, node, tpdf, tpdf_size, Tpdf);
+std::vector<S_Schema_Node_Leaf> Schema_Node_List::keys() {
     auto list = (struct lys_node_list *) node;
 
-    auto s_vector = new std::vector<S_Schema_Node_Leaf>;
+    std::vector<S_Schema_Node_Leaf> s_vector;
 
     for (uint8_t i = 0; i < list->keys_size; i++) {
-        s_vector->push_back(std::make_shared<Schema_Node_Leaf>((struct lys_node *) list->keys[i], deleter));
+        s_vector.push_back(std::make_shared<Schema_Node_Leaf>((struct lys_node *) list->keys[i], deleter));
     }
 
     return s_vector;
 }
-std::vector<S_Unique> *Schema_Node_List::unique() LY_NEW_LIST_CASTED(lys_node_list, node, unique, unique_size, Unique);
+std::vector<S_Unique> Schema_Node_List::unique() LY_NEW_LIST_CASTED(lys_node_list, node, unique, unique_size, Unique);
 
 Schema_Node_Anydata::~Schema_Node_Anydata() {};
 S_When Schema_Node_Anydata::when() LY_NEW_CASTED(lys_node_anydata, node, when, When);
-std::vector<S_Restr> *Schema_Node_Anydata::must() LY_NEW_LIST_CASTED(lys_node_anydata, node, must, must_size, Restr);
+std::vector<S_Restr> Schema_Node_Anydata::must() LY_NEW_LIST_CASTED(lys_node_anydata, node, must, must_size, Restr);
 
 Schema_Node_Uses::~Schema_Node_Uses() {};
 S_When Schema_Node_Uses::when() LY_NEW_CASTED(lys_node_uses, node, when, When);
-std::vector<S_Refine> *Schema_Node_Uses::refine() LY_NEW_LIST_CASTED(lys_node_uses, node, refine, refine_size, Refine);
-std::vector<S_Schema_Node_Augment> *Schema_Node_Uses::augment() {
+std::vector<S_Refine> Schema_Node_Uses::refine() LY_NEW_LIST_CASTED(lys_node_uses, node, refine, refine_size, Refine);
+std::vector<S_Schema_Node_Augment> Schema_Node_Uses::augment() {
     auto uses = (struct lys_node_uses *) node;
 
-    auto s_vector = new std::vector<S_Schema_Node_Augment>;
+    std::vector<S_Schema_Node_Augment> s_vector;
 
     for (uint8_t i = 0; i < uses->augment_size; i++) {
-        s_vector->push_back(std::make_shared<Schema_Node_Augment>((struct lys_node *) &uses->augment[i], deleter));
+        s_vector.push_back(std::make_shared<Schema_Node_Augment>((struct lys_node *) &uses->augment[i], deleter));
     }
 
     return s_vector;
@@ -393,21 +392,21 @@ S_Schema_Node_Grp Schema_Node_Uses::grp() {
 };
 
 Schema_Node_Grp::~Schema_Node_Grp() {};
-std::vector<S_Tpdf> *Schema_Node_Grp::tpdf() LY_NEW_LIST_CASTED(lys_node_grp, node, tpdf, tpdf_size, Tpdf);
+std::vector<S_Tpdf> Schema_Node_Grp::tpdf() LY_NEW_LIST_CASTED(lys_node_grp, node, tpdf, tpdf_size, Tpdf);
 
 Schema_Node_Case::~Schema_Node_Case() {};
 S_When Schema_Node_Case::when() LY_NEW_CASTED(lys_node_case, node, when, When);
 
 Schema_Node_Inout::~Schema_Node_Inout() {};
-std::vector<S_Tpdf> *Schema_Node_Inout::tpdf() LY_NEW_LIST_CASTED(lys_node_inout, node, tpdf, tpdf_size, Tpdf);
-std::vector<S_Restr> *Schema_Node_Inout::must() LY_NEW_LIST_CASTED(lys_node_inout, node, must, must_size, Restr);
+std::vector<S_Tpdf> Schema_Node_Inout::tpdf() LY_NEW_LIST_CASTED(lys_node_inout, node, tpdf, tpdf_size, Tpdf);
+std::vector<S_Restr> Schema_Node_Inout::must() LY_NEW_LIST_CASTED(lys_node_inout, node, must, must_size, Restr);
 
 Schema_Node_Notif::~Schema_Node_Notif() {};
-std::vector<S_Tpdf> *Schema_Node_Notif::tpdf() LY_NEW_LIST_CASTED(lys_node_notif, node, tpdf, tpdf_size, Tpdf);
-std::vector<S_Restr> *Schema_Node_Notif::must() LY_NEW_LIST_CASTED(lys_node_notif, node, must, must_size, Restr);
+std::vector<S_Tpdf> Schema_Node_Notif::tpdf() LY_NEW_LIST_CASTED(lys_node_notif, node, tpdf, tpdf_size, Tpdf);
+std::vector<S_Restr> Schema_Node_Notif::must() LY_NEW_LIST_CASTED(lys_node_notif, node, must, must_size, Restr);
 
 Schema_Node_Rpc_Action::~Schema_Node_Rpc_Action() {};
-std::vector<S_Tpdf> *Schema_Node_Rpc_Action::tpdf() LY_NEW_LIST_CASTED(lys_node_rpc_action, node, tpdf, tpdf_size, Tpdf);
+std::vector<S_Tpdf> Schema_Node_Rpc_Action::tpdf() LY_NEW_LIST_CASTED(lys_node_rpc_action, node, tpdf, tpdf_size, Tpdf);
 
 Schema_Node_Augment::~Schema_Node_Augment() {};
 S_When Schema_Node_Augment::when() LY_NEW_CASTED(lys_node_augment, node, when, When);
@@ -417,7 +416,7 @@ When::When(struct lys_when *when, S_Deleter deleter):
     deleter(deleter)
 {};
 When::~When() {};
-std::vector<S_Ext_Instance> *When::ext() LY_NEW_P_LIST(when, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> When::ext() LY_NEW_P_LIST(when, ext, ext_size, Ext_Instance);
 
 Substmt::Substmt(struct lyext_substmt *substmt, S_Deleter deleter):
     substmt(substmt),
@@ -430,7 +429,7 @@ Ext::Ext(struct lys_ext *ext, S_Deleter deleter):
     deleter(deleter)
 {};
 Ext::~Ext() {};
-std::vector<S_Ext_Instance> *Ext::ext_instance() LY_NEW_P_LIST(ext, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Ext::ext_instance() LY_NEW_P_LIST(ext, ext, ext_size, Ext_Instance);
 S_Module Ext::module() LY_NEW(ext, module, Module);
 
 Refine_Mod_List::Refine_Mod_List(struct lys_refine_mod_list *list, S_Deleter deleter):
@@ -453,9 +452,9 @@ Refine::Refine(struct lys_refine *refine, S_Deleter deleter):
     deleter(deleter)
 {};
 Refine::~Refine() {};
-std::vector<S_Ext_Instance> *Refine::ext() LY_NEW_P_LIST(refine, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Refine::ext() LY_NEW_P_LIST(refine, ext, ext_size, Ext_Instance);
 S_Module Refine::module() LY_NEW(refine, module, Module);
-std::vector<S_Restr> *Refine::must() LY_NEW_LIST(refine, must, must_size, Restr);
+std::vector<S_Restr> Refine::must() LY_NEW_LIST(refine, must, must_size, Restr);
 S_Refine_Mod Refine::mod() {return std::make_shared<Refine_Mod>(refine->mod, refine->target_type, deleter);};
 
 Deviate::Deviate(struct lys_deviate *deviate, S_Deleter deleter):
@@ -463,7 +462,7 @@ Deviate::Deviate(struct lys_deviate *deviate, S_Deleter deleter):
     deleter(deleter)
 {};
 Deviate::~Deviate() {};
-std::vector<S_Ext_Instance> *Deviate::ext() LY_NEW_P_LIST(deviate, ext, ext_size, Ext_Instance);
+std::vector<S_Ext_Instance> Deviate::ext() LY_NEW_P_LIST(deviate, ext, ext_size, Ext_Instance);
 S_Restr Deviate::must() {return deviate->must ? std::make_shared<Restr>(deviate->must, deleter) : nullptr;};
 S_Unique Deviate::unique() {return deviate->unique ? std::make_shared<Unique>(deviate->unique, deleter) : nullptr;};
 S_Type Deviate::type() {return deviate->type ? std::make_shared<Type>(deviate->type, deleter) : nullptr;}
@@ -474,8 +473,8 @@ Deviation::Deviation(struct lys_deviation *deviation, S_Deleter deleter):
 {};
 Deviation::~Deviation() {};
 S_Schema_Node Deviation::orig_node() LY_NEW(deviation, orig_node, Schema_Node);
-std::vector<S_Deviate> *Deviation::deviate() LY_NEW_LIST(deviation, deviate, deviate_size, Deviate);
-std::vector<S_Ext_Instance> *Deviation::ext() LY_NEW_P_LIST(deviation, ext, ext_size, Ext_Instance);
+std::vector<S_Deviate> Deviation::deviate() LY_NEW_LIST(deviation, deviate, deviate_size, Deviate);
+std::vector<S_Ext_Instance> Deviation::ext() LY_NEW_P_LIST(deviation, ext, ext_size, Ext_Instance);
 
 Import::Import(struct lys_import *import, S_Deleter deleter):
     import(import),
@@ -519,4 +518,4 @@ Ident::Ident(struct lys_ident *ident, S_Deleter deleter):
     deleter(deleter)
 {};
 Ident::~Ident() {};
-std::vector<S_Ident> *Ident::base() LY_NEW_P_LIST(ident, base, base_size, Ident);
+std::vector<S_Ident> Ident::base() LY_NEW_P_LIST(ident, base, base_size, Ident);

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -143,11 +143,11 @@ public:
     /** get rev variable from [lys_module](@ref lys_module)*/
     S_Revision rev();
     /** get deviation variable from [lys_module](@ref lys_module)*/
-    std::vector<S_Deviation> *deviation();
+    std::vector<S_Deviation> deviation();
     /** get data variable from [lys_module](@ref lys_module)*/
     S_Schema_Node data() LY_NEW(module, data, Schema_Node);
     /** wrapper for [lys_getnext](@ref lys_getnext) */
-    std::vector<S_Schema_Node> *data_instantiables(int options);
+    std::vector<S_Schema_Node> data_instantiables(int options);
     /** wrapper for [lys_print_mem](@ref lys_print_mem) */
     std::string print_mem(LYS_OUTFORMAT format, int options);
     std::string print_mem(LYS_OUTFORMAT format, const char *target, int options);
@@ -219,7 +219,7 @@ public:
     /** get rev variable from [lys_submodule](@ref lys_submodule)*/
     S_Revision rev();
     /** get deviation variable from [lys_submodule](@ref lys_submodule)*/
-    std::vector<S_Deviation> *deviation();
+    std::vector<S_Deviation> deviation();
     /** get belongsto variable from [lys_submodule](@ref lys_submodule)*/
     S_Module belongsto() LY_NEW(submodule, belongsto, Module);
 
@@ -263,9 +263,9 @@ public:
     /** get pos variable from [lys_type_bit](@ref lys_type_bit)*/
     uint32_t pos() {return info_bit->pos;};
     /** get ext variable from [lys_type_bit](@ref lys_type_bit)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get iffeature variable from [lys_type_bit](@ref lys_type_bit)*/
-    std::vector<S_Iffeature> *iffeature();
+    std::vector<S_Iffeature> iffeature();
 
 private:
     lys_type_bit *info_bit;
@@ -279,7 +279,7 @@ public:
     Type_Info_Bits(struct lys_type_info_bits *info_bits, S_Deleter deleter);
     ~Type_Info_Bits();
     /** get bit variable from [lys_type_info_bits](@ref lys_type_info_bits)*/
-    std::vector<S_Type_Bit> *bit();
+    std::vector<S_Type_Bit> bit();
     /** get count variable from [lys_type_info_bits](@ref lys_type_info_bits)*/
     unsigned int count() {return info_bits->count;};
 
@@ -327,9 +327,9 @@ public:
     /** get value variable from [lys_type_enum](@ref lys_type_enum)*/
     int32_t value() {return info_enum->value;};
     /** get ext variable from [lys_type_enum](@ref lys_type_enum)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get iffeature variable from [lys_type_enum](@ref lys_type_enum)*/
-    std::vector<S_Iffeature> *iffeature();
+    std::vector<S_Iffeature> iffeature();
 
 private:
     lys_type_enum *info_enum;
@@ -343,7 +343,7 @@ public:
     Type_Info_Enums(struct lys_type_info_enums *info_enums, S_Deleter deleter);
     ~Type_Info_Enums();
     /** get enm variable from [lys_type_info_enums](@ref lys_type_info_enums)*/
-    std::vector<S_Type_Enum> *enm();
+    std::vector<S_Type_Enum> enm();
     /** get count variable from [lys_type_info_enums](@ref lys_type_info_enums)*/
     unsigned int count() {return info_enums->count;};
 
@@ -359,7 +359,7 @@ public:
     Type_Info_Ident(struct lys_type_info_ident *info_ident, S_Deleter deleter);
     ~Type_Info_Ident();
     /** get ref variable from [lys_type_info_ident](@ref lys_type_info_ident)*/
-    std::vector<S_Ident> *ref();
+    std::vector<S_Ident> ref();
     /** get count variable from [lys_type_info_ident](@ref lys_type_info_ident)*/
     int count() {return info_ident->count;};
 
@@ -439,7 +439,7 @@ public:
     Type_Info_Union(struct lys_type_info_union *info_union, S_Deleter deleter);
     ~Type_Info_Union();
     /** get types variable from [lys_type_info_union](@ref lys_type_info_union)*/
-    std::vector<S_Type> *types();
+    std::vector<S_Type> types();
     /** get count variable from [lys_type_info_union](@ref lys_type_info_union)*/
     int count() {return info_union->count;};
     /** get has_ptr_type variable from [lys_type_info_union](@ref lys_type_info_union)*/
@@ -495,7 +495,7 @@ public:
     /** get ext_size variable from [lys_type](@ref lys_type)*/
     uint8_t ext_size() {return type->ext_size;};
     /** get ext variable from [lys_type](@ref lys_type)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get der variable from [lys_type](@ref lys_type)*/
     S_Tpdf der();
     /** get parent variable from [lys_type](@ref lys_type)*/
@@ -518,9 +518,9 @@ public:
     /** get ext_size variable from [lys_iffeature](@ref lys_iffeature)*/
     uint8_t ext_size() {return iffeature->ext_size;};
     /** get features variable from [lys_iffeature](@ref lys_iffeature)*/
-    std::vector<S_Feature> *features();
+    std::vector<S_Feature> features();
     /** get ext variable from [lys_iffeature](@ref lys_iffeature)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
 
 private:
     struct lys_iffeature *iffeature;
@@ -549,7 +549,7 @@ public:
     /** get ext_type variable from [lys_ext_instance](@ref lys_ext_instance)*/
     uint8_t ext_type() {return ext_instance->ext_type;};
     /** get ext variable from [lys_ext_instance](@ref lys_ext_instance)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get priv variable from [lys_ext_instance](@ref lys_ext_instance)*/
     void *priv() {return ext_instance->priv;};
     /** get module variable from [lys_ext_instance](@ref lys_ext_instance)*/
@@ -580,9 +580,9 @@ public:
     /** get iffeature_size variable from [lys_node](@ref lys_node)*/
     uint8_t iffeature_size() {return node->iffeature_size;};
     /** get ext variable from [lys_node](@ref lys_node)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get iffeature variable from [lys_node](@ref lys_node)*/
-    std::vector<S_Iffeature> *iffeature() LY_NEW_LIST(node, iffeature, iffeature_size, Iffeature);
+    std::vector<S_Iffeature> iffeature() LY_NEW_LIST(node, iffeature, iffeature_size, Iffeature);
     /** get module variable from [lys_node](@ref lys_node)*/
     S_Module module();
     /** get nodetype variable from [lys_node](@ref lys_node)*/
@@ -601,7 +601,7 @@ public:
     /** wrapper for [lyd_validate_value](@ref lyd_validate_value) */
     int validate_value(const char *value) {return lyd_validate_value(node, value);};
     /** wrapper for [lys_getnext](@ref lys_getnext) */
-    std::vector<S_Schema_Node> *child_instantiables(int options);
+    std::vector<S_Schema_Node> child_instantiables(int options);
     /** wrapper for [lys_find_path](@ref lys_find_path) */
     S_Set find_path(const char *path);
     /** wrapper for [lys_xpath_atomize](@ref lys_xpath_atomize) */
@@ -612,9 +612,9 @@ public:
 
     /* emulate TREE macro's */
     /** wrapper for macro [LY_TREE_FOR](@ref LY_TREE_FOR) */
-    std::vector<S_Schema_Node> *tree_for();
+    std::vector<S_Schema_Node> tree_for();
     /** wrapper for macro [LY_TREE_DFS_BEGIN](@ref LY_TREE_DFS_BEGIN) and [LY_TREE_DFS_END](@ref LY_TREE_DFS_END) */
-    std::vector<S_Schema_Node> *tree_dfs();
+    std::vector<S_Schema_Node> tree_dfs();
 
     /* SWIG can not access private variables so it needs public getters */
     struct lys_node *swig_node() {return node;};
@@ -771,13 +771,13 @@ public:
     /** get backlinks variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     S_Set backlinks();
     /** get must variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
     /** get type variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     S_Type type();
     /** get units variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     const char *units() {return ((struct lys_node_leaflist *)node)->units;};
     /** get dflt variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<std::string> *dflt();
+    std::vector<std::string> dflt();
     /** get min variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     uint32_t min() {return ((struct lys_node_leaflist *)node)->min;};
     /** get max variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
@@ -819,13 +819,13 @@ public:
     /** get when variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     S_When when();
     /** get must variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
     /** get tpdf variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<S_Tpdf> *tpdf();
+    std::vector<S_Tpdf> tpdf();
     /** get keys variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<S_Schema_Node_Leaf> *keys();
+    std::vector<S_Schema_Node_Leaf> keys();
     /** get unique variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
-    std::vector<S_Unique> *unique();
+    std::vector<S_Unique> unique();
     /** get min variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
     uint32_t min() {return ((struct lys_node_list *)node)->min;};
     /** get max variable from [lys_node_leaflist](@ref lys_node_leaflist)*/
@@ -862,7 +862,7 @@ public:
     /** get when variable from [lys_node_anydata](@ref lys_node_anydata)*/
     S_When when();
     /** get must variable from [lys_node_anydata](@ref lys_node_anydata)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
 
 private:
     struct lys_node *node;
@@ -893,9 +893,9 @@ public:
     /** get when variable from [lys_node_uses](@ref lys_node_uses)*/
     S_When when();
     /** get refine variable from [lys_node_uses](@ref lys_node_uses)*/
-    std::vector<S_Refine> *refine();
+    std::vector<S_Refine> refine();
     /** get augment variable from [lys_node_uses](@ref lys_node_uses)*/
-    std::vector<S_Schema_Node_Augment> *augment();
+    std::vector<S_Schema_Node_Augment> augment();
     /** get grp variable from [lys_node_uses](@ref lys_node_uses)*/
     S_Schema_Node_Grp grp();
 
@@ -926,7 +926,7 @@ public:
     /** get tpdf_size variable from [lys_node_grp](@ref lys_node_grp)*/
     uint8_t tpdf_size() {return ((struct lys_node_grp *)node)->tpdf_size;};
     /** get tpdf variable from [lys_node_grp](@ref lys_node_grp)*/
-    std::vector<S_Tpdf> *tpdf();
+    std::vector<S_Tpdf> tpdf();
 
 private:
     struct lys_node *node;
@@ -984,9 +984,9 @@ public:
     /** get must_size variable from [lys_node_inout](@ref lys_node_inout)*/
     uint8_t must_size() {return ((struct lys_node_inout *)node)->must_size;};
     /** get tpdf variable from [lys_node_inout](@ref lys_node_inout)*/
-    std::vector<S_Tpdf> *tpdf();
+    std::vector<S_Tpdf> tpdf();
     /** get must variable from [lys_node_inout](@ref lys_node_inout)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
 
 private:
     struct lys_node *node;
@@ -1017,9 +1017,9 @@ public:
     /** get must_size variable from [lys_node_notif](@ref lys_node_notif)*/
     uint8_t must_size() {return ((struct lys_node_notif *)node)->must_size;};
     /** get tpdf variable from [lys_node_notif](@ref lys_node_notif)*/
-    std::vector<S_Tpdf> *tpdf();
+    std::vector<S_Tpdf> tpdf();
     /** get must variable from [lys_node_notif](@ref lys_node_notif)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
 
 private:
     struct lys_node *node;
@@ -1048,7 +1048,7 @@ public:
     /** get tpdf_size variable from [lys_node_rpc_action](@ref lys_node_rpc_action)*/
     uint8_t tpdf_size() {return ((struct lys_node_rpc_action *)node)->tpdf_size;};
     /** get tpdf variable from [lys_node_rpc_action](@ref lys_node_rpc_action)*/
-    std::vector<S_Tpdf> *tpdf();
+    std::vector<S_Tpdf> tpdf();
 
 private:
     struct lys_node *node;
@@ -1118,7 +1118,7 @@ public:
     /** get ext_size variable from [lys_ext](@ref lys_ext)*/
     uint8_t ext_size() {return ext->ext_size;};
     /** get ext_instance variable from [lys_ext](@ref lys_ext)*/
-    std::vector<S_Ext_Instance> *ext_instance();
+    std::vector<S_Ext_Instance> ext_instance();
     /** get argument variable from [lys_ext](@ref lys_ext)*/
     const char *argument() {return ext->argument;};
     /** get module variable from [lys_ext](@ref lys_ext)*/
@@ -1187,15 +1187,15 @@ public:
     /** get dflt_size variable from [lys_refine](@ref lys_refine)*/
     uint8_t dflt_size() {return refine->dflt_size;};
     /** get ext variable from [lys_refine](@ref lys_refine)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get iffeature variable from [lys_refine](@ref lys_refine)*/
-    std::vector<S_Iffeature> *iffeature() LY_NEW_LIST(refine, iffeature, iffeature_size, Iffeature);
+    std::vector<S_Iffeature> iffeature() LY_NEW_LIST(refine, iffeature, iffeature_size, Iffeature);
     /** get module variable from [lys_refine](@ref lys_refine)*/
     S_Module module();
     /** get must variable from [lys_refine](@ref lys_refine)*/
-    std::vector<S_Restr> *must();
+    std::vector<S_Restr> must();
     /** get dflt variable from [lys_refine](@ref lys_refine)*/
-    std::vector<std::string> *dflt() LY_NEW_STRING_LIST(refine, dflt, dflt_size);
+    std::vector<std::string> dflt() LY_NEW_STRING_LIST(refine, dflt, dflt_size);
     /** get mod variable from [lys_refine](@ref lys_refine)*/
     S_Refine_Mod mod();
 
@@ -1239,9 +1239,9 @@ public:
     /** get units variable from [lys_deviate](@ref lys_deviate)*/
     const char *units() {return deviate->units;};
     /** get dflt variable from [lys_deviate](@ref lys_deviate)*/
-    std::vector<std::string> *dflt() LY_NEW_STRING_LIST(deviate, dflt, dflt_size);
+    std::vector<std::string> dflt() LY_NEW_STRING_LIST(deviate, dflt, dflt_size);
     /** get ext variable from [lys_deviate](@ref lys_deviate)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
 
 private:
     struct lys_deviate *deviate;
@@ -1267,9 +1267,9 @@ public:
     /** get ext_size variable from [lys_deviation](@ref lys_deviation)*/
     uint8_t ext_size() {return deviation->ext_size;};
     /** get deviate variable from [lys_deviation](@ref lys_deviation)*/
-    std::vector<S_Deviate> *deviate();
+    std::vector<S_Deviate> deviate();
     /** get ext variable from [lys_deviation](@ref lys_deviation)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
 
 private:
     struct lys_deviation *deviation;
@@ -1291,7 +1291,7 @@ public:
     /** get ext_size variable from [lys_import](@ref lys_import)*/
     uint8_t ext_size() {return import->ext_size;};
     /** get ext variable from [lys_import](@ref lys_import)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(import, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(import, ext, ext_size, Ext_Instance);
     /** get dsc variable from [lys_import](@ref lys_import)*/
     const char *dsc() {return import->dsc;};
     /** get ref variable from [lys_import](@ref lys_import)*/
@@ -1315,7 +1315,7 @@ public:
     /** get ext_size variable from [lys_include](@ref lys_include)*/
     uint8_t ext_size() {return include->ext_size;};
     /** get ext variable from [lys_include](@ref lys_include)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(include, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(include, ext, ext_size, Ext_Instance);
     /** get dsc variable from [lys_include](@ref lys_include)*/
     const char *dsc() {return include->dsc;};
     /** get ref variable from [lys_include](@ref lys_include)*/
@@ -1367,7 +1367,7 @@ public:
     /** get has_union_leafref variable from [lys_tpdf](@ref lys_tpdf)*/
     uint8_t has_union_leafref() {return tpdf->has_union_leafref;};
     /** get ext variable from [lys_tpdf](@ref lys_tpdf)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(tpdf, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(tpdf, ext, ext_size, Ext_Instance);
     /** get units variable from [lys_tpdf](@ref lys_tpdf)*/
     const char *units() {return tpdf->units;};
     /** get module variable from [lys_tpdf](@ref lys_tpdf)*/
@@ -1389,7 +1389,7 @@ public:
     Unique(struct lys_unique *unique, S_Deleter deleter);
     ~Unique();
     /** get expr variable from [lys_unique](@ref lys_unique)*/
-    std::vector<std::string> *expr() LY_NEW_STRING_LIST(unique, expr, expr_size);
+    std::vector<std::string> expr() LY_NEW_STRING_LIST(unique, expr, expr_size);
     /** get expr_size variable from [lys_unique](@ref lys_unique)*/
     uint8_t expr_size() {return unique->expr_size;};
     /** get trg_type variable from [lys_unique](@ref lys_unique)*/
@@ -1419,9 +1419,9 @@ public:
     /** get iffeature_size variable from [lys_feature](@ref lys_feature)*/
     uint8_t iffeature_size() {return feature->iffeature_size;};
     /** get ext variable from [lys_feature](@ref lys_feature)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(feature, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(feature, ext, ext_size, Ext_Instance);
     /** get iffeature variable from [lys_feature](@ref lys_feature)*/
-    std::vector<S_Iffeature> *iffeature() LY_NEW_LIST(feature, iffeature, iffeature_size, Iffeature);
+    std::vector<S_Iffeature> iffeature() LY_NEW_LIST(feature, iffeature, iffeature_size, Iffeature);
     /** get module variable from [lys_feature](@ref lys_feature)*/
     S_Module module() LY_NEW(feature, module, Module);
     /** get depfeatures variable from [lys_feature](@ref lys_feature)*/
@@ -1449,7 +1449,7 @@ public:
     /** get emsg variable from [lys_restr](@ref lys_restr)*/
     const char *emsg() {return restr->emsg;};
     /** get ext variable from [lys_restr](@ref lys_restr)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(restr, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(restr, ext, ext_size, Ext_Instance);
     /** get ext_size variable from [lys_restr](@ref lys_restr)*/
     uint8_t ext_size() {return restr->ext_size;};
 
@@ -1471,7 +1471,7 @@ public:
     /** get ref variable from [lys_when](@ref lys_when)*/
     const char *ref() {return when->ref;};
     /** get ext variable from [lys_when](@ref lys_when)*/
-    std::vector<S_Ext_Instance> *ext();
+    std::vector<S_Ext_Instance> ext();
     /** get ext_size variable from [lys_when](@ref lys_when)*/
     uint8_t ext_size() {return when->ext_size;};
 
@@ -1501,13 +1501,13 @@ public:
     /** get base_size variable from [lys_ident](@ref lys_ident)*/
     uint8_t base_size() {return ident->base_size;};
     /** get ext variable from [lys_ident](@ref lys_ident)*/
-    std::vector<S_Ext_Instance> *ext() LY_NEW_P_LIST(ident, ext, ext_size, Ext_Instance);
+    std::vector<S_Ext_Instance> ext() LY_NEW_P_LIST(ident, ext, ext_size, Ext_Instance);
     /** get iffeature variable from [lys_ident](@ref lys_ident)*/
-    std::vector<S_Iffeature> *iffeature() LY_NEW_LIST(ident, iffeature, iffeature_size, Iffeature);
+    std::vector<S_Iffeature> iffeature() LY_NEW_LIST(ident, iffeature, iffeature_size, Iffeature);
     /** get module variable from [lys_ident](@ref lys_ident)*/
     S_Module module() LY_NEW(ident, module, Module);
     /** get base variable from [lys_ident](@ref lys_ident)*/
-    std::vector<S_Ident> *base();
+    std::vector<S_Ident> base();
     /** get der variable from [lys_ident](@ref lys_ident)*/
     S_Set der() LY_NEW(ident, der, Set);
 

--- a/swig/cpp/tests/test_libyang.cpp
+++ b/swig/cpp/tests/test_libyang.cpp
@@ -40,15 +40,13 @@ TEST(test_ly_ctx_new)
     try {
         auto ctx = S_Context(new Context(yang_folder1));
         ASSERT_FALSE(nullptr == ctx);
-        auto list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_FALSE(nullptr == list);
-        ASSERT_EQ(1, list->size());
+        auto list = ctx->get_searchdirs();
+        ASSERT_EQ(1, list.size());
 
         ctx = S_Context(new Context(yang_folder2));
         ASSERT_FALSE(nullptr == ctx);
-        list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_FALSE(nullptr == list);
-        ASSERT_EQ(2, list->size());
+        list = ctx->get_searchdirs();
+        ASSERT_EQ(2, list.size());
     } catch( const std::exception& e ) {
         mt::printFailed(e.what(), stdout);
         return;
@@ -76,9 +74,9 @@ TEST(test_ly_ctx_get_searchdirs)
         auto ctx = S_Context(new Context(yang_folder));
         ASSERT_FALSE(nullptr == ctx);
 
-        auto list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_EQ(1, list->size());
-        ASSERT_EQ(yang_folder, list->at(0));
+        auto list = ctx->get_searchdirs();
+        ASSERT_EQ(1, list.size());
+        ASSERT_EQ(yang_folder, list.at(0));
     } catch( const std::exception& e ) {
         mt::printFailed(e.what(), stdout);
         return;
@@ -94,19 +92,19 @@ TEST(test_ly_ctx_set_searchdir)
         auto ctx = S_Context(new Context(yang_folder));
         ASSERT_FALSE(nullptr == ctx);
 
-        auto list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_EQ(1, list->size());
-        ASSERT_EQ(yang_folder, list->at(0));
+        auto list = ctx->get_searchdirs();
+        ASSERT_EQ(1, list.size());
+        ASSERT_EQ(yang_folder, list.at(0));
 
         ctx->set_searchdir(new_yang_folder);
-        list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_EQ(2, list->size());
-        ASSERT_EQ(new_yang_folder, list->at(1));
+        list = ctx->get_searchdirs();
+        ASSERT_EQ(2, list.size());
+        ASSERT_EQ(new_yang_folder, list.at(1));
 
         ctx->unset_searchdirs(0);
-        list = std::shared_ptr<std::vector<std::string>>(ctx->get_searchdirs());
-        ASSERT_EQ(1, list->size());
-        ASSERT_EQ(new_yang_folder, list->at(0));
+        list = ctx->get_searchdirs();
+        ASSERT_EQ(1, list.size());
+        ASSERT_EQ(new_yang_folder, list.at(0));
     } catch( const std::exception& e ) {
         mt::printFailed(e.what(), stdout);
         return;

--- a/swig/cpp/tests/test_tree_schema.cpp
+++ b/swig/cpp/tests/test_tree_schema.cpp
@@ -505,8 +505,8 @@ TEST(test_ly_schema_node_path)
         auto set = schema_node->find_path(path_template);
         ASSERT_NOTNULL(set);
 
-        auto schemas = std::shared_ptr<std::vector<S_Schema_Node>>(set->schema());
-        auto schema = schemas->at(0);
+        auto schemas = set->schema();
+        auto schema = schemas.at(0);
         auto path = schema->path(0);
         ASSERT_STREQ(path_template, path);
     } catch (const std::exception& e) {

--- a/swig/swig_base/cpp_classes.i
+++ b/swig/swig_base/cpp_classes.i
@@ -416,6 +416,29 @@
 
 %shared_ptr(Error);
 
+%template(vectorData_Node) std::vector<std::shared_ptr<Data_Node>, std::allocator<std::shared_ptr <Data_Node> > >;
+%template(vectorSchema_Node) std::vector<std::shared_ptr<Schema_Node>, std::allocator<std::shared_ptr <Schema_Node> > >;
+%template(vector_String) std::vector<std::string, std::allocator<std::string> >;
+%template(vectorModules) std::vector<std::shared_ptr<Module>, std::allocator<std::shared_ptr<Module> > >;
+%template(vectorType) std::vector<std::shared_ptr<Type>, std::allocator<std::shared_ptr<Type> > >;
+%template(vectorExt_Instance) std::vector<std::shared_ptr<Ext_Instance>, std::allocator<std::shared_ptr<Ext_Instance> > >;
+%template(vectorIffeature) std::vector<std::shared_ptr<Iffeature>, std::allocator<std::shared_ptr<Iffeature> > >;
+%template(vectorFeature) std::vector<std::shared_ptr<Feature>, std::allocator<std::shared_ptr<Feature> > >;
+%template(vectorWhen) std::vector<std::shared_ptr<When>, std::allocator<std::shared_ptr<When> > >;
+%template(vectorRefine) std::vector<std::shared_ptr<Refine>, std::allocator<std::shared_ptr<Refine> > >;
+%template(vectorXml_Elem) std::vector<std::shared_ptr<Xml_Elem>, std::allocator<std::shared_ptr<Xml_Elem> > >;
+%template(vectorDeviate) std::vector<std::shared_ptr<Deviate>, std::allocator<std::shared_ptr<Deviate> > >;
+%template(vectorDeviation) std::vector<std::shared_ptr<Deviation>, std::allocator<std::shared_ptr<Deviation> > >;
+%template(vectorIdent) std::vector<std::shared_ptr<Ident>, std::allocator<std::shared_ptr<Ident> > >;
+%template(vectorRestr) std::vector<std::shared_ptr<Restr>, std::allocator<std::shared_ptr<Restr> > >;
+%template(vectorTpdf) std::vector<std::shared_ptr<Tpdf>, std::allocator<std::shared_ptr<Tpdf> > >;
+%template(vectorUnique) std::vector<std::shared_ptr<Unique>, std::allocator<std::shared_ptr<Unique> > >;
+%template(vectorSchema_Node_Leaf) std::vector<std::shared_ptr<Schema_Node_Leaf>, std::allocator<std::shared_ptr<Schema_Node_Leaf> > >;
+%template(vectorSchema_Node_Augment) std::vector<std::shared_ptr<Schema_Node_Augment>, std::allocator<std::shared_ptr<Schema_Node_Augment> > >;
+%template(vectorType_Bit) std::vector<std::shared_ptr<Type_Bit>, std::allocator<std::shared_ptr<Type_Bit> > >;
+%template(vectorType_Enum) std::vector<std::shared_ptr<Type_Enum>, std::allocator<std::shared_ptr<Type_Enum> > >;
+%template(vectorError) std::vector<std::shared_ptr<Error>, std::allocator<std::shared_ptr<Error> > >;
+
 %{
 /* Includes the header in the wrapper code */
 #include "Xml.hpp"
@@ -431,26 +454,3 @@
 %include "Libyang.hpp"
 %include "Tree_Data.hpp"
 %include "Tree_Schema.hpp"
-
-%template(vector_String) std::vector<std::string>;
-%template(vectorModules) std::vector<S_Module>;
-%template(vectorType) std::vector<S_Type>;
-%template(vectorData_Node) std::vector<S_Data_Node>;
-%template(vectorSchema_Node) std::vector<S_Schema_Node>;
-%template(vectorExt_Instance) std::vector<S_Ext_Instance>;
-%template(vectorIffeature) std::vector<S_Iffeature>;
-%template(vectorFeature) std::vector<S_Feature>;
-%template(vectorWhen) std::vector<S_When>;
-%template(vectorRefine) std::vector<S_Refine>;
-%template(vectorXml_Elem) std::vector<S_Xml_Elem>;
-%template(vectorDeviate) std::vector<S_Deviate>;
-%template(vectorDeviation) std::vector<S_Deviation>;
-%template(vectorIdent) std::vector<S_Ident>;
-%template(vectorRestr) std::vector<S_Restr>;
-%template(vectorTpdf) std::vector<S_Tpdf>;
-%template(vectorUnique) std::vector<S_Unique>;
-%template(vectorSchema_Node_Leaf) std::vector<S_Schema_Node_Leaf>;
-%template(vectorSchema_Node_Augment) std::vector<S_Schema_Node_Augment>;
-%template(vectorType_Bit) std::vector<S_Type_Bit>;
-%template(vectorType_Enum) std::vector<S_Type_Enum>;
-%template(vectorError) std::vector<S_Error>;


### PR DESCRIPTION
To simplify the C++ bindings, std::vector's are allocated on the stack.

C++ and Python examples are updated.

Signed-off-by: Mislav Novakovic <mislav.novakovic@sartura.hr>