### PR TITLE
JSON: fix bug on platforms where char is unsigned

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -150,7 +150,7 @@ lyjson_parse_text(struct ly_ctx *ctx, const char *data, unsigned int *len)
             }
             o += r - 1; /* o is ++ in for loop */
             (*len) += i; /* number of read characters */
-        } else if ((data[*len] >= 0 && data[*len] < 0x20) || data[*len] == 0x5c) {
+        } else if ((((signed char)data[*len]) >= 0 && data[*len] < 0x20) || data[*len] == 0x5c) {
             /* control characters must be escaped */
             LOGVAL(ctx, LYE_XML_INVAL, LY_VLOG_NONE, NULL, "control character (unescaped)");
             goto error;

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -41,7 +41,7 @@ json_print_string(struct lyout *out, const char *text)
 
     ly_write(out, "\"", 1);
     for (i = n = 0; text[i]; i++) {
-        if (text[i] >= 0 && text[i] < 0x20) {
+        if (((signed char)text[i]) >= 0 && text[i] < 0x20) {
             /* control character */
             n += ly_print(out, "\\u%.4X", text[i]);
         } else {


### PR DESCRIPTION
ARM defaults to `char` having the same range as a `unsigned char`, and therefore comparisons for `>= 0` are always true, and the compiler correctly warns against them.

By first converting the data type to a signed char, we ensure that the code behaves in the same way as if the `char` was already a signed type. That's apparently the developers' intention here, and that's how x86 operates.

fixes #580