### PR TITLE
JSON: Improve readability of ASCII checks

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -150,7 +150,7 @@ lyjson_parse_text(struct ly_ctx *ctx, const char *data, unsigned int *len)
             }
             o += r - 1; /* o is ++ in for loop */
             (*len) += i; /* number of read characters */
-        } else if ((((signed char)data[*len]) >= 0 && data[*len] < 0x20) || data[*len] == 0x5c) {
+        } else if ((((signed char)data[*len]) >= 0 && data[*len] < 0x20)) {
             /* control characters must be escaped */
             LOGVAL(ctx, LYE_XML_INVAL, LY_VLOG_NONE, NULL, "control character (unescaped)");
             goto error;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -150,7 +150,8 @@ lyjson_parse_text(struct ly_ctx *ctx, const char *data, unsigned int *len)
             }
             o += r - 1; /* o is ++ in for loop */
             (*len) += i; /* number of read characters */
-        } else if ((((signed char)data[*len]) >= 0 && data[*len] < 0x20)) {
+        } else if ((unsigned char)(data[*len]) < 0x20) {
+            /* In C, char != unsigned char != signed char, so let's work with ASCII explicitly */
             /* control characters must be escaped */
             LOGVAL(ctx, LYE_XML_INVAL, LY_VLOG_NONE, NULL, "control character (unescaped)");
             goto error;

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -41,11 +41,12 @@ json_print_string(struct lyout *out, const char *text)
 
     ly_write(out, "\"", 1);
     for (i = n = 0; text[i]; i++) {
-        if (((signed char)text[i]) >= 0 && text[i] < 0x20) {
+        const unsigned char ascii = text[i];
+        if (ascii < 0x20) {
             /* control character */
-            n += ly_print(out, "\\u%.4X", text[i]);
+            n += ly_print(out, "\\u%.4X", ascii);
         } else {
-            switch (text[i]) {
+            switch (ascii) {
             case '"':
                 n += ly_print(out, "\\\"");
                 break;


### PR DESCRIPTION
- JSON: remove redundant test. We've already checked for backslash in the branch above, so there's no need to check for 0x5c again here.

- JSON: more readable fix of char/signed char/unsigned char
    
@michalvasko  correctly suggested that a mere cast is not terribly readable. This patch ensures that all comparisons are done on unsigned chars which match one's understanding of ASCII codes. Now that everything is positive, the condition can be simplified to check just for values `< 0x20`.

I am not introducing the `const unsigned char ascii` into `parser_json.c` because that code can consume more than one character in one loop iteration. If there was another variable, then one would have to be extra careful not to skip over its re-assignment after bumping the index.

refs #580