### PR TITLE
Fix lyb bit-handling bugs

### DIFF
--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -382,11 +382,10 @@ lyb_parse_val_1(struct ly_ctx *ctx, struct lys_type *type, LY_DATA_TYPE value_ty
         for (i = 0; i < type->info.bits.count; ++i) {
             if (i % 8 == 0) {
                 /* read another byte */
-                ret += (r = lyb_read(data, &byte, sizeof byte, lybs));
+                ret += (r = lyb_read(data + ret, &byte, sizeof byte, lybs));
                 if (r < 0) {
                     return -1;
                 }
-                data += r;
             }
 
             if (byte & (0x01 << (i % 8))) {

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -386,6 +386,7 @@ lyb_parse_val_1(struct ly_ctx *ctx, struct lys_type *type, LY_DATA_TYPE value_ty
                 if (r < 0) {
                     return -1;
                 }
+                data += r;
             }
 
             if (byte & (0x01 << (i % 8))) {

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -769,9 +769,8 @@ lyb_print_value(const struct lys_type *type, const char *value_str, lyd_val valu
             /* will be a full byte */
             for (byte = 0, i = 0; i < 8; ++i) {
                 if (value.bit[bits_i + i]) {
-                    byte |= 0x80;
+                    byte |= (1 << i);
                 }
-                byte >>= 1;
             }
             ret += lyb_write(out, &byte, sizeof byte, lybs);
             bits_i += 8;
@@ -781,11 +780,9 @@ lyb_print_value(const struct lys_type *type, const char *value_str, lyd_val valu
         if (type->info.bits.count % 8) {
             for (byte = 0, i = 0; i < type->info.bits.count % 8; ++i) {
                 if (value.bit[bits_i + i]) {
-                    byte |= 0x80;
+                    byte |= (1 << i);
                 }
-                byte >>= 1;
             }
-            byte >>= 8 - (i + 1);
             ret += lyb_write(out, &byte, sizeof byte, lybs);
         }
         break;

--- a/tests/data/files/types.xml
+++ b/tests/data/files/types.xml
@@ -1,7 +1,7 @@
 <types xmlns="urn:ty">
     <bin>TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ=</bin>
 
-    <bits>CF</bits>
+    <bits>position-0 position-5</bits>
 
     <boolean-true>true</boolean-true>
 

--- a/tests/data/files/types.yang
+++ b/tests/data/files/types.yang
@@ -18,12 +18,56 @@ module types {
 
     leaf bits {
       type bits {
-        bit CF {
+        bit position-0 {
           position 0;
         }
-
-        bit OF {
+        bit position-1 {
           position 1;
+        }
+        bit position-2 {
+          position 2;
+        }
+        bit position-3 {
+          position 3;
+        }
+        bit position-4 {
+          position 4;
+        }
+        bit position-5 {
+          position 5;
+        }
+        bit position-6 {
+          position 6;
+        }
+        bit position-7 {
+          position 7;
+        }
+        bit position-8 {
+          position 8;
+        }
+        bit position-9 {
+          position 9;
+        }
+        bit position-10 {
+          position 10;
+        }
+        bit position-11 {
+          position 11;
+        }
+        bit position-12 {
+          position 12;
+        }
+        bit position-13 {
+          position 13;
+        }
+        bit position-14 {
+          position 14;
+        }
+        bit position-15 {
+          position 15;
+        }
+        bit position-16 {
+          position 16;
         }
       }
     }


### PR DESCRIPTION
This commit fixes a couple of problems with the handling of the `bit` type for the `lyb` file format. Both bugs were only exposed when there were more than 8 values defined for the bit type.

The first bug was an off-by-one error. If the user attempted to set the value at position 0, no values would be set. If the user attempted to set the value at position 1, position 0 would be erroneously set instead, and so forth. I fixed this by correcting the bit shifts in `lyb_print_value()`.

The second bug was due to the fact that `lyb_parse_val_1()` continued to read the encoded data byte for positions 0 through 7 for all subsequent positions. Thus if the user had set the value at position 0, it would appear that the values at position 8, position 16, and so forth were also set. I fixed this by taking an offset into account when reading from the encoded data in the loop.

This commit also contains a test modification to verify the fixes. Without the source code patches, a set of `position-0 position-5` will result in a data tree with `position-0` not set at all, with `position-4` set instead of `position-5`, and `position-4` erroneously mirrored into `position-12`.