### PR TITLE
Module filepath on BSD

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -884,8 +884,11 @@ ly_ctx_load_localfile(struct ly_ctx *ctx, struct lys_module *module, const char 
 
     if (!result->filepath) {
         char rpath[PATH_MAX];
-        if (realpath(filepath, rpath) != NULL)
+        if (realpath(filepath, rpath) != NULL) {
             result->filepath = lydict_insert(ctx, rpath, 0);
+        } else {
+            result->filepath = lydict_insert(ctx, filepath, 0);
+        }
     }
 
     /* success */

--- a/src/context.c
+++ b/src/context.c
@@ -882,6 +882,12 @@ ly_ctx_load_localfile(struct ly_ctx *ctx, struct lys_module *module, const char 
         }
     }
 
+    if (!result->filepath) {
+        char rpath[PATH_MAX];
+        if (realpath(filepath, rpath) != NULL)
+            result->filepath = lydict_insert(ctx, rpath, 0);
+    }
+
     /* success */
 cleanup:
     free(filepath);

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1130,7 +1130,12 @@ lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format)
 
     if (!ret->filepath) {
         /* store URI */
-        ((struct lys_module *)ret)->filepath = lydict_insert(ctx, path, 0);
+        char rpath[PATH_MAX];
+        if (realpath(path, rpath) != NULL) {
+            ((struct lys_module *)ret)->filepath = lydict_insert(ctx, rpath, 0);
+        } else {
+            ((struct lys_module *)ret)->filepath = lydict_insert(ctx, path, 0);
+        }
     }
 
     return ret;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8.12)
 # Correct RPATH usage on OS X
 set(CMAKE_MACOSX_RPATH TRUE)
 
+# Set TESTS_DIR to realpath
+get_filename_component(TESTS_DIR "${CMAKE_SOURCE_DIR}/tests" REALPATH)
+
 set(api_tests test_libyang test_tree_schema test_xml test_dict test_tree_data test_tree_data_dup test_tree_data_merge test_xpath test_xpath_1.1 test_diff test_hash_table)
 set(data_tests test_data_initialization test_leafref_remove test_instid_remove test_keys test_autodel test_when test_when_1.1 test_must_1.1 test_defaults test_emptycont test_unique test_mandatory test_json test_parse_print test_values test_metadata test_yangtypes_xpath test_yang_data test_state_lists test_unknown_element test_lyb)
 set(schema_yin_tests test_print_transform)

--- a/tests/config.h.in
+++ b/tests/config.h.in
@@ -16,7 +16,7 @@
 
 #define UNUSED(x) @COMPILER_UNUSED_ATTR@
 
-#define TESTS_DIR "@CMAKE_SOURCE_DIR@/tests"
+#define TESTS_DIR "@TESTS_DIR@"
 #define BUILD_DIR "@PROJECT_BINARY_DIR@"
 
 #ifdef LY_ENABLED_CACHE


### PR DESCRIPTION
To record filename module was loaded from, libyang uses OS-dependent methods
to recover filename from open file descriptor. As these methods are defined for Linux
and Apple builds only, file path on BSD systems is either not recorded at all (when 
lys_parse_fd called from context.c) or recorded as relative path (when called from 
tree_schema.c). 
This patch is an attempt to implement OS-independent way of recording absolute
path name of module file if os-dependent methods failed or were unavailable.

PS: CMakeList and tests.h patches required to cover the case when build working
directory has different realpath, f.e., you build under /home/user when /home is a symlink
to /usr/home.
