### PR TITLE
Implement callbacks in the C++ API

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -904,7 +904,7 @@ ly_ctx_load_sub_module_clb(struct ly_ctx *ctx, struct lys_module *module, const 
     struct lys_module *mod = NULL;
     char *module_data = NULL;
     LYS_INFORMAT format = LYS_IN_UNKNOWN;
-    void (*module_data_free)(void *module_data) = NULL;
+    void (*module_data_free)(void *module_data, void *user_data) = NULL;
 
     ly_errno = LY_SUCCESS;
     if (module) {
@@ -928,7 +928,7 @@ ly_ctx_load_sub_module_clb(struct ly_ctx *ctx, struct lys_module *module, const 
         }
 
         if (module_data_free) {
-            module_data_free(module_data);
+            module_data_free(module_data, ctx->imp_clb_data);
         }
     }
 

--- a/src/context.c
+++ b/src/context.c
@@ -902,7 +902,7 @@ ly_ctx_load_sub_module_clb(struct ly_ctx *ctx, struct lys_module *module, const 
                            int implement, struct unres_schema *unres)
 {
     struct lys_module *mod = NULL;
-    char *module_data = NULL;
+    const char *module_data = NULL;
     LYS_INFORMAT format = LYS_IN_UNKNOWN;
     void (*module_data_free)(void *module_data, void *user_data) = NULL;
 
@@ -928,7 +928,7 @@ ly_ctx_load_sub_module_clb(struct ly_ctx *ctx, struct lys_module *module, const 
         }
 
         if (module_data_free) {
-            module_data_free(module_data, ctx->imp_clb_data);
+            module_data_free((char *)module_data, ctx->imp_clb_data);
         }
     }
 

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -1457,8 +1457,10 @@ const struct lys_module *ly_ctx_load_module(struct ly_ctx *ctx, const char *name
  * @return Requested module data, NULL if the module is supposed to be loaded
  * using standard mechanisms (searched for in the filesystem), NULL and #ly_errno set if
  * the callback failed resulting in the module failing to load.
+ * If an @arg free_module_data callback is provided, it will be used to free the allegedly const data
+ * which were returned by this callback.
  */
-typedef char *(*ly_module_imp_clb)(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
+typedef const char *(*ly_module_imp_clb)(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
                                    void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data));
 
 /**

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -1459,7 +1459,7 @@ const struct lys_module *ly_ctx_load_module(struct ly_ctx *ctx, const char *name
  * the callback failed resulting in the module failing to load.
  */
 typedef char *(*ly_module_imp_clb)(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
-                                   void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data));
+                                   void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data));
 
 /**
  * @brief Set missing include or import module callback. It is meant to be used when the models

--- a/swig/python/yang.i
+++ b/swig/python/yang.i
@@ -68,7 +68,7 @@ private:
 };
 
 static char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
-                                   void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data)) {
+                                   void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data)) {
     Wrap_cb *ctx = (Wrap_cb *) user_data;
     (void)free_module_data;
     auto pair = ctx->ly_module_imp_clb(mod_name, mod_rev, submod_name, sub_rev, ctx->private_ctx);

--- a/swig/python/yang.i
+++ b/swig/python/yang.i
@@ -67,7 +67,7 @@ private:
     PyObject *_callback;
 };
 
-static char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
+static const char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
                                    void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data)) {
     Wrap_cb *ctx = (Wrap_cb *) user_data;
     (void)free_module_data;


### PR DESCRIPTION
## Lambdas and std::function for schema callbacks

This patch series makes it possible to use C++-style API with lambdas or `std::function` as callbacks for requesting module implementations/imports. It changes the public API (trivially), so I had to adapt libnetconf2 and Netopeer2-server.

There are three commits:

###  C++-ish way of reading module data via callbacks
    
This was not possible to do when using C++ bindings because the `ly_ctx` was private. Also, while C-style freestanding functions certainly work, this API can be used more easily I think.
    
The Python bindings already contained support for something like this. I do not know if it's possible to reimplement Python's usual semantics on top of the API introduced in this patch.

### Change constness of the data returned by module implementation callbacks
    
libyang itself won't modify these data, so a `const char *` is a better match. That will allow returning, e.g., string literals or C++'s `std::string::c_str` without any extra deleter.
    
The cost of this patch is an extra cast which is needed when calling a deleter. If a deleter is used, then quite obviously that data cannot be const.

### Pass the original user_data to the deleter function

The callback which is used for feeding libyang with module source code accepts a generic void* for contextualization. The callback itself can, when called, specify another function which can be used for deleting the result. The function signature matches that of `free`. However, when this custom deleter is called, the user_data context is not passed.
    
This means that the first callback cannot really provide any contextualization. It could still swap a generic `free` for something else, but that "something else" again lacks any context because it can only be a free-standing function.
    
In the C++ API for this, I will need a real context even for the custom deleter, otherwise it is not possible to use basic features such as a `std::function`.
    
The Python bindings appear to ignore the custom deleter. I have no clue if that behavior is correct or if it leaks.