### PR TITLE
C++: work with no custom deleter for schema callbacks

### DIFF
--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -291,7 +291,7 @@ const char* Context::cpp_mod_missing_cb(const char *mod_name, const char *mod_re
         auto ret = cb(mod_name, mod_rev, submod_name, sub_rev);
         if (ret.data) {
             *format = ret.format;
-            *free_module_data = Context::cpp_mod_missing_deleter;
+            *free_module_data = x.second ? Context::cpp_mod_missing_deleter : nullptr;
             return ret.data;
         }
         if (ly_errno != LY_SUCCESS) {

--- a/swig/cpp/src/Libyang.cpp
+++ b/swig/cpp/src/Libyang.cpp
@@ -287,11 +287,13 @@ const char* Context::cpp_mod_missing_cb(const char *mod_name, const char *mod_re
     Context *ctx = static_cast<Context*>(user_data);
     for (const auto &x : ctx->mod_missing_cb) {
         const auto &cb = x.first;
-        ctx->mod_missing_deleter = &x.second;
         auto ret = cb(mod_name, mod_rev, submod_name, sub_rev);
         if (ret.data) {
             *format = ret.format;
-            *free_module_data = x.second ? Context::cpp_mod_missing_deleter : nullptr;
+            if (x.second) {
+                ctx->mod_missing_deleter.push_back(&x.second);
+                *free_module_data = Context::cpp_mod_missing_deleter;
+            }
             return ret.data;
         }
         if (ly_errno != LY_SUCCESS) {
@@ -305,8 +307,8 @@ const char* Context::cpp_mod_missing_cb(const char *mod_name, const char *mod_re
 void Context::cpp_mod_missing_deleter(void *data, void *user_data)
 {
     Context *ctx = static_cast<Context*>(user_data);
-    (*ctx->mod_missing_deleter)(data);
-    ctx->mod_missing_deleter = nullptr;
+    (*ctx->mod_missing_deleter.back())(data);
+    ctx->mod_missing_deleter.pop_back();
 }
 
 

--- a/swig/cpp/src/Libyang.hpp
+++ b/swig/cpp/src/Libyang.hpp
@@ -137,7 +137,7 @@ public:
     friend Error;
 
     std::vector<std::pair<mod_missing_cb_t, mod_missing_deleter_t>> mod_missing_cb;
-    const mod_missing_deleter_t *mod_missing_deleter;
+    std::vector<const mod_missing_deleter_t *> mod_missing_deleter;
     static const char* cpp_mod_missing_cb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev, void *user_data, LYS_INFORMAT *format, void(**free_module_data)(void *model_data, void *user_data));
     static void cpp_mod_missing_deleter(void *data, void *user_data);
 

--- a/swig/cpp/tests/test_libyang.cpp
+++ b/swig/cpp/tests/test_libyang.cpp
@@ -438,10 +438,11 @@ TEST(test_ly_set)
 TEST(test_module_impl_callback)
 {
     std::string mod_a{"module a {namespace urn:a; prefix a; import b { prefix b; } import c { prefix c; } import d { prefix d; } leaf a { type b:mytype; } leaf a1 { type c:mytype; } }"};
-    std::string mod_b{"module b {namespace urn:b; prefix b; typedef mytype { type string; }}"};
+    std::string mod_b{"module b {namespace urn:b; prefix b; import b_1 { prefix b_1; } typedef mytype { type string; }}"};
+    std::string mod_b_1{"module b_1 {namespace urn:b_1; prefix b_1; typedef mytype { type string; }}"};
     std::string mod_c{"module c {namespace urn:c; prefix c; typedef mytype { type string; }}"};
     std::string mod_d{"module d {namespace urn:d; prefix d; typedef mytype { type string; }}"};
-    int b_allocated = 0, b_freed = 0, c_allocated = 0, c_freed = 0, d_allocated = 0;
+    int b_allocated = 0, b_freed = 0, b_1_allocated = 0, b_1_freed = 0, c_allocated = 0, c_freed = 0, d_allocated = 0;
     auto mod_b_cb = [mod_b, &b_allocated](const char *mod_name, const char *, const char *, const char *) -> libyang::Context::mod_missing_cb_return {
         if (mod_name == std::string("b")) {
             ASSERT_EQ(0, b_allocated);
@@ -453,6 +454,19 @@ TEST(test_module_impl_callback)
     auto mod_b_free = [&b_allocated, &b_freed](void *data) {
         ASSERT_EQ(1, b_allocated);
         ++b_freed;
+        free(data);
+    };
+    auto mod_b_1_cb = [mod_b_1, &b_1_allocated](const char *mod_name, const char *, const char *, const char *) -> libyang::Context::mod_missing_cb_return {
+        if (mod_name == std::string("b_1")) {
+            ASSERT_EQ(0, b_1_allocated);
+            ++b_1_allocated;
+            return {LYS_IN_YANG, strdup(mod_b_1.c_str())};
+        }
+        return {LYS_IN_UNKNOWN, nullptr};
+    };
+    auto mod_b_1_free = [&b_1_allocated, &b_1_freed](void *data) {
+        ASSERT_EQ(1, b_1_allocated);
+        ++b_1_freed;
         free(data);
     };
     auto mod_c_cb = [mod_c, &c_allocated](const char *mod_name, const char *, const char *, const char *) -> libyang::Context::mod_missing_cb_return {
@@ -481,11 +495,14 @@ TEST(test_module_impl_callback)
 
     auto ctx = std::make_shared<libyang::Context>();
     ctx->add_missing_module_callback(mod_b_cb, mod_b_free);
+    ctx->add_missing_module_callback(mod_b_1_cb, mod_b_1_free);
     ctx->add_missing_module_callback(mod_c_cb, mod_c_free);
     ctx->add_missing_module_callback(mod_d_cb);
     ctx->parse_module_mem(mod_a.c_str(), LYS_IN_YANG);
     ASSERT_EQ(1, b_allocated);
     ASSERT_EQ(1, b_freed);
+    ASSERT_EQ(1, b_1_allocated);
+    ASSERT_EQ(1, b_1_freed);
     ASSERT_EQ(1, c_allocated);
     ASSERT_EQ(1, c_freed);
     ASSERT_EQ(1, d_allocated);


### PR DESCRIPTION
Because it is an error to call an empty `std::function`, make sure that we handle that situation without throwing a `std::bad_function_call`. This is all in order to make the deleter truly optional.

This is a followup fix for https://github.com/CESNET/libyang/pull/602; the test suite was not checking that use case.