### PR TITLE
Fix misaligned when pointer in uses/choice/case

### DIFF
--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1357,6 +1357,10 @@ struct lys_node_choice {
 
     void *priv;                      /**< private caller's data, not used by libyang */
 
+#ifdef LY_ENABLED_CACHE
+    uint8_t hash[LYS_NODE_HASH_COUNT]; /**< schema hash required for LYB printer/parser */
+#endif
+
     /* specific choice's data */
     struct lys_when *when;           /**< when statement (optional) */
     struct lys_node *dflt;           /**< default case of the choice (optional) */
@@ -1618,6 +1622,10 @@ struct lys_node_uses {
 
     void *priv;                      /**< private caller's data, not used by libyang */
 
+#ifdef LY_ENABLED_CACHE
+    uint8_t hash[LYS_NODE_HASH_COUNT]; /**< schema hash required for LYB printer/parser */
+#endif
+
     /* specific uses's data */
     struct lys_when *when;           /**< when statement (optional) */
     struct lys_refine *refine;       /**< array of refine changes to the referred grouping */
@@ -1700,6 +1708,10 @@ struct lys_node_case {
                                           node in the list. */
 
     void *priv;                      /**< private caller's data, not used by libyang */
+
+#ifdef LY_ENABLED_CACHE
+    uint8_t hash[LYS_NODE_HASH_COUNT]; /**< schema hash required for LYB printer/parser */
+#endif
 
     /* specific case's data */
     struct lys_when *when;           /**< when statement (optional) */


### PR DESCRIPTION
Fixes https://github.com/sysrepo/sysrepo/issues/1272.

The root cause of https://github.com/sysrepo/sysrepo/issues/1272 is that `resolve_applies_when()` erroneously returns true for the ietf-snmp leaf "use-prefix". `resolve_applies_when()` incorrectly evaluates the parent container "tsm" to have a when-condition.

The node type for the "tsm" container is `LYS_CONTAINER`. `resolve_applies_when()` casts the schema node to `struct lys_node_uses *`, but this struct has a different offset for the `when` pointer than `lys_node_container`. When the lyb file format was implemented, a 4-byte hash was added to `lys_node_container` prior to its when pointer, but a corresponding 4-byte value was not added to `lys_node_uses`. Thus the `when` pointer in the two structures is now at a different offset. When `resolve_applies_when()` reads what it thinks is the `when` pointer on the container node, it is actually reading part of the hash array, which happens to be non-zero, and so the method thinks there is a when condition present.

I fixed this by adding the 4-byte hash array to `lys_node_uses`, `lys_node_choice`, and `lys_node_case`, just above the `when` pointer.