### PR TITLE
Fix JSON printer issue when called with non-first list entry

### DIFF
--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -356,6 +356,10 @@ json_print_leaf_list(struct lyout *out, int level, const struct lyd_node *node, 
                 flag_attrs = 1;
             }
         }
+        if (toplevel && !(options & LYP_WITHSIBLINGS)) {
+            /* if initially called without LYP_WITHSIBLINGS do not print other list entries */
+            break;
+        }
         for (list = list->next; list && list->schema != node->schema; list = list->next);
         if (list) {
             ly_print(out, ",%s", (level ? "\n" : ""));
@@ -533,8 +537,8 @@ json_print_nodes(struct lyout *out, int level, const struct lyd_node *root, int 
             break;
         case LYS_LEAFLIST:
         case LYS_LIST:
-            /* is it already printed? */
-            for (iter = node->prev; iter->next; iter = iter->prev) {
+            /* is it already printed? (root node is not) */
+            for (iter = node->prev; iter->next && node != root; iter = iter->prev) {
                 if (iter == node) {
                     continue;
                 }
@@ -543,7 +547,7 @@ json_print_nodes(struct lyout *out, int level, const struct lyd_node *root, int 
                     break;
                 }
             }
-            if (!iter->next) {
+            if (!iter->next || node == root) {
                 if (comma_flag) {
                     /* print the previous comma */
                     ly_print(out, ",%s", (level ? "\n" : ""));


### PR DESCRIPTION
When lyd_print called to print non-first list entry in JSON format, it incorrectly assumes
that this entry was already printed. 
Following program illustrates this problem:

```c
#include <libyang/libyang.h>

int
main()
{
	struct ly_ctx *ctx = ly_ctx_new(NULL, 0);
	struct lyd_node *node = ly_ctx_info(ctx);
	struct ly_set *set;

	lyd_print_file(stdout, node, LYD_JSON, LYP_WITHSIBLINGS|LYP_FORMAT);

	set = lyd_find_path(node, "/ietf-yang-library:yang-library/module-set/import-only-module[name='ietf-inet-types']");
//	set = lyd_find_path(node, "/ietf-yang-library:yang-library/module-set/module[name='yang']");
	if (set && set->number) {
		printf("================== JSON FORMAT ========================\n");
		lyd_print_file(stdout, set->set.d[0], LYD_JSON, LYP_FORMAT);
		printf("================== XML  FORMAT ========================\n");
		lyd_print_file(stdout, set->set.d[0], LYD_XML,  LYP_FORMAT);
		printf("================== END  OUTPUT ========================\n");
	};
	return 0;
};
```

and the JSON output is unexpectedly empty:

```
[....]
================== JSON FORMAT ========================
{

}
================== XML  FORMAT ========================
<import-only-module xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-library">
  <name>ietf-inet-types</name>
  <revision>2013-07-15</revision>
  <namespace>urn:ietf:params:xml:ns:yang:ietf-inet-types</namespace>
</import-only-module>
================== END  OUTPUT ========================
```
