### PR TITLE
Libyang shall use standard fileno(3) instead of unportable _fileno.

### DIFF
--- a/swig/cpp/tests/test_tree_data.cpp
+++ b/swig/cpp/tests/test_tree_data.cpp
@@ -166,7 +166,7 @@ TEST(test_ly_ctx_parse_data_fd)
         ctx->parse_module_path(yin_file, LYS_IN_YIN);
 
         FILE *f = fopen(config_file, "r");
-        auto fd = f->_fileno;
+        auto fd = fileno(f);
         auto root = ctx->parse_data_fd(fd, LYD_XML, LYD_OPT_NOSIBLINGS | LYD_OPT_STRICT);
         ASSERT_NOTNULL(root);
         ASSERT_STREQ("x", root->schema()->name());

--- a/swig/cpp/tests/test_tree_schema.cpp
+++ b/swig/cpp/tests/test_tree_schema.cpp
@@ -332,13 +332,13 @@ TEST(test_ly_ctx_parse_module_fd)
         ASSERT_NOTNULL(ctx);
 
         FILE *f = fopen(yin_file, "r");
-        auto fd = f->_fileno;
+        auto fd = fileno(f);
         auto module = ctx->parse_module_fd(fd, LYS_IN_YIN);
         ASSERT_NOTNULL(module);
         ASSERT_STREQ("a", module->name());
         fclose(f);
         f = fopen(yang_file, "r");
-        fd = f->_fileno;
+        fd = fileno(f);
         module = ctx->parse_module_fd(fd, LYS_IN_YANG);
         ASSERT_NOTNULL(module);
         ASSERT_STREQ("b", module->name());
@@ -359,7 +359,7 @@ TEST(test_ly_ctx_parse_module_fd_invalid)
         ASSERT_NOTNULL(ctx);
 
         FILE *f = fopen(yin_file, "r");
-        auto fd = f->_fileno;
+        auto fd = fileno(f);
         auto module = ctx->parse_module_fd(fd, LYS_IN_YANG);
         throw std::runtime_error("exception not thrown");
     } catch( const std::exception& e ) {


### PR DESCRIPTION
... else it breaks swig build on at least freebsd.