### PR TITLE
json parser BUGFIX list/leaf-list in input/output do not have to be ordered

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -518,7 +518,7 @@ repeat:
         len += skip_ws(&data[len]);
         if (data[len] == ',') {
             /* various validation checks */
-            if (lyv_data_context((struct lyd_node*)leaf, options, unres) ||
+            if (lyv_data_context((struct lyd_node*)leaf, options | LYD_OPT_TRUSTED, unres) ||
                     lyv_data_content((struct lyd_node*)leaf, options, unres) ||
                     lyv_multicases((struct lyd_node*)leaf, NULL, first_sibling, 0, NULL)) {
                 return 0;
@@ -1213,7 +1213,7 @@ attr_repeat:
 
             if (data[len] == ',') {
                 /* various validation checks */
-                if (lyv_data_context(list, options, unres) ||
+                if (lyv_data_context(list, options | LYD_OPT_TRUSTED, unres) ||
                         lyv_data_content(list, options, unres) ||
                         lyv_multicases(list, NULL, prev ? &first_sibling : NULL, 0, NULL)) {
                     goto error;


### PR DESCRIPTION
Hi,
It seems #608 is still not fixed fully, multi instances of list or leaf-list in input/output will cause an error when parsing json data tree, hope it could be fully fixed this time...