### PR TITLE
Fix big endian issues writing and reading .LYB files

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -7335,6 +7335,7 @@ lyd_lyb_data_length(const char *data)
 {
     const char *ptr;
     uint16_t i, mod_count, str_len;
+    uint8_t tmp_buf[2];
     LYB_META meta;
 
     if (!data) {
@@ -7353,13 +7354,15 @@ lyd_lyb_data_length(const char *data)
     ++ptr;
 
     /* models */
-    memcpy(&mod_count, ptr, 2);
+    memcpy(tmp_buf, ptr, 2);
     ptr += 2;
+    mod_count = tmp_buf[0] | (tmp_buf[1] << 8);
 
     for (i = 0; i < mod_count; ++i) {
         /* model name */
-        memcpy(&str_len, ptr, 2);
+        memcpy(tmp_buf, ptr, 2);
         ptr += 2;
+        str_len = tmp_buf[0] | (tmp_buf[1] << 8);
 
         ptr += str_len;
 


### PR DESCRIPTION
The print and parse routines which handle .LYB files assume a little endian
CPU. This means libyang is failing when it is compiled for a big endian
target.

For example consider the code:
 lyb_write(out, (uint8_t *)&mod_count, 2, lybs);

mod_count is an integer and on a typical 32 bit big endian target its
format in memory is (byte0(MSB) byte1 byte2 byte3(LSB)) meaning
if mod_count has a value of 1 the first three bytes of mod_count
are zero, and as the routine only write the first two bytes, it writes
out 0. This effectively corrupts the .LYB file.

This patch modifies the routines to write and read .LYB files to use
endian agnostic methods to access data in a .LYB file.