### PR TITLE
Fix double free invalid "bits" leaf values

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1245,7 +1245,8 @@ lyp_parse_value(struct lys_type *type, const char **value_, struct lyxml_elem *x
 
     /* fully clear the value */
     if (store) {
-        lyd_free_value(*val, *val_type, *val_flags, type);
+        if (type->base != LY_TYPE_BITS)
+            lyd_free_value(*val, *val_type, *val_flags, type);
         *val_flags &= ~LY_VALUE_UNRES;
     }
 
@@ -1334,6 +1335,7 @@ lyp_parse_value(struct lys_type *type, const char **value_, struct lyxml_elem *x
         if (!value) {
             /* no bits set */
             if (store) {
+                lyd_free_value(*val, *val_type, *val_flags, type);
                 /* store empty array */
                 val->bit = bits;
                 *val_type = LY_TYPE_BITS;
@@ -1414,6 +1416,7 @@ lyp_parse_value(struct lys_type *type, const char **value_, struct lyxml_elem *x
         make_canonical(ctx, LY_TYPE_BITS, value_, bits, &type->info.bits.count);
 
         if (store) {
+            lyd_free_value(*val, *val_type, *val_flags, type);
             /* store the result */
             val->bit = bits;
             *val_type = LY_TYPE_BITS;


### PR DESCRIPTION
When setting an invalid value to a "bits" leaf, we end up with a corrupted data tree. This randomly causes segfaults. I wrote a simple program to reproduce the problem:

```c
/* example.c */
#include <libyang/libyang.h>

static const char *yang =
	"module example {"
	"  namespace 'urn:example';"
	"  prefix 'ex';"
	"  container listen {"
	"    leaf protos {"
	"      type bits {"
	"        bit tcp;"
	"        bit udp;"
	"        bit tcp6;"
	"        bit udp6;"
	"      }"
	"      default 'tcp';"
	"    }"
	"  }"
	"}";

void main(void) {
	struct ly_ctx *ctx;
	const struct lys_module *module;
	struct lyd_node *listen;
	struct lyd_node_leaf_list *protos;

	ctx = ly_ctx_new(NULL, 0);
	module = lys_parse_mem(ctx, yang, LYS_IN_YANG);
	listen = lyd_new(NULL, module, "listen");
	protos = (struct lyd_node_leaf_list *)
		lyd_new_leaf(listen, module, "protos", "tcp6");

	lyd_change_leaf(protos, "invalid");
	lyd_validate(&listen, LYD_OPT_STRICT | LYD_OPT_CONFIG, ctx);

	lyd_free_withsiblings(listen);
	ly_ctx_destroy(ctx, NULL);
}
```

```
root@ubuntu1604:~# gcc -o example example.c -lyang
root@ubuntu1604:~# ./example 
libyang[0]: Invalid value "invalid" in "protos" element. (path: /example:listen/protos)
*** Error in `./example': double free or corruption (fasttop): 0x0000000001f02a30 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7ff63d7f37e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7ff63d7fc37a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7ff63d80053c]
/usr/lib/x86_64-linux-gnu/libyang.so.0.16(lyd_free_value+0xb1)[0x7ff63dc01f99]
/usr/lib/x86_64-linux-gnu/libyang.so.0.16(+0xbc17a)[0x7ff63dc0217a]
/usr/lib/x86_64-linux-gnu/libyang.so.0.16(+0xbc039)[0x7ff63dc02039]
/usr/lib/x86_64-linux-gnu/libyang.so.0.16(lyd_free+0x1d)[0x7ff63dc021f0]
/usr/lib/x86_64-linux-gnu/libyang.so.0.16(lyd_free_withsiblings+0x64)[0x7ff63dc02257]
./example[0x4009e9]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf0)[0x7ff63d79c830]
./example[0x400869]
...
Aborted (core dumped)
root@ubuntu1604:~# 
```