### PR TITLE
unittest crash fixes for test_yang_data

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -5038,9 +5038,10 @@ resolve_extension(struct unres_ext *info, struct lys_ext_instance **ext, struct 
             /* nothing change */
             break;
         case LYEXT_COMPLEX:
-            tmp_ext = realloc(*ext, sizeof **ext + ((struct lyext_plugin_complex*)e->plugin)->instance_size);
+            tmp_ext = realloc(*ext, ((struct lyext_plugin_complex*)e->plugin)->instance_size);
             LY_CHECK_ERR_GOTO(!tmp_ext, LOGMEM(ctx), error);
-            memset((char *)tmp_ext + sizeof **ext, 0, ((struct lyext_plugin_complex*)e->plugin)->instance_size - sizeof **ext);
+            memset((char *)tmp_ext + offsetof(struct lys_ext_instance_complex, content), 0,
+                   ((struct lyext_plugin_complex*)e->plugin)->instance_size - offsetof(struct lys_ext_instance_complex, content));
             (*ext) = tmp_ext;
             ((struct lys_ext_instance_complex*)(*ext))->substmt = ((struct lyext_plugin_complex*)e->plugin)->substmt;
             if (info->data.yang) {

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -5038,7 +5038,7 @@ resolve_extension(struct unres_ext *info, struct lys_ext_instance **ext, struct 
             /* nothing change */
             break;
         case LYEXT_COMPLEX:
-            tmp_ext = realloc(*ext, ((struct lyext_plugin_complex*)e->plugin)->instance_size);
+            tmp_ext = realloc(*ext, sizeof **ext + ((struct lyext_plugin_complex*)e->plugin)->instance_size);
             LY_CHECK_ERR_GOTO(!tmp_ext, LOGMEM(ctx), error);
             memset((char *)tmp_ext + sizeof **ext, 0, ((struct lyext_plugin_complex*)e->plugin)->instance_size - sizeof **ext);
             (*ext) = tmp_ext;

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -108,6 +108,8 @@ check:
             /* unresolved augment, let's say it's enabled */
             return NULL;
         }
+    } else if (node->nodetype == LYS_EXT) {
+        return NULL;
     } else if (node->parent) {
         node = node->parent;
     } else {


### PR DESCRIPTION
These should fix the crash seen on Debian big-endian builds (#679)

(The realloc() does not cause the crash, I just found it while looking for the crash)