### PR TITLE
Update resolve.c

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -7614,6 +7614,7 @@ check_instid_ext_dep(const struct lys_node *sleaf, const char *json_instid)
     const struct lys_node *op_node, *first_node;
     enum int_log_opts prev_ilo;
     char *buf;
+    char *tempBuf = NULL;
     int ret = 0;
 
     if (!json_instid || !json_instid[0]) {
@@ -7631,7 +7632,10 @@ check_instid_ext_dep(const struct lys_node *sleaf, const char *json_instid)
     }
 
     /* get the first node from the instid */
-    buf = strndup(json_instid, strchr(json_instid + 1, '/') - json_instid);
+    tempBuf = strchr(json_instid + 1, '/');
+    if (!tempBuf)
+      return 0;
+    buf = strndup(json_instid, tempBuf - json_instid);
     if (!buf) {
         /* so that we do not have to bother with logging, say it is not external */
         return 0;

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -7613,8 +7613,7 @@ check_instid_ext_dep(const struct lys_node *sleaf, const char *json_instid)
 {
     const struct lys_node *op_node, *first_node;
     enum int_log_opts prev_ilo;
-    char *buf;
-    char *tempBuf = NULL;
+    char *buf, *tmp;
     int ret = 0;
 
     if (!json_instid || !json_instid[0]) {
@@ -7632,10 +7631,11 @@ check_instid_ext_dep(const struct lys_node *sleaf, const char *json_instid)
     }
 
     /* get the first node from the instid */
-    tempBuf = strchr(json_instid + 1, '/');
-    if (!tempBuf)
-      return 0;
-    buf = strndup(json_instid, tempBuf - json_instid);
+    tmp = strchr(json_instid + 1, '/');
+    if (!tmp) {
+        return 0;
+    }
+    buf = strndup(json_instid, tmp - json_instid);
     if (!buf) {
         /* so that we do not have to bother with logging, say it is not external */
         return 0;


### PR DESCRIPTION
when strchr returns 0, above code might crash, so added a safety code check when strchr returns 0. I am getting crash in case of invalid identityref. 