### PR TITLE
Fix for duplicating namespaces in anyxml data when making reply for get command based on filter.

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -219,8 +219,13 @@ lyxml_dup_elem(struct ly_ctx *ctx, struct lyxml_elem *elem, struct lyxml_elem *p
     /* correct namespaces */
     lyxml_correct_elem_ns(ctx, result, 1, 0);
 
+    if(elem->attr && (LYXML_ATTR_NS == elem->attr->type))
+      attr = elem->attr->next;
+    else
+      attr = elem->attr;
+
     /* duplicate attributes */
-    for (attr = elem->attr; attr; attr = attr->next) {
+    for (; attr; attr = attr->next) {
         lyxml_dup_attr(ctx, result, attr);
     }
 


### PR DESCRIPTION
Hi, I am working on get command when filters are applied on different YANG model. I found an issue when having following model.

**child.yang**
```
module child {
namespace "urn:test:params:xml:ns:yang:child";
prefix child;

container a {
     leaf b {
         type uint32;
     }
     leaf c {
         type string;
     }
  }
}
```

**parent.yang**
```
module parent {
namespace "urn:test:params:xml:ns:yang:parent";
prefix parent;

  list x {
      key "y";
      leaf y {
         type uint32;
      }
      anyxml z;
   }
}
```

Now, when I try to retrieve above model data using get filters, the previous code inserts duplicating namespaces in "z" node in the rpc-reply for anyxml data. The duplicate namespace is making the client (like netconf-console or MG-SOFT NETCONF GUI) fail to display the data received for the queried command. I am getting the following output for below filter query:

**rpc-query:**
```
<?xml version="1.0" encoding="utf-8"?>
<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="10">
  <get>
    <filter type="subtree">
      <parent:x xmlns:parent="urn:test:params:xml:ns:yang:parent">
        <parent:y>4</parent:y>
      </parent:x>
    </filter>
  </get>
</rpc>
```

The corresponding rpc-reply is:
```
<rpc-reply
    xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="10">
    <data
        xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
        <x
            xmlns="urn:test:params:xml:ns:yang:parent">
            <y>4</y>
            <z>
                <a
                    xmlns="urn:test:params:xml:ns:yang:parent"
                    xmlns="urn:test:params:xml:ns:yang:parent">
                    <b>65</b>
                    <c>NNTMRT0XYZ12</c>
                </a>
            </z>
        </x>
    </data>
</rpc-reply>
```

The code-changes done is fix for the above issue which I have done in my code and is working.