### PR TITLE
Add basic tests to fuzz the libyang xml and YANG/YIN parsers with AFL.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ option(ENABLE_CALLGRIND_TESTS "Build performance tests to be run with callgrind"
 option(ENABLE_CACHE "Enable data caching for schemas and hash tables for data (time-efficient at the cost of increased space-complexity)" ON)
 option(ENABLE_LATEST_REVISIONS "Enable reusing of latest revisions of schemas" ON)
 option(ENABLE_LYD_PRIV "Add a private pointer also to struct lyd_node (data node structure), just like in struct lys_node, for arbitrary user data" OFF)
+option(ENABLE_FUZZ_TARGETS "Build target programs suitable for fuzzing with AFL" OFF)
 set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libyang" CACHE STRING "Directory with libyang plugins (extensions and user types)")
 
 if(ENABLE_CACHE)
@@ -402,6 +403,10 @@ if(ENABLE_BUILD_TESTS)
         set(ENABLE_BUILD_TESTS NO)
     endif(CMOCKA_FOUND)
 endif(ENABLE_BUILD_TESTS)
+
+if(ENABLE_BUILD_FUZZ_TARGETS)
+    add_subdirectory(tests/fuzz)
+endif(ENABLE_BUILD_FUZZ_TARGETS)
 
 if(GEN_LANGUAGE_BINDINGS AND GEN_CPP_BINDINGS)
     add_subdirectory(swig)

--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ Tests can be run by the make's `test` target:
 $ make test
 ```
 
+## Fuzzing
+
+Simple fuzzing targets, fuzzing instructions and a Dockerfile that builds the fuzz targets
+and the AFL fuzzer are available in the `tests/fuzz` directory.
+
+The `tests/fuzz` directory also contains a README file that describes the whole process in more detail.
+
 ## Bindings
 
 We provide bindings for high-level languages using [SWIG](http://www.swig.org/)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+set(fuzz_targets yangfuzz xmlfuzz)
+
+foreach(target_name IN LISTS fuzz_targets)
+    add_executable(${target_name} ${target_name}.c)
+    target_link_libraries(${target_name} yang)
+endforeach(target_name)

--- a/tests/fuzz/Dockerfile
+++ b/tests/fuzz/Dockerfile
@@ -1,0 +1,27 @@
+FROM moflow/afl-tools
+
+MAINTAINER mislav.novakovic@sartura.hr
+
+RUN \
+    apt-get update && apt-get install -y \
+    # general tools
+    git \
+    cmake \
+    build-essential \
+    vim \
+    # libyang
+    libpcre3-dev \
+    libcmocka-dev
+
+RUN mkdir /opt/dev
+WORKDIR /opt/dev
+
+# libyang
+RUN \
+    git clone -b devel https://github.com/CESNET/libyang.git && \
+    cd libyang && mkdir build && cd build && \
+    git fetch origin pull/702/head:fuzz && git checkout fuzz && \
+    cmake -DCMAKE_C_COMPILER=afl-clang-fast -DCMAKE_BUILD_TYPE="Release" -DENABLE_BUILD_FUZZ_TARGETS=ON .. && \
+    make && \
+    make install && \
+    ldconfig

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,44 @@
+# FUZZING
+Two simple programs, xmlfuzz and yangfuzz are available in this directory and
+are designed to be used with the [AFL](http://lcamtuf.coredump.cx/afl/) fuzzer.
+
+To build the fuzz targets, the ENABLE_BUILD_FUZZ_TARGETS option has to be enabled.
+
+To add AFL instrumentation when compiling the programs, the AFL clang-fast compiler
+should be used with the following cmake option:
+
+It is reccomended to set the build type to Release, since otherwise the fuzzer will detect failed asserts as crashes.
+
+```
+$ cmake -DENABLE_BUILD_FUZZ_TARGETS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=path_to_afl/afl-clang-fast ..
+```
+
+After that the programs can be built by running make:
+```
+$ make
+```
+
+The yangfuzz and xmlfuzz executables will then be available in the root of the build directory that was used.
+
+The libyang yang and xml test files available in the `tests/data/files` subdirectory can be used as initial
+test cases for fuzzing the programs with AFL.
+
+The files that will be used as starting test cases should be copied into a single directory. Those files should then be minimized by using afl-cmin and afl-tmin.
+Also, AFL will issue a warning about a decrease of performance when working with large files, so only smaller test cases should be used.
+
+To increase the speed of fuzzing, the test cases and AFL output files should be stored on a temporary RAM disk.
+If a new fuzz target is used, AFL persistent mode should be used. More about persistent mode can be read in the official AFL documentation.
+
+When all of the above is done the fuzzing process can begin. AFL supports running multiple instances of the fuzzer, which can speed up the
+process on multi core CPUs. The first fuzz instance should be started in master mode, and the other instances in slave mode.
+The total number of instances should usually be equal to the number of cores.
+
+Below is an example of running 2 instances. The -i flag specifies the testcase input directory, and the -o file specifies the directory the fuzzer will use for output.
+```
+afl-fuzz -i minimised_testcases/ -o syncdir/ -M fuzzer1 -- libyang/build/fuzz/yangfuzz @@
+afl-fuzz -i minimised_testcases/ -o syncdir/ -S fuzzer2 -- libyang/build/fuzz/yangfuzz @@
+```
+
+# Dockerfile
+
+Since setting up the fuzz targets can be a complicated process, a Dockerfile that builds libyang with the fuzzing targets is also available in this directory, and can be used to fuzz libyang.

--- a/tests/fuzz/xmlfuzz.c
+++ b/tests/fuzz/xmlfuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lyxml_parse_path(ctx, argv[1], 0);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}

--- a/tests/fuzz/yangfuzz.c
+++ b/tests/fuzz/yangfuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lys_parse_path(ctx, argv[1], LYS_IN_YANG);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}


### PR DESCRIPTION
Hi,

I've recently been fuzzing the libyang YANG parser with the american fuzzy lop (AFL) fuzzer, and in the process i had to write test programs that were used by the fuzzer.

This PR would add the test programs i used to fuzz the parser, the required cmake changes, and some notes about fuzzing in the README.

I decided to use the value 100 in the __AFL_LOOP(100) statements after experimenting with the fuzzer on my machine, so the value could differ for other fuzzer runs, especially if the code that was fuzzed was different.
