### PR TITLE
packages: Make RPM package options same as official Debian Pkg options

### DIFF
--- a/packages/libyang.spec.in
+++ b/packages/libyang.spec.in
@@ -107,7 +107,12 @@ cd build
 %else
     %define cmake_valgrind "-DENABLE_VALGRIND_TESTS=OFF"
 %endif
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -D CMAKE_BUILD_TYPE:String="@BUILD_TYPE@" %{cmake_valgrind} %{cmake_lang_bind} %{cmake_enable_cache} ..
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+   -DCMAKE_BUILD_TYPE:String="@BUILD_TYPE@" \
+   -DENABLE_LYD_PRIV=ON \
+   -DGEN_JAVA_BINDINGS=OFF \
+   -DGEN_JAVASCRIPT_BINDINGS=OFF \
+   %{cmake_valgrind} %{cmake_lang_bind} %{cmake_enable_cache} ..
 make
 
 %check


### PR DESCRIPTION
This sets the same build options for the RPM package as they are used in the official debian package
Main change is to enable ENABLE_LYD_PRIV and disable JAVA/JAVASCRIPT bindings in the package build.
(Sidenote: The `ENABLE_LYD_PRIV` is needed in libyang for the FRR project)
Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>