### PR TITLE
c++: Virtual methods require a virtual destructor

### DIFF
--- a/swig/cpp/src/Tree_Data.cpp
+++ b/swig/cpp/src/Tree_Data.cpp
@@ -523,8 +523,9 @@ S_Value Attr::value() {
 }
 S_Attr Attr::next() LY_NEW(attr, next, Attr);
 
-Difflist::Difflist(struct lyd_difflist *diff, S_Deleter deleter) {
-    diff = diff;
+Difflist::Difflist(struct lyd_difflist *diff, S_Deleter deleter):
+    diff(diff)
+{
     deleter = std::make_shared<Deleter>(diff, deleter);
 }
 Difflist::~Difflist() {};

--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -121,7 +121,7 @@ public:
     //                                     const char *val_str);
     //struct lyd_node *lyd_new_output_leaf(struct lyd_node *parent, const struct lys_module *module, const char *name,
     //                                     void *value, LYD_ANYDATA_VALUETYPE value_type);
-    ~Data_Node();
+    virtual ~Data_Node();
     /** get schema variable from [lyd_node](@ref lyd_node)*/
     S_Schema_Node schema() LY_NEW(node, schema, Schema_Node);
     /** get validity variable from [lyd_node](@ref lyd_node)*/


### PR DESCRIPTION
This might lead to calling a wrong destructor when destroying an instance of a child class. clang fortunately warns about that:
```
warning: destructor called on non-final 'libyang::Data_Node' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
```