### PR TITLE
Remove unused members

### DIFF
--- a/swig/cpp/src/Tree_Data.cpp
+++ b/swig/cpp/src/Tree_Data.cpp
@@ -30,10 +30,9 @@ extern "C" {
 
 namespace libyang {
 
-Value::Value(lyd_val value, LY_DATA_TYPE* value_type, uint8_t value_flags, S_Deleter deleter):
+Value::Value(lyd_val value, LY_DATA_TYPE* value_type, S_Deleter deleter):
     value(value),
     type(*value_type),
-    flags(value_flags),
     deleter(deleter)
 {};
 Value::~Value() {};
@@ -475,7 +474,7 @@ Data_Node_Leaf_List::Data_Node_Leaf_List(struct lyd_node *node, S_Deleter delete
 Data_Node_Leaf_List::~Data_Node_Leaf_List() {};
 S_Value Data_Node_Leaf_List::value() {
     struct lyd_node_leaf_list *leaf = (struct lyd_node_leaf_list *) node;
-    return std::make_shared<Value>(leaf->value, &leaf->value_type, leaf->value_flags, deleter);
+    return std::make_shared<Value>(leaf->value, &leaf->value_type, deleter);
 }
 int Data_Node_Leaf_List::change_leaf(const char *val_str) {
     int ret = lyd_change_leaf((struct lyd_node_leaf_list *) node, val_str);
@@ -519,7 +518,7 @@ Attr::Attr(struct lyd_attr *attr, S_Deleter deleter):
 Attr::~Attr() {};
 S_Value Attr::value() {
     struct lyd_node_leaf_list *leaf = (struct lyd_node_leaf_list *) attr;
-    return std::make_shared<Value>(leaf->value, &leaf->value_type, leaf->value_flags, deleter);
+    return std::make_shared<Value>(leaf->value, &leaf->value_type, deleter);
 }
 S_Attr Attr::next() LY_NEW(attr, next, Attr);
 

--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -45,7 +45,7 @@ class Value
 {
 public:
     /** wrapper for struct [lyd_val](@ref lyd_val), for internal use only */
-    Value(lyd_val value, LY_DATA_TYPE* value_type, uint8_t value_flags, S_Deleter deleter);
+    Value(lyd_val value, LY_DATA_TYPE* value_type, S_Deleter deleter);
     ~Value();
     /** get binary variable from [lyd_val](@ref lyd_val)*/
     const char *binary() {return LY_TYPE_BINARY == type ? value.binary : throw "wrong type";};
@@ -86,7 +86,6 @@ public:
 private:
     lyd_val value;
     LY_DATA_TYPE type;
-    uint8_t flags;
     S_Deleter deleter;
 };
 

--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -167,10 +167,9 @@ Type_Info_Union::Type_Info_Union(lys_type_info_union *info_union, S_Deleter dele
 Type_Info_Union::~Type_Info_Union() {};
 std::vector<S_Type> Type_Info_Union::types() LY_NEW_LIST(info_union, types, count, Type);
 
-Type_Info::Type_Info(union lys_type_info info, LY_DATA_TYPE *type, uint8_t flags, S_Deleter deleter):
+Type_Info::Type_Info(union lys_type_info info, LY_DATA_TYPE *type, S_Deleter deleter):
     info(info),
     type(*type),
-    flags(flags),
     deleter(deleter)
 {};
 Type_Info::~Type_Info() {};
@@ -199,7 +198,7 @@ Type::~Type() {};
 std::vector<S_Ext_Instance> Type::ext() LY_NEW_P_LIST(type, ext, ext_size, Ext_Instance);
 S_Tpdf Type::der() {return type->der ? std::make_shared<Tpdf>(type->der, deleter) : nullptr;};
 S_Tpdf Type::parent() {return type->parent ? std::make_shared<Tpdf>(type->parent, deleter) : nullptr;};
-S_Type_Info Type::info() {return std::make_shared<Type_Info>(type->info, &type->base, type->value_flags, deleter);};
+S_Type_Info Type::info() {return std::make_shared<Type_Info>(type->info, &type->base, deleter);};
 
 Iffeature::Iffeature(struct lys_iffeature *iffeature, S_Deleter deleter):
     iffeature(iffeature),

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -405,7 +405,7 @@ class Type_Info
 {
 public:
     /** wrapper for struct [lys_type_info](@ref lys_type_info), for internal use only */
-    Type_Info(union lys_type_info info, LY_DATA_TYPE *type, uint8_t flags, S_Deleter deleter);
+    Type_Info(union lys_type_info info, LY_DATA_TYPE *type, S_Deleter deleter);
     ~Type_Info();
     /** get binary variable from [lys_type_info](@ref lys_type_info)*/
     S_Type_Info_Binary binary();
@@ -431,7 +431,6 @@ public:
 private:
     union lys_type_info info;
     LY_DATA_TYPE type;
-    uint8_t flags;
     S_Deleter deleter;
 };
 


### PR DESCRIPTION
Looking at the source, both of these flags appear to be used just internally within libyang. They are only set and never read, and therefore clang warns about their use:
```
swig/cpp/src/Tree_Data.hpp:89:13: warning: private field 'flags' is not used [-Wunused-private-field]
swig/cpp/src/Tree_Schema.hpp:434:13: warning: private field 'flags' is not used [-Wunused-private-field]
```
If they are useful for users of libyang and if they should be made available, then an accessor and presumably also some consumers of this variable should be added.