### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/src/user_types/user_inet_types.c
+++ b/src/user_types/user_inet_types.c
@@ -18,6 +18,8 @@
 #include <string.h>
 #include <errno.h>
 #include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 #include "../user_types.h"
 


### PR DESCRIPTION
Include "<sys/socket.h>" to have AF_INET6 and "<netinet/in.h>" to have
the in6_addr structure.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>