### PR TITLE
extensions BUGFIX fix link error when ENABLE_STATIC=ON

### DIFF
--- a/src/extensions.h
+++ b/src/extensions.h
@@ -35,7 +35,11 @@ extern "C" {
  * @brief Macro to store version of extension plugins API in the plugins.
  * It is matched when the plugin is being loaded by libyang.
  */
+#ifdef STATIC
+#define LYEXT_VERSION_CHECK
+#else
 #define LYEXT_VERSION_CHECK int lyext_api_version = LYEXT_API_VERSION;
+#endif
 
 /**
  * @brief Extension instance structure parent enumeration

--- a/src/user_types.h
+++ b/src/user_types.h
@@ -36,7 +36,11 @@ extern "C" {
  * @brief Macro to store version of user type plugins API in the plugins.
  * It is matched when the plugin is being loaded by libyang.
  */
+#ifdef STATIC
+#define LYTYPE_VERSION_CHECK
+#else
 #define LYTYPE_VERSION_CHECK int lytype_api_version = LYTYPE_API_VERSION;
+#endif
 
 
 /**


### PR DESCRIPTION
Fix the following error when ENABLE_STATIC is "ON".

```
[100%] Linking C executable yanglint
libmetadata.a(metadata.c.o):(.data+0xa8): multiple definition of `lyext_api_version'
libnacm.a(nacm.c.o):(.data+0x0): first defined here
libyangdata.a(yangdata.c.o):(.data+0x60): multiple definition of `lyext_api_version'
libnacm.a(nacm.c.o):(.data+0x0): first defined here
libuser_inet_types.a(user_inet_types.c.o):(.data+0x0): multiple definition of `lytype_api_version'
libuser_yang_types.a(user_yang_types.c.o):(.data+0x0): first defined here
```

Since we are linking all extensions statically in the same binary, we must not have duplicate public symbols. When building with ENABLE_STATIC dynamic plugins loading is disabled anyway, we do not need version check.