### PR TITLE
valgrind: conditional jump or move depends on uninitialized value(s)

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -7610,6 +7610,7 @@ unres_schema_dup(struct lys_module *mod, struct unres_schema *unres, void *item,
         LY_CHECK_ERR_RETURN(!iff_data, LOGMEM(mod->ctx), -1);
         iff_data->fname = lydict_insert(mod->ctx, ((struct unres_iffeat_data *)unres->str_snode[i])->fname, 0);
         iff_data->node = ((struct unres_iffeat_data *)unres->str_snode[i])->node;
+        iff_data->infeature = ((struct unres_iffeat_data *)unres->str_snode[i])->infeature;
         if (unres_schema_add_node(mod, unres, new_item, type, (struct lys_node *)iff_data) == -1) {
             LOGINT(mod->ctx);
             return -1;


### PR DESCRIPTION
Hi,

This PR addresses/fixes a Valgrind issue found in our environment 

"conditional jump or move depends on uninitialized value(s)".

(Note that the check has been applied to an older version of libyang (about 3 moths ago), therefore the line number may not match. Nevertheless, the root cause still exists in devel branch)

Additional information:

==19192== Conditional jump or move depends on uninitialised value(s)
==19192== at 0x8B18159: resolve_unres_schema_item (resolve.c:6909)
==19192== by 0x8B19188: resolve_unres_schema_types (resolve.c:7265)
==19192== by 0x8B19448: resolve_unres_schema (resolve.c:7339)
==19192== by 0x8B8364F: yang_read_module (parser_yang.c:2669)
==19192== by 0x8B8D903: lys_parse_mem_ (tree_schema.c:1044)
==19192== by 0x8B8E1AB: lys_parse_fd_ (tree_schema.c:1226)
==19192== by 0x8B8DF97: lys_parse_fd (tree_schema.c:1180)
==19192== by 0x8B8DCEE: lys_parse_path (tree_schema.c:1132)
==19192== by 0x7BC2CDC: dm_load_schema_file (data_manager.c:1109)
==19192== by 0x7BC30A8: dm_load_module_deps_r (data_manager.c:1183)
==19192== by 0x7BC2F2F: dm_load_module_ident_deps_r (data_manager.c:1145)
==19192== by 0x7BC3707: dm_load_module (data_manager.c:1270)

==19192== Uninitialised value was created by a heap allocation
==19192== at 0x4C28A2E: malloc (vg_replace_malloc.c:270)
==19192== by 0x8B19C42: unres_schema_dup (resolve.c:7528)
==19192== by 0x8B94DBC: lys_node_dup_recursion (tree_schema.c:3133)
==19192== by 0x8B965D5: lys_node_dup (tree_schema.c:3542)
==19192== by 0x8B12A91: resolve_uses (resolve.c:5141)
==19192== by 0x8B15DC9: resolve_unres_schema_uses (resolve.c:6013)
==19192== by 0x8B184EA: resolve_unres_schema_item (resolve.c:6968)
==19192== by 0x8B196C3: unres_schema_add_node (resolve.c:7435)
==19192== by 0x8B881B8: yang_check_uses (parser_yang.c:4173)
==19192== by 0x8B88B1A: yang_check_nodes (parser_yang.c:4388)
==19192== by 0x8B8701C: yang_check_container (parser_yang.c:3754)
==19192== by 0x8B887D3: yang_check_nodes (parser_yang.c:4294)

place of usage:

{{ if (iff_data->infeature) {}}
   /* store backlink into the target feature to allow reverse changes in case of changing feature status */

place of creation:

{{ /* duplicate unres_iffeature_data */}}
{{ iff_data = malloc(sizeof *iff_data);}}
{{ LY_CHECK_ERR_RETURN(!iff_data, LOGMEM(mod->ctx), -1);}}
{{ iff_data->fname = lydict_insert(mod->ctx, ((struct unres_iffeat_data *)unres->str_snode[i])->fname, 0);}}
{{ iff_data->node = ((struct unres_iffeat_data *)unres->str_snode[i])->node;}}
{{ if (unres_schema_add_node(mod, unres, new_item, type, (struct lys_node *)iff_data) == -1) {}}
    LOGINT(mod->ctx);
    return -1;
{{ }}}

Best regards,
Frank