### PR TITLE
Fix the potential dead loop in ly_ctx_new()

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -99,7 +99,10 @@ ly_ctx_new(const char *search_dir, int options)
     ly_load_plugins();
 
     /* initialize thread-specific key */
-    while ((i = pthread_key_create(&ctx->errlist_key, ly_err_free)) == EAGAIN);
+    if (pthread_key_create(&ctx->errlist_key, ly_err_free) == EAGAIN) {
+        LOGERR(NULL, LY_ESYS, "pthread_key_create() in ly_ctx_new() failed");
+        goto error;
+    }
 
     /* models list */
     ctx->models.list = calloc(16, sizeof *ctx->models.list);

--- a/src/context.c
+++ b/src/context.c
@@ -99,7 +99,7 @@ ly_ctx_new(const char *search_dir, int options)
     ly_load_plugins();
 
     /* initialize thread-specific key */
-    if (pthread_key_create(&ctx->errlist_key, ly_err_free) == EAGAIN) {
+    if (pthread_key_create(&ctx->errlist_key, ly_err_free) != 0) {
         LOGERR(NULL, LY_ESYS, "pthread_key_create() in ly_ctx_new() failed");
         goto error;
     }


### PR DESCRIPTION
As I know, there can be 1024 pthread_key_t at most in a process.
Every ly_ctx struct hold one pthread_key_t.  So, if there are more than 1024 ly_ctx structs, the statements bellow in ly_ctx_new() function will run in dead loop.

```
    /* initialize thread-specific key */
    while ((i = pthread_key_create(&ctx->errlist_key, ly_err_free)) == EAGAIN);
```




