### PR TITLE
libyang2: yin parser BUGFIX wrong condition in if statement

### DIFF
--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -3257,7 +3257,7 @@ yin_parse_extension_instance(struct yin_parser_ctx *ctx, struct yin_arg_record *
  * @return LY_ERR values.
  */
 static LY_ERR
-yin_parse_ext_instance_arg(struct yin_parser_ctx *ctx, struct yin_arg_record *attrs, const char **data, enum ly_stmt elem_type,
+yin_parse_extension_instance_arg(struct yin_parser_ctx *ctx, struct yin_arg_record *attrs, const char **data, enum ly_stmt elem_type,
                            const char **arg)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -3363,8 +3363,8 @@ yin_parse_ext_instance_arg(struct yin_parser_ctx *ctx, struct yin_arg_record *at
                         LY_EVALID);
         LY_CHECK_RET(lyxml_get_element(&ctx->xml_ctx, data, &prefix, &prefix_len, &name, &name_len));
         child = yin_match_keyword(ctx, name, name_len, prefix, prefix_len, elem_type);
-        if ((elem_type == LY_STMT_ERROR_MESSAGE && child == LY_STMT_ARG_VALUE) ||
-            (elem_type != LY_STMT_ERROR_MESSAGE && child == LY_STMT_ARG_TEXT)) {
+        if ((elem_type == LY_STMT_ERROR_MESSAGE && child != LY_STMT_ARG_VALUE) ||
+            (elem_type != LY_STMT_ERROR_MESSAGE && child != LY_STMT_ARG_TEXT)) {
             LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_UNEXP_SUBELEM, name_len, name, ly_stmt2str(elem_type));
             return LY_EVALID;
         }
@@ -3420,7 +3420,7 @@ yin_parse_element_generic(struct yin_parser_ctx *ctx, const char *name, size_t n
         goto cleanup;
     } else if ((*element)->kw != LY_STMT_EXTENSION_INSTANCE) {
         /* element is known yang keyword, which means argument can be parsed correctly. */
-        ret = yin_parse_ext_instance_arg(ctx, attrs, data, (*element)->kw, &(*element)->arg);
+        ret = yin_parse_extension_instance_arg(ctx, attrs, data, (*element)->kw, &(*element)->arg);
         LY_CHECK_GOTO(ret, cleanup);
     } else {
         /* load attributes in generic way, save all attributes in linked list */

--- a/tests/src/test_parser_yin.c
+++ b/tests/src/test_parser_yin.c
@@ -542,8 +542,8 @@ test_yin_parse_extension_instance(void **state)
                 "<yin:namespace uri=\"uri\"/>"
                 "<yin:revision date=\"data\"/>"
                 "<yin:unique tag=\"tag\"/>"
-                "<yin:contact><text>contact-val</text></yin:contact>"
-                "<yin:error-message><value>err-msg</value></yin:error-message>"
+                "<yin:description><yin:text>contact-val</yin:text></yin:description>"
+                "<yin:error-message><yin:value>err-msg</yin:value></yin:error-message>"
            "</myext:extension-elem>";
     lyxml_get_element(&st->yin_ctx->xml_ctx, &data, &prefix, &prefix_len, &name, &name_len);
     yin_load_attributes(st->yin_ctx, &data, &args);
@@ -4229,6 +4229,37 @@ test_yin_parse_module(void **state)
     const char *data;
     struct lys_module *mod;
     struct yin_parser_ctx *yin_ctx = NULL;
+
+    mod = calloc(1, sizeof *mod);
+    mod->ctx = st->ctx;
+    data = "<module xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\" xmlns:md=\"urn:ietf:params:xml:ns:yang:ietf-yang-metadata\" name=\"a\"> \n"
+           "<yang-version value=\"1.1\"/>\n"
+           "<namespace uri=\"urn:tests:extensions:metadata:a\"/>\n"
+           "<prefix value=\"a\"/>\n"
+           "<import module=\"ietf-yang-metadata\">\n"
+                "<prefix value=\"md\"/>\n"
+           "</import>\n"
+           "<feature name=\"f\"/>\n"
+           "<md:annotation name=\"x\">\n"
+                "<description>\n"
+                "<text>test</text>\n"
+                "</description>\n"
+                "<reference>\n"
+                "<text>test</text>\n"
+                "</reference>\n"
+                "<if-feature name=\"f\"/>\n"
+                "<status value=\"current\"/>\n"
+                "<type name=\"uint8\"/>\n"
+                "<units name=\"meters\"/>\n"
+           "</md:annotation>\n"
+           "</module>\n";
+    assert_int_equal(yin_parse_module(&yin_ctx, data, mod), LY_SUCCESS);
+    assert_null(mod->parsed->exts->child->next->child);
+    assert_string_equal(mod->parsed->exts->child->next->arg, "test");
+    lys_module_free(mod, NULL);
+    yin_parser_ctx_free(yin_ctx);
+    mod = NULL;
+    yin_ctx = NULL;
 
     mod = calloc(1, sizeof *mod);
     mod->ctx = st->ctx;


### PR DESCRIPTION
This caused disfunction of yin elements with argument mapped to
subelement in extension instances.