### PR TITLE
Introduce API tracing for debug logging

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -36,12 +36,16 @@ THREAD_LOCAL int8_t ly_errno_glob;
 API LY_ERR *
 ly_errno_glob_address(void)
 {
+    FUN_IN;
+
     return (LY_ERR *)&ly_errno_glob;
 }
 
 API LY_VECODE
 ly_vecode(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct ly_err_item *i;
 
     i = ly_err_first(ctx);
@@ -55,6 +59,8 @@ ly_vecode(const struct ly_ctx *ctx)
 API const char *
 ly_errmsg(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct ly_err_item *i;
 
     i = ly_err_first(ctx);
@@ -68,6 +74,8 @@ ly_errmsg(const struct ly_ctx *ctx)
 API const char *
 ly_errpath(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct ly_err_item *i;
 
     i = ly_err_first(ctx);
@@ -81,6 +89,8 @@ ly_errpath(const struct ly_ctx *ctx)
 API const char *
 ly_errapptag(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct ly_err_item *i;
 
     i = ly_err_first(ctx);
@@ -94,6 +104,8 @@ ly_errapptag(const struct ly_ctx *ctx)
 API struct ly_err_item *
 ly_err_first(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     if (!ctx) {
         return NULL;
     }
@@ -119,6 +131,8 @@ ly_err_free(void *ptr)
 API void
 ly_err_clean(struct ly_ctx *ctx, struct ly_err_item *eitem)
 {
+    FUN_IN;
+
     struct ly_err_item *i, *first;
 
     first = ly_err_first(ctx);
@@ -601,6 +615,8 @@ transform_xml2json(struct ly_ctx *ctx, const char *expr, struct lyxml_elem *xml,
 API char *
 ly_path_xml2json(struct ly_ctx *ctx, const char *xml_path, struct lyxml_elem *xml)
 {
+    FUN_IN;
+
     const char *json_path;
     char *ret = NULL;
 
@@ -1190,6 +1206,8 @@ error:
 API char *
 ly_path_data2schema(struct ly_ctx *ctx, const char *data_path)
 {
+    FUN_IN;
+
     struct lyxp_expr *exp;
     uint16_t out_used, cur_exp = 0;
     char *out;

--- a/src/common.h.in
+++ b/src/common.h.in
@@ -127,6 +127,8 @@ void ly_log_dbg(int group, const char *format, ...);
 
 #endif
 
+#define FUN_IN LOGDBG(LY_LDGAPI, "%s", __func__);
+
 #define LOGMEM(ctx) LOGERR(ctx, LY_EMEM, "Memory allocation failed (%s()).", __func__)
 
 #define LOGINT(ctx) LOGERR(ctx, LY_EINT, "Internal error (%s:%d).", __FILE__, __LINE__)

--- a/src/context.c
+++ b/src/context.c
@@ -72,6 +72,8 @@ static struct internal_modules_s {
 API unsigned int
 ly_ctx_internal_modules_count(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     if (!ctx) {
         return 0;
     }
@@ -81,6 +83,8 @@ ly_ctx_internal_modules_count(struct ly_ctx *ctx)
 API struct ly_ctx *
 ly_ctx_new(const char *search_dir, int options)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx = NULL;
     struct lys_module *module;
     char *search_dir_list;
@@ -302,12 +306,16 @@ error:
 API struct ly_ctx *
 ly_ctx_new_ylpath(const char *search_dir, const char *path, LYD_FORMAT format, int options)
 {
+    FUN_IN;
+
     return ly_ctx_new_yl_common(search_dir, path, format, options, lyd_parse_path);
 }
 
 API struct ly_ctx *
 ly_ctx_new_ylmem(const char *search_dir, const char *data, LYD_FORMAT format, int options)
 {
+    FUN_IN;
+
     return ly_ctx_new_yl_common(search_dir, data, format, options, lyd_parse_mem);
 }
 
@@ -334,72 +342,96 @@ ly_ctx_unset_option(struct ly_ctx *ctx, int options)
 API void
 ly_ctx_set_disable_searchdirs(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_set_option(ctx, LY_CTX_DISABLE_SEARCHDIRS);
 }
 
 API void
 ly_ctx_unset_disable_searchdirs(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_unset_option(ctx, LY_CTX_DISABLE_SEARCHDIRS);
 }
 
 API void
 ly_ctx_set_disable_searchdir_cwd(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_set_option(ctx, LY_CTX_DISABLE_SEARCHDIR_CWD);
 }
 
 API void
 ly_ctx_unset_disable_searchdir_cwd(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_unset_option(ctx, LY_CTX_DISABLE_SEARCHDIR_CWD);
 }
 
 API void
 ly_ctx_set_prefer_searchdirs(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_set_option(ctx, LY_CTX_PREFER_SEARCHDIRS);
 }
 
 API void
 ly_ctx_unset_prefer_searchdirs(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_unset_option(ctx, LY_CTX_PREFER_SEARCHDIRS);
 }
 
 API void
 ly_ctx_set_allimplemented(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_set_option(ctx, LY_CTX_ALLIMPLEMENTED);
 }
 
 API void
 ly_ctx_unset_allimplemented(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_unset_option(ctx, LY_CTX_ALLIMPLEMENTED);
 }
 
 API void
 ly_ctx_set_trusted(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_set_option(ctx, LY_CTX_TRUSTED);
 }
 
 API void
 ly_ctx_unset_trusted(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     ly_ctx_unset_option(ctx, LY_CTX_TRUSTED);
 }
 
 API int
 ly_ctx_get_options(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     return ctx->models.flags;
 }
 
 API int
 ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
 {
+    FUN_IN;
+
     char *new_dir = NULL;
     int index = 0;
     void *r;
@@ -454,6 +486,8 @@ cleanup:
 API const char * const *
 ly_ctx_get_searchdirs(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     if (!ctx) {
         LOGARG;
         return NULL;
@@ -464,6 +498,8 @@ ly_ctx_get_searchdirs(const struct ly_ctx *ctx)
 API void
 ly_ctx_unset_searchdirs(struct ly_ctx *ctx, int index)
 {
+    FUN_IN;
+
     int i;
 
     if (!ctx->models.search_paths) {
@@ -488,6 +524,8 @@ ly_ctx_unset_searchdirs(struct ly_ctx *ctx, int index)
 API void
 ly_ctx_destroy(struct ly_ctx *ctx, void (*private_destructor)(const struct lys_node *node, void *priv))
 {
+    FUN_IN;
+
     int i;
 
     if (!ctx) {
@@ -525,6 +563,8 @@ ly_ctx_destroy(struct ly_ctx *ctx, void (*private_destructor)(const struct lys_n
 API const struct lys_submodule *
 ly_ctx_get_submodule2(const struct lys_module *main_module, const char *submodule)
 {
+    FUN_IN;
+
     const struct lys_submodule *result;
     int i;
 
@@ -553,6 +593,8 @@ API const struct lys_submodule *
 ly_ctx_get_submodule(const struct ly_ctx *ctx, const char *module, const char *revision, const char *submodule,
                      const char *sub_revision)
 {
+    FUN_IN;
+
     const struct lys_module *mainmod;
     const struct lys_submodule *ret = NULL, *submod;
     uint32_t idx = 0;
@@ -670,12 +712,16 @@ ly_ctx_get_module_by(const struct ly_ctx *ctx, const char *key, size_t key_len, 
 API const struct lys_module *
 ly_ctx_get_module_by_ns(const struct ly_ctx *ctx, const char *ns, const char *revision, int implemented)
 {
+    FUN_IN;
+
     return ly_ctx_get_module_by(ctx, ns, 0, offsetof(struct lys_module, ns), revision, 0, implemented);
 }
 
 API const struct lys_module *
 ly_ctx_get_module(const struct ly_ctx *ctx, const char *name, const char *revision, int implemented)
 {
+    FUN_IN;
+
     return ly_ctx_get_module_by(ctx, name, 0, offsetof(struct lys_module, name), revision, 0, implemented);
 }
 
@@ -688,6 +734,8 @@ ly_ctx_nget_module(const struct ly_ctx *ctx, const char *name, size_t name_len, 
 API const struct lys_module *
 ly_ctx_get_module_older(const struct ly_ctx *ctx, const struct lys_module *module)
 {
+    FUN_IN;
+
     int i;
     const struct lys_module *result = NULL, *iter;
 
@@ -730,6 +778,8 @@ ly_ctx_get_module_older(const struct ly_ctx *ctx, const struct lys_module *modul
 API void
 ly_ctx_set_module_imp_clb(struct ly_ctx *ctx, ly_module_imp_clb clb, void *user_data)
 {
+    FUN_IN;
+
     if (!ctx) {
         LOGARG;
         return;
@@ -742,6 +792,8 @@ ly_ctx_set_module_imp_clb(struct ly_ctx *ctx, ly_module_imp_clb clb, void *user_
 API ly_module_imp_clb
 ly_ctx_get_module_imp_clb(const struct ly_ctx *ctx, void **user_data)
 {
+    FUN_IN;
+
     if (!ctx) {
         LOGARG;
         return NULL;
@@ -756,6 +808,8 @@ ly_ctx_get_module_imp_clb(const struct ly_ctx *ctx, void **user_data)
 API void
 ly_ctx_set_module_data_clb(struct ly_ctx *ctx, ly_module_data_clb clb, void *user_data)
 {
+    FUN_IN;
+
     if (!ctx) {
         LOGARG;
         return;
@@ -768,6 +822,8 @@ ly_ctx_set_module_data_clb(struct ly_ctx *ctx, ly_module_data_clb clb, void *use
 API ly_module_data_clb
 ly_ctx_get_module_data_clb(const struct ly_ctx *ctx, void **user_data)
 {
+    FUN_IN;
+
     if (!ctx) {
         LOGARG;
         return NULL;
@@ -784,6 +840,8 @@ ly_ctx_get_module_data_clb(const struct ly_ctx *ctx, void **user_data)
 API void
 ly_ctx_set_priv_dup_clb(struct ly_ctx *ctx, void *(*priv_dup_clb)(const void *priv))
 {
+    FUN_IN;
+
     ctx->priv_dup_clb = priv_dup_clb;
 }
 
@@ -1034,6 +1092,8 @@ search_file:
 API const struct lys_module *
 ly_ctx_load_module(struct ly_ctx *ctx, const char *name, const char *revision)
 {
+    FUN_IN;
+
     if (!ctx || !name) {
         LOGARG;
         return NULL;
@@ -1232,6 +1292,8 @@ next_sibling:
 API int
 lys_set_disabled(const struct lys_module *module)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx; /* shortcut */
     struct lys_module *mod;
     struct ly_set *mods;
@@ -1377,6 +1439,8 @@ lys_set_enabled_(struct ly_set *mods, struct lys_module *mod)
 API int
 lys_set_enabled(const struct lys_module *module)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx; /* shortcut */
     struct lys_module *mod;
     struct ly_set *mods, *disabled;
@@ -1482,6 +1546,8 @@ API int
 ly_ctx_remove_module(const struct lys_module *module,
                      void (*private_destructor)(const struct lys_node *node, void *priv))
 {
+    FUN_IN;
+
     struct ly_ctx *ctx; /* shortcut */
     struct lys_module *mod = NULL;
     struct ly_set *mods;
@@ -1608,6 +1674,8 @@ imported:
 API void
 ly_ctx_clean(struct ly_ctx *ctx, void (*private_destructor)(const struct lys_node *node, void *priv))
 {
+    FUN_IN;
+
     if (!ctx) {
         return;
     }
@@ -1630,6 +1698,8 @@ ly_ctx_clean(struct ly_ctx *ctx, void (*private_destructor)(const struct lys_nod
 API const struct lys_module *
 ly_ctx_get_module_iter(const struct ly_ctx *ctx, uint32_t *idx)
 {
+    FUN_IN;
+
     if (!ctx || !idx) {
         LOGARG;
         return NULL;
@@ -1647,6 +1717,8 @@ ly_ctx_get_module_iter(const struct ly_ctx *ctx, uint32_t *idx)
 API const struct lys_module *
 ly_ctx_get_disabled_module_iter(const struct ly_ctx *ctx, uint32_t *idx)
 {
+    FUN_IN;
+
     if (!ctx || !idx) {
         LOGARG;
         return NULL;
@@ -1775,12 +1847,16 @@ ylib_submodules(struct lyd_node *parent, struct lys_module *cur_mod, int bis)
 API uint16_t
 ly_ctx_get_module_set_id(const struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     return ctx->models.module_set_id;
 }
 
 API struct lyd_node *
 ly_ctx_info(struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     int i, bis = 0;
     char id[8];
     char *str;
@@ -1965,6 +2041,8 @@ error:
 API const struct lys_node *
 ly_ctx_get_node(const struct ly_ctx *ctx, const struct lys_node *start, const char *nodeid, int output)
 {
+    FUN_IN;
+
     const struct lys_node *node;
 
     if ((!ctx && !start) || !nodeid || ((nodeid[0] != '/') && !start)) {
@@ -1985,6 +2063,8 @@ ly_ctx_get_node(const struct ly_ctx *ctx, const struct lys_node *start, const ch
 API struct ly_set *
 ly_ctx_find_path(struct ly_ctx *ctx, const char *path)
 {
+    FUN_IN;
+
     struct ly_set *resultset = NULL;
 
     if (!ctx || !path) {

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -144,6 +144,8 @@ dict_hash_multi(uint32_t hash, const char *key_part, size_t len)
 API void
 lydict_remove(struct ly_ctx *ctx, const char *value)
 {
+    FUN_IN;
+
     size_t len;
     int ret;
     uint32_t hash;
@@ -233,6 +235,8 @@ dict_insert(struct ly_ctx *ctx, char *value, size_t len, int zerocopy)
 API const char *
 lydict_insert(struct ly_ctx *ctx, const char *value, size_t len)
 {
+    FUN_IN;
+
     const char *result;
 
     if (!value) {
@@ -253,6 +257,8 @@ lydict_insert(struct ly_ctx *ctx, const char *value, size_t len)
 API const char *
 lydict_insert_zc(struct ly_ctx *ctx, char *value)
 {
+    FUN_IN;
+
     const char *result;
 
     if (!value) {

--- a/src/libyang.h.in
+++ b/src/libyang.h.in
@@ -1915,6 +1915,7 @@ int ly_log_options(int opts);
 #define LY_LDGYIN   0x04 /**< YIN parser messages. */
 #define LY_LDGXPATH 0x08 /**< XPath parsing end evaluation. */
 #define LY_LDGDIFF  0x10 /**< Diff processing and creation. */
+#define LY_LDGAPI   0x20 /**< API tracing. */
 
 /**
  * @}

--- a/src/log.c
+++ b/src/log.c
@@ -263,6 +263,9 @@ ly_log_dbg(int group, const char *format, ...)
     case LY_LDGDIFF:
         str_group = "DIFF";
         break;
+    case LY_LDGAPI:
+        str_group = "API";
+        break;
     default:
         LOGINT(NULL);
         return;

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -1305,6 +1305,8 @@ finish:
 API int
 lyd_lyb_data_length(const char *data)
 {
+    FUN_IN;
+
     struct lyb_state lybs;
     int r = 0, ret = 0, i;
     size_t len;

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -559,6 +559,8 @@ error:
 API struct lyd_node *
 lyd_parse_xml(struct ly_ctx *ctx, struct lyxml_elem **root, int options, ...)
 {
+    FUN_IN;
+
     va_list ap;
     int r;
     struct unres_data *unres = NULL;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -52,12 +52,16 @@ static uint32_t plugin_refs;
 API const char * const *
 ly_get_loaded_plugins(void)
 {
+    FUN_IN;
+
     return (const char * const *)loaded_plugins;
 }
 
 API int
 ly_clean_plugins(void)
 {
+    FUN_IN;
+
     unsigned int u;
     int ret = EXIT_SUCCESS;
 
@@ -165,6 +169,8 @@ lytype_load_plugin(void *dlhandler, const char *file_name)
 API int
 ly_register_types(struct lytype_plugin_list *plugin, const char *log_name)
 {
+    FUN_IN;
+
     struct lytype_plugin_list *p;
     uint32_t u, v;
 
@@ -228,6 +234,8 @@ lyext_load_plugin(void *dlhandler, const char *file_name)
 API int
 ly_register_exts(struct lyext_plugin_list *plugin, const char *log_name)
 {
+    FUN_IN;
+
     struct lyext_plugin_list *p;
     struct lyext_plugin_complex *pluginc;
     uint32_t u, v;
@@ -378,6 +386,8 @@ ly_load_plugins_dir(DIR *dir, const char *dir_path, int ext_or_type)
 API void
 ly_load_plugins(void)
 {
+    FUN_IN;
+
     DIR* dir;
     const char *pluginsdir;
 
@@ -462,6 +472,8 @@ ext_get_plugin(const char *name, const char *module, const char *revision)
 API int
 lys_ext_instance_presence(struct lys_ext *def, struct lys_ext_instance **ext, uint8_t ext_size)
 {
+    FUN_IN;
+
     uint8_t index;
 
     if (!def || (ext_size && !ext)) {
@@ -492,6 +504,8 @@ lys_ext_instance_presence(struct lys_ext *def, struct lys_ext_instance **ext, ui
 API void *
 lys_ext_complex_get_substmt(LY_STMT stmt, struct lys_ext_instance_complex *ext, struct lyext_substmt **info)
 {
+    FUN_IN;
+
     int i;
 
     if (!ext || !ext->def || !ext->def->plugin || ext->def->plugin->type != LYEXT_COMPLEX) {

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1034,6 +1034,8 @@ lyd_parse_data_(struct ly_ctx *ctx, const char *data, LYD_FORMAT format, int opt
 API struct lyd_node *
 lyd_parse_mem(struct ly_ctx *ctx, const char *data, LYD_FORMAT format, int options, ...)
 {
+    FUN_IN;
+
     va_list ap;
     struct lyd_node *result;
 
@@ -1073,6 +1075,8 @@ lyd_parse_fd_(struct ly_ctx *ctx, int fd, LYD_FORMAT format, int options, va_lis
 API struct lyd_node *
 lyd_parse_fd(struct ly_ctx *ctx, int fd, LYD_FORMAT format, int options, ...)
 {
+    FUN_IN;
+
     struct lyd_node *ret;
     va_list ap;
 
@@ -1086,6 +1090,8 @@ lyd_parse_fd(struct ly_ctx *ctx, int fd, LYD_FORMAT format, int options, ...)
 API struct lyd_node *
 lyd_parse_path(struct ly_ctx *ctx, const char *path, LYD_FORMAT format, int options, ...)
 {
+    FUN_IN;
+
     int fd;
     struct lyd_node *ret;
     va_list ap;
@@ -1165,6 +1171,8 @@ _lyd_new(struct lyd_node *parent, const struct lys_node *schema, int dflt)
 API struct lyd_node *
 lyd_new(struct lyd_node *parent, const struct lys_module *module, const char *name)
 {
+    FUN_IN;
+
     const struct lys_node *snode = NULL, *siblings;
 
     if ((!parent && !module) || !name) {
@@ -1259,6 +1267,8 @@ _lyd_new_leaf(struct lyd_node *parent, const struct lys_node *schema, const char
 API struct lyd_node *
 lyd_new_leaf(struct lyd_node *parent, const struct lys_module *module, const char *name, const char *val_str)
 {
+    FUN_IN;
+
     const struct lys_node *snode = NULL, *siblings;
 
     if ((!parent && !module) || !name) {
@@ -1369,6 +1379,8 @@ check_leaf_list_backlinks(struct lyd_node *node, int op)
 API int
 lyd_change_leaf(struct lyd_node_leaf_list *leaf, const char *val_str)
 {
+    FUN_IN;
+
     const char *backup;
     int val_change, dflt_change;
     struct lyd_node *parent;
@@ -1507,6 +1519,8 @@ API struct lyd_node *
 lyd_new_anydata(struct lyd_node *parent, const struct lys_module *module, const char *name,
                 void *value, LYD_ANYDATA_VALUETYPE value_type)
 {
+    FUN_IN;
+
     const struct lys_node *siblings, *snode;
 
     if ((!parent && !module) || !name) {
@@ -1532,6 +1546,8 @@ lyd_new_anydata(struct lyd_node *parent, const struct lys_module *module, const 
 API struct lyd_node *
 lyd_new_yangdata(const struct lys_module *module, const char *name_template, const char *name)
 {
+    FUN_IN;
+
     const struct lys_node *schema = NULL, *snode;
 
     if (!module || !name_template || !name) {
@@ -1557,6 +1573,8 @@ lyd_new_yangdata(const struct lys_module *module, const char *name_template, con
 API struct lyd_node *
 lyd_new_output(struct lyd_node *parent, const struct lys_module *module, const char *name)
 {
+    FUN_IN;
+
     const struct lys_node *snode = NULL, *siblings;
 
     if ((!parent && !module) || !name) {
@@ -1583,6 +1601,8 @@ lyd_new_output(struct lyd_node *parent, const struct lys_module *module, const c
 API struct lyd_node *
 lyd_new_output_leaf(struct lyd_node *parent, const struct lys_module *module, const char *name, const char *val_str)
 {
+    FUN_IN;
+
     const struct lys_node *snode = NULL, *siblings;
 
     if ((!parent && !module) || !name) {
@@ -1609,6 +1629,8 @@ API struct lyd_node *
 lyd_new_output_anydata(struct lyd_node *parent, const struct lys_module *module, const char *name,
                        void *value, LYD_ANYDATA_VALUETYPE value_type)
 {
+    FUN_IN;
+
     const struct lys_node *siblings, *snode;
 
     if ((!parent && !module) || !name) {
@@ -1864,6 +1886,8 @@ API struct lyd_node *
 lyd_new_path(struct lyd_node *data_tree, const struct ly_ctx *ctx, const char *path, void *value,
              LYD_ANYDATA_VALUETYPE value_type, int options)
 {
+    FUN_IN;
+
     char *str;
     const char *mod_name, *name, *val_name, *val, *node_mod_name, *id, *backup_mod_name = NULL, *yang_data_name = NULL;
     struct lyd_node *ret = NULL, *node, *parent = NULL;
@@ -2227,6 +2251,8 @@ lyd_new_path(struct lyd_node *data_tree, const struct ly_ctx *ctx, const char *p
 API unsigned int
 lyd_list_pos(const struct lyd_node *node)
 {
+    FUN_IN;
+
     unsigned int pos;
     struct lys_node *schema;
 
@@ -2971,6 +2997,8 @@ lyd_merge_siblings(struct lyd_node *target, struct lyd_node *source, int options
 API int
 lyd_merge_to_ctx(struct lyd_node **trg, const struct lyd_node *src, int options, struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct lyd_node *node = NULL, *node2, *target, *trg_merge_start, *src_merge_start = NULL;
     const struct lyd_node *iter;
     struct lys_node *src_snode, *sch = NULL;
@@ -3231,6 +3259,8 @@ error:
 API int
 lyd_merge(struct lyd_node *target, const struct lyd_node *source, int options)
 {
+    FUN_IN;
+
     if (!target || !source) {
         LOGARG;
         return -1;
@@ -3242,6 +3272,8 @@ lyd_merge(struct lyd_node *target, const struct lyd_node *source, int options)
 API void
 lyd_free_diff(struct lyd_difflist *diff)
 {
+    FUN_IN;
+
     if (diff) {
         free(diff->type);
         free(diff->first);
@@ -3597,6 +3629,8 @@ lyd_diff_init_difflist(struct ly_ctx *ctx, unsigned int *size)
 API struct lyd_difflist *
 lyd_diff(struct lyd_node *first, struct lyd_node *second, int options)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx;
     int rc;
     struct lyd_node *elem1, *elem2, *iter, *aux, *parent = NULL, *next1, *next2;
@@ -4556,6 +4590,8 @@ error:
 API int
 lyd_insert(struct lyd_node *parent, struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!node || !parent || (parent->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA))) {
         LOGARG;
         return EXIT_FAILURE;
@@ -4567,6 +4603,8 @@ lyd_insert(struct lyd_node *parent, struct lyd_node *node)
 API int
 lyd_insert_sibling(struct lyd_node **sibling, struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!sibling || !node) {
         LOGARG;
         return EXIT_FAILURE;
@@ -4782,6 +4820,8 @@ error:
 API int
 lyd_insert_before(struct lyd_node *sibling, struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!node || !sibling) {
         LOGARG;
         return EXIT_FAILURE;
@@ -4793,6 +4833,8 @@ lyd_insert_before(struct lyd_node *sibling, struct lyd_node *node)
 API int
 lyd_insert_after(struct lyd_node *sibling, struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!node || !sibling) {
         LOGARG;
         return EXIT_FAILURE;
@@ -4869,6 +4911,8 @@ lyd_node_pos_cmp(const void *item1, const void *item2)
 API int
 lyd_schema_sort(struct lyd_node *sibling, int recursive)
 {
+    FUN_IN;
+
     uint32_t len, i;
     struct lyd_node *node;
     struct lys_node *first_ssibling = NULL;
@@ -5135,6 +5179,8 @@ cleanup:
 API int
 lyd_validate(struct lyd_node **node, int options, void *var_arg, ...)
 {
+    FUN_IN;
+
     struct lyd_node *iter, *data_tree = NULL;
     struct lyd_difflist **diff = NULL;
     struct ly_ctx *ctx = NULL;
@@ -5229,6 +5275,8 @@ lyd_validate(struct lyd_node **node, int options, void *var_arg, ...)
 API int
 lyd_validate_modules(struct lyd_node **node, const struct lys_module **modules, int mod_count, int options, ...)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx;
     struct lyd_difflist **diff = NULL;
     va_list ap;
@@ -5272,6 +5320,8 @@ lyd_validate_modules(struct lyd_node **node, const struct lys_module **modules, 
 API int
 lyd_validate_value(struct lys_node *node, const char *value)
 {
+    FUN_IN;
+
     struct lyd_node_leaf_list leaf;
     struct lys_node_leaf *sleaf = (struct lys_node_leaf*)node;
     int ret = EXIT_SUCCESS;
@@ -5433,6 +5483,8 @@ lyd_unlink_internal(struct lyd_node *node, int permanent)
 API int
 lyd_unlink(struct lyd_node *node)
 {
+    FUN_IN;
+
     return lyd_unlink_internal(node, 1);
 }
 
@@ -5670,6 +5722,8 @@ lyd_dup_keys(struct lyd_node *new_list, const struct lyd_node *old_list, struct 
 API struct lyd_node *
 lyd_dup_to_ctx(const struct lyd_node *node, int options, struct ly_ctx *ctx)
 {
+    FUN_IN;
+
     struct ly_ctx *log_ctx;
     struct lys_node *schema;
     const char *yang_data_name;
@@ -5828,6 +5882,8 @@ error:
 API struct lyd_node *
 lyd_dup(const struct lyd_node *node, int options)
 {
+    FUN_IN;
+
     return lyd_dup_to_ctx(node, options, NULL);
 }
 
@@ -5946,6 +6002,8 @@ lyd_dup_withsiblings_to_ctx(const struct lyd_node *node, int options, struct ly_
 API struct lyd_node *
 lyd_dup_withsiblings(const struct lyd_node *node, int options)
 {
+    FUN_IN;
+
     if (!node) {
         return NULL;
     }
@@ -5956,6 +6014,8 @@ lyd_dup_withsiblings(const struct lyd_node *node, int options)
 API void
 lyd_free_attr(struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_attr *attr, int recursive)
 {
+    FUN_IN;
+
     struct lyd_attr *iter;
     struct lys_type **type;
 
@@ -6020,6 +6080,8 @@ lyd_attr_parent(const struct lyd_node *root, struct lyd_attr *attr)
 API struct lyd_attr *
 lyd_insert_attr(struct lyd_node *parent, const struct lys_module *mod, const char *name, const char *value)
 {
+    FUN_IN;
+
     struct lyd_attr *a, *iter;
     struct ly_ctx *ctx;
     const struct lys_module *module;
@@ -6224,6 +6286,8 @@ lyd_free_internal_r(struct lyd_node *node, int top)
 API void
 lyd_free(struct lyd_node *node)
 {
+    FUN_IN;
+
     lyd_free_internal_r(node, 1);
 }
 
@@ -6243,6 +6307,8 @@ lyd_free_withsiblings_r(struct lyd_node *first)
 API void
 lyd_free_withsiblings(struct lyd_node *node)
 {
+    FUN_IN;
+
     struct lyd_node *iter, *aux;
 
     if (!node) {
@@ -6392,6 +6458,8 @@ end:
 API char *
 lyd_path(const struct lyd_node *node)
 {
+    FUN_IN;
+
     char *buf = NULL;
 
     if (!node) {
@@ -6454,6 +6522,8 @@ lyd_build_relative_data_path(const struct lys_module *module, const struct lyd_n
 API struct ly_set *
 lyd_find_path(const struct lyd_node *ctx_node, const char *path)
 {
+    FUN_IN;
+
     struct lyxp_set xp_set;
     struct ly_set *set;
     char *yang_xpath;
@@ -6513,6 +6583,8 @@ lyd_find_path(const struct lyd_node *ctx_node, const char *path)
 API struct ly_set *
 lyd_find_instance(const struct lyd_node *data, const struct lys_node *schema)
 {
+    FUN_IN;
+
     struct ly_set *ret, *ret_aux, *spath;
     const struct lys_node *siter;
     struct lyd_node *iter;
@@ -6599,6 +6671,8 @@ error:
 API struct lyd_node *
 lyd_first_sibling(struct lyd_node *node)
 {
+    FUN_IN;
+
     struct lyd_node *start;
 
     if (!node) {
@@ -6618,6 +6692,8 @@ lyd_first_sibling(struct lyd_node *node)
 API struct ly_set *
 ly_set_new(void)
 {
+    FUN_IN;
+
     struct ly_set *new;
 
     new = calloc(1, sizeof(struct ly_set));
@@ -6628,6 +6704,8 @@ ly_set_new(void)
 API void
 ly_set_free(struct ly_set *set)
 {
+    FUN_IN;
+
     if (!set) {
         return;
     }
@@ -6639,6 +6717,8 @@ ly_set_free(struct ly_set *set)
 API int
 ly_set_contains(const struct ly_set *set, void *node)
 {
+    FUN_IN;
+
     unsigned int i;
 
     if (!set) {
@@ -6659,6 +6739,8 @@ ly_set_contains(const struct ly_set *set, void *node)
 API struct ly_set *
 ly_set_dup(const struct ly_set *set)
 {
+    FUN_IN;
+
     struct ly_set *new;
 
     if (!set) {
@@ -6679,6 +6761,8 @@ ly_set_dup(const struct ly_set *set)
 API int
 ly_set_add(struct ly_set *set, void *node, int options)
 {
+    FUN_IN;
+
     unsigned int i;
     void **new;
 
@@ -6712,6 +6796,8 @@ ly_set_add(struct ly_set *set, void *node, int options)
 API int
 ly_set_merge(struct ly_set *trg, struct ly_set *src, int options)
 {
+    FUN_IN;
+
     unsigned int i, ret;
     void **new;
 
@@ -6757,6 +6843,8 @@ ly_set_merge(struct ly_set *trg, struct ly_set *src, int options)
 API int
 ly_set_rm_index(struct ly_set *set, unsigned int index)
 {
+    FUN_IN;
+
     if (!set || (index + 1) > set->number) {
         LOGARG;
         return EXIT_FAILURE;
@@ -6778,6 +6866,8 @@ ly_set_rm_index(struct ly_set *set, unsigned int index)
 API int
 ly_set_rm(struct ly_set *set, void *node)
 {
+    FUN_IN;
+
     unsigned int i;
 
     if (!set || !node) {
@@ -6803,6 +6893,8 @@ ly_set_rm(struct ly_set *set, void *node)
 API int
 ly_set_clean(struct ly_set *set)
 {
+    FUN_IN;
+
     if (!set) {
         return EXIT_FAILURE;
     }
@@ -6814,6 +6906,8 @@ ly_set_clean(struct ly_set *set)
 API int
 lyd_wd_default(struct lyd_node_leaf_list *node)
 {
+    FUN_IN;
+
     struct lys_node_leaf *leaf;
     struct lys_node_leaflist *llist;
     struct lyd_node *iter;
@@ -6964,6 +7058,8 @@ unres_data_diff_rem(struct unres_data *unres, unsigned int idx)
 API void
 lyd_free_val_diff(struct lyd_difflist *diff)
 {
+    FUN_IN;
+
     uint32_t i;
 
     if (!diff) {
@@ -7805,6 +7901,8 @@ unlink_datatree:
 API struct lys_module *
 lyd_node_module(const struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!node) {
         return NULL;
     }
@@ -7815,6 +7913,8 @@ lyd_node_module(const struct lyd_node *node)
 API double
 lyd_dec64_to_double(const struct lyd_node *node)
 {
+    FUN_IN;
+
     if (!node || !(node->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST))
             || (((struct lys_node_leaf *)node->schema)->type.base != LY_TYPE_DEC64)) {
         LOGARG;
@@ -7827,6 +7927,8 @@ lyd_dec64_to_double(const struct lyd_node *node)
 API const struct lys_type *
 lyd_leaf_type(const struct lyd_node_leaf_list *leaf)
 {
+    FUN_IN;
+
     struct lys_type *type;
 
     if (!leaf || !(leaf->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST))) {
@@ -7862,6 +7964,8 @@ lyd_leaf_type(const struct lyd_node_leaf_list *leaf)
 API void *
 lyd_set_private(const struct lyd_node *node, void *priv)
 {
+    FUN_IN;
+
     void *prev;
 
     if (!node) {

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -47,6 +47,8 @@ static int lys_type_dup(struct lys_module *mod, struct lys_node *parent, struct 
 API const struct lys_node_list *
 lys_is_key(const struct lys_node_leaf *node, uint8_t *index)
 {
+    FUN_IN;
+
     struct lys_node *parent = (struct lys_node *)node;
     struct lys_node_list *list;
     uint8_t i;
@@ -78,6 +80,8 @@ lys_is_key(const struct lys_node_leaf *node, uint8_t *index)
 API const struct lys_node *
 lys_is_disabled(const struct lys_node *node, int recursive)
 {
+    FUN_IN;
+
     int i;
 
     if (!node) {
@@ -128,6 +132,8 @@ check:
 API const struct lys_type *
 lys_getnext_union_type(const struct lys_type *last, const struct lys_type *type)
 {
+    FUN_IN;
+
     int found = 0;
 
     if (!type || (type->base != LY_TYPE_UNION)) {
@@ -249,6 +255,8 @@ lys_getnext_data(const struct lys_module *mod, const struct lys_node *parent, co
 API const struct lys_node *
 lys_getnext(const struct lys_node *last, const struct lys_node *parent, const struct lys_module *module, int options)
 {
+    FUN_IN;
+
     const struct lys_node *next, *aug_parent;
     struct lys_node **snode;
 
@@ -1078,6 +1086,8 @@ lys_parse_mem_(struct ly_ctx *ctx, const char *data, LYS_INFORMAT format, const 
 API const struct lys_module *
 lys_parse_mem(struct ly_ctx *ctx, const char *data, LYS_INFORMAT format)
 {
+    FUN_IN;
+
     return lys_parse_mem_(ctx, data, format, NULL, 0, 1);
 }
 
@@ -1123,6 +1133,8 @@ lys_sub_parse_mem(struct lys_module *module, const char *data, LYS_INFORMAT form
 API const struct lys_module *
 lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format)
 {
+    FUN_IN;
+
     int fd;
     const struct lys_module *ret;
     const char *rev, *dot, *filename;
@@ -1187,6 +1199,8 @@ lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format)
 API const struct lys_module *
 lys_parse_fd(struct ly_ctx *ctx, int fd, LYS_INFORMAT format)
 {
+    FUN_IN;
+
     return lys_parse_fd_(ctx, fd, format, NULL, 1);
 }
 
@@ -1289,6 +1303,8 @@ lys_sub_parse_fd(struct lys_module *module, int fd, LYS_INFORMAT format, struct 
 API int
 lys_search_localfile(const char * const *searchpaths, int cwd, const char *name, const char *revision, char **localfile, LYS_INFORMAT *format)
 {
+    FUN_IN;
+
     size_t len, flen, match_len = 0, dir_len;
     int i, implicit_cwd = 0, ret = EXIT_FAILURE;
     char *wd, *wn = NULL;
@@ -1647,6 +1663,8 @@ API void
 lys_iffeature_free(struct ly_ctx *ctx, struct lys_iffeature *iffeature, uint8_t iffeature_size,
                    int shallow, void (*private_destructor)(const struct lys_node *node, void *priv))
 {
+    FUN_IN;
+
     uint8_t i;
 
     for (i = 0; i < iffeature_size; ++i) {
@@ -1937,6 +1955,8 @@ lys_copy_union_leafrefs(struct lys_module *mod, struct lys_node *parent, struct 
 API const void *
 lys_ext_instance_substmt(const struct lys_ext_instance *ext)
 {
+    FUN_IN;
+
     if (!ext) {
         return NULL;
     }
@@ -2849,6 +2869,8 @@ lys_node_free(struct lys_node *node, void (*private_destructor)(const struct lys
 API struct lys_module *
 lys_implemented_module(const struct lys_module *mod)
 {
+    FUN_IN;
+
     struct ly_ctx *ctx;
     int i;
 
@@ -3942,18 +3964,24 @@ lys_features_change(const struct lys_module *module, const char *name, int op)
 API int
 lys_features_enable(const struct lys_module *module, const char *feature)
 {
+    FUN_IN;
+
     return lys_features_change(module, feature, 1);
 }
 
 API int
 lys_features_disable(const struct lys_module *module, const char *feature)
 {
+    FUN_IN;
+
     return lys_features_change(module, feature, 0);
 }
 
 API int
 lys_features_state(const struct lys_module *module, const char *feature)
 {
+    FUN_IN;
+
     int i, j;
 
     if (!module || !feature) {
@@ -3992,6 +4020,8 @@ lys_features_state(const struct lys_module *module, const char *feature)
 API const char **
 lys_features_list(const struct lys_module *module, uint8_t **states)
 {
+    FUN_IN;
+
     const char **result = NULL;
     int i, j;
     unsigned int count;
@@ -4050,6 +4080,8 @@ lys_features_list(const struct lys_module *module, uint8_t **states)
 API struct lys_module *
 lys_node_module(const struct lys_node *node)
 {
+    FUN_IN;
+
     if (!node) {
         return NULL;
     }
@@ -4060,6 +4092,8 @@ lys_node_module(const struct lys_node *node)
 API struct lys_module *
 lys_main_module(const struct lys_module *module)
 {
+    FUN_IN;
+
     if (!module) {
         return NULL;
     }
@@ -4070,6 +4104,8 @@ lys_main_module(const struct lys_module *module)
 API struct lys_node *
 lys_parent(const struct lys_node *node)
 {
+    FUN_IN;
+
     struct lys_node *parent;
 
     if (!node) {
@@ -4116,6 +4152,8 @@ lys_child(const struct lys_node *node, LYS_NODE nodetype)
 API void *
 lys_set_private(const struct lys_node *node, void *priv)
 {
+    FUN_IN;
+
     void *prev;
 
     if (!node) {
@@ -4230,6 +4268,8 @@ lys_data_path_reverse(const struct lys_node *node, char * const buf, uint32_t bu
 API struct ly_set *
 lys_xpath_atomize(const struct lys_node *ctx_node, enum lyxp_node_type ctx_node_type, const char *expr, int options)
 {
+    FUN_IN;
+
     struct lyxp_set set;
     const struct lys_node *parent;
     struct ly_set *ret_set;
@@ -4293,6 +4333,8 @@ lys_xpath_atomize(const struct lys_node *ctx_node, enum lyxp_node_type ctx_node_
 API struct ly_set *
 lys_node_xpath_atomize(const struct lys_node *node, int options)
 {
+    FUN_IN;
+
     const struct lys_node *next, *elem, *parent, *tmp;
     struct lyxp_set set;
     struct ly_set *ret_set;
@@ -4980,6 +5022,8 @@ nextsibling:
 API int
 lys_set_implemented(const struct lys_module *module)
 {
+    FUN_IN;
+
     struct unres_schema *unres;
     int disabled = 0;
 
@@ -5054,6 +5098,8 @@ lys_submodule_module_data_free(struct lys_submodule *submodule)
 API char *
 lys_path(const struct lys_node *node, int options)
 {
+    FUN_IN;
+
     char *buf = NULL;
 
     if (!node) {
@@ -5071,6 +5117,8 @@ lys_path(const struct lys_node *node, int options)
 API char *
 lys_data_path(const struct lys_node *node)
 {
+    FUN_IN;
+
     char *result = NULL, buf[1024];
     const char *separator, *name;
     int i, used;
@@ -5190,6 +5238,8 @@ lys_getnext_target_aug(struct lys_node_augment *last, const struct lys_module *m
 API struct ly_set *
 lys_find_path(const struct lys_module *cur_module, const struct lys_node *cur_node, const char *path)
 {
+    FUN_IN;
+
     struct ly_set *ret;
     int rc;
 

--- a/src/xml.c
+++ b/src/xml.c
@@ -43,6 +43,8 @@ static struct lyxml_attr *lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *
 API const struct lyxml_ns *
 lyxml_get_ns(const struct lyxml_elem *elem, const char *prefix)
 {
+    FUN_IN;
+
     struct lyxml_attr *attr;
 
     if (!elem) {
@@ -246,6 +248,8 @@ lyxml_dup_elem(struct ly_ctx *ctx, struct lyxml_elem *elem, struct lyxml_elem *p
 API struct lyxml_elem *
 lyxml_dup(struct ly_ctx *ctx, struct lyxml_elem *root)
 {
+    FUN_IN;
+
     return lyxml_dup_elem(ctx, root, NULL, 1, 0);
 }
 
@@ -307,6 +311,8 @@ lyxml_unlink_elem(struct ly_ctx *ctx, struct lyxml_elem *elem, int copy_ns)
 API void
 lyxml_unlink(struct ly_ctx *ctx, struct lyxml_elem *elem)
 {
+    FUN_IN;
+
     if (!elem) {
         return;
     }
@@ -391,6 +397,8 @@ lyxml_free_elem(struct ly_ctx *ctx, struct lyxml_elem *elem)
 API void
 lyxml_free(struct ly_ctx *ctx, struct lyxml_elem *elem)
 {
+    FUN_IN;
+
     if (!elem) {
         return;
     }
@@ -402,6 +410,8 @@ lyxml_free(struct ly_ctx *ctx, struct lyxml_elem *elem)
 API void
 lyxml_free_withsiblings(struct ly_ctx *ctx, struct lyxml_elem *elem)
 {
+    FUN_IN;
+
     struct lyxml_elem *iter, *aux;
 
     if (!elem) {
@@ -423,6 +433,8 @@ lyxml_free_withsiblings(struct ly_ctx *ctx, struct lyxml_elem *elem)
 API const char *
 lyxml_get_attr(const struct lyxml_elem *elem, const char *name, const char *ns)
 {
+    FUN_IN;
+
     struct lyxml_attr *a;
 
     assert(elem);
@@ -1141,6 +1153,8 @@ error:
 API struct lyxml_elem *
 lyxml_parse_mem(struct ly_ctx *ctx, const char *data, int options)
 {
+    FUN_IN;
+
     const char *c = data;
     unsigned int len;
     struct lyxml_elem *root, *first = NULL, *next;
@@ -1225,6 +1239,8 @@ error:
 API struct lyxml_elem *
 lyxml_parse_path(struct ly_ctx *ctx, const char *filename, int options)
 {
+    FUN_IN;
+
     struct lyxml_elem *elem = NULL;
     size_t length;
     int fd;
@@ -1431,6 +1447,8 @@ dump_siblings(struct lyout *out, const struct lyxml_elem *e, int options)
 API int
 lyxml_print_file(FILE *stream, const struct lyxml_elem *elem, int options)
 {
+    FUN_IN;
+
     struct lyout out;
 
     if (!stream || !elem) {
@@ -1452,6 +1470,8 @@ lyxml_print_file(FILE *stream, const struct lyxml_elem *elem, int options)
 API int
 lyxml_print_fd(int fd, const struct lyxml_elem *elem, int options)
 {
+    FUN_IN;
+
     struct lyout out;
 
     if (fd < 0 || !elem) {
@@ -1473,6 +1493,8 @@ lyxml_print_fd(int fd, const struct lyxml_elem *elem, int options)
 API int
 lyxml_print_mem(char **strp, const struct lyxml_elem *elem, int options)
 {
+    FUN_IN;
+
     struct lyout out;
     int r;
 
@@ -1497,6 +1519,8 @@ lyxml_print_mem(char **strp, const struct lyxml_elem *elem, int options)
 API int
 lyxml_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg, const struct lyxml_elem *elem, int options)
 {
+    FUN_IN;
+
     struct lyout out;
 
     if (!writeclb || !elem) {


### PR DESCRIPTION
The logs implemented so far simply show function entries to
support debugging and discovery of API usage patterns.

The relevant bit flag is LY_LDGAPI (0x20) and usage is similar to
the existing debugging flags:

        ly_verb(LY_LLDBG);
        ly_verb_dbg(LY_LDGAPI);

Related logs show a "API: " prefix.

So far every function with the 'API' macro is traced with the
exception of logging and printing related API functions.