### PR TITLE
printer: ignore EAGAIN and EINTR errno

### DIFF
--- a/src/printer.c
+++ b/src/printer.c
@@ -127,6 +127,15 @@ ly_print(struct lyout *out, const char *format, ...)
     case LYOUT_CALLBACK:
         count = vasprintf(&msg, format, ap);
         count = out->method.clb.f(out->method.clb.arg, msg, count);
+        if (count >= 0) {
+            /*
+             * Depending on what the callback function does, errno might
+             * contain non-zero values that are not real "errors" (EAGAIN or
+             * EINTR). Reset errno if the callback returns a zero or positive
+             * value.
+             */
+            errno = 0;
+        }
         free(msg);
         break;
     }


### PR DESCRIPTION
When using libnetconf2 via the UNIX or FD transport and sending large configs, we can get the following error from libyang:

```
Print error (Resource temporarily unavailable).
```

Do not fail when errno holds `EAGAIN` or `EINTR`. These are not errors. This can occur when using ly_print_clb with a callback that does I/O on a non-blocking file or if the application received a signal during the write syscall.

Ideally, we should check the return value of every `ly_print` call but it would be rather tedious and would make the code clobbered.

Fixes: 609d708ca567 ("printer CHANGE use errno to check for printer errors")