### PR TITLE
fix one anyxml/anydata coredump

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -439,7 +439,7 @@ cast_string_recursive(struct lyd_node *node, struct lys_module *local_mod, int f
                 }
                 break;
             case LYD_ANYDATA_XML:
-                if (lyxml_print_mem(&buf, any->value.xml, LYXML_PRINT_SIBLINGS)) {
+                if (!lyxml_print_mem(&buf, any->value.xml, LYXML_PRINT_SIBLINGS)) {
                     return -1;
                 }
                 break;


### PR DESCRIPTION
Hi Radek/Machal,
  I add  an anyxml statement to the file  `tests/schema/yang/ietf/ietf-ip.yang`,  
then modify  the file `test_xpath.c`  for testing xpath.
When I run the test_xpath,  the result is testcases shows failure. A coredump happened.
I think it may be the anyxml statement leading to coredump. 
I think it's  a bug in xpath for anyxml/anydata.
  
```
add anyxml statement for test xpath,file changlogs： 
1.schema/yang/ietf/ietfietf-ip.yang；                                   
2.schema/yin/ietf/ietf-ip.yin;
3.test_xpath.c

diff -Npur libyang-master-old/tests/api/test_xpath.c libyang-master-new/tests/api/test_xpath.c
--- libyang-master-old/tests/api/test_xpath.c	2019-10-09 15:54:10.000000000 +0800
+++ libyang-master-new/tests/api/test_xpath.c	2019-10-10 11:04:54.252645860 +0800
@@ -52,6 +52,9 @@ static const char *data =
         "<ip:ip>10.0.0.2</ip:ip>"
         "<ip:link-layer-address>01:34:56:78:9a:bc:de:f0</ip:link-layer-address>"
       "</ip:neighbor>"
+      "<ip:introduction>"
+        "<ip:desc>wlan interface</ip:desc>"
+      "</ip:introduction>"
     "</ip:ipv4>"
     "<ip:ipv6>"
       "<ip:enabled>true</ip:enabled>"
@@ -280,7 +283,7 @@ test_advanced(void **state)
 
     st->set = lyd_find_path(st->dt, "//interface[name='iface1']/ietf-ip:ipv4//*");
     assert_ptr_not_equal(st->set, NULL);
-    assert_int_equal(st->set->number, 12);
+    assert_int_equal(st->set->number, 13);
     ly_set_free(st->set);
     st->set = NULL;
 }
diff -Npur libyang-master-old/tests/schema/yang/ietf/ietf-ip.yang libyang-master-new/tests/schema/yang/ietf/ietf-ip.yang
--- libyang-master-old/tests/schema/yang/ietf/ietf-ip.yang	2019-10-09 15:54:10.000000000 +0800
+++ libyang-master-new/tests/schema/yang/ietf/ietf-ip.yang	2019-10-10 11:03:31.596645860 +0800
@@ -180,7 +180,7 @@ module ietf-ip {
      leaf enabled {
        type boolean;
@@ -274,7 +274,7 @@ module ietf-ip {
            "The link-layer address of the neighbor node.";
        }
      }
-
+     anyxml introduction;
    }
 
 
diff -Npur libyang-master-old/tests/schema/yin/ietf/ietf-ip.yin libyang-master-new/tests/schema/yin/ietf/ietf-ip.yin
--- libyang-master-old/tests/schema/yin/ietf/ietf-ip.yin	2019-10-09 15:54:10.000000000 +0800
+++ libyang-master-new/tests/schema/yin/ietf/ietf-ip.yin	2019-10-10 11:04:10.940645860 +0800
@@ -155,7 +155,8 @@ If an interface is not capable of runnin
 must not allow the client to configure these parameters.</text>
     </description>
     <container name="ipv4">
       <presence value="Enables IPv4 unless the 'enabled' leaf&#10;(which defaults to 'true') is set to 'false'"/>
       <description>
         <text>Parameters for the IPv4 address family.</text>
       </description>
@@ -259,9 +260,11 @@ ARP Cache.</text>
           </description>
         </leaf>
       </list>
+      <anyxml name="introduction"/>
     </container>
     <container name="ipv6">
       <presence value="Enables IPv6 unless the 'enabled' leaf&#10;(which defaults to 'true') is set to 
```
###test xpath,error info as follows
```
libyang-master/build # ./tests/test_xpath
[==========] Running 4 test(s).
[ RUN      ] test_invalid
libyang[0]: Unexpected character(s) ':' (:interface/name).
libyang[0]: Unexpected XPath token ] (]).
libyang[0]: Unexpected XPath token Unknown (()).
libyang[0]: Unparsed characters "()" left at the end of an XPath expression.
[       OK ] test_invalid
[ RUN      ] test_simple
[       OK ] test_simple
[ RUN      ] test_advanced
[       OK ] test_advanced
[ RUN      ] test_functions_operators
test_xpath: /data/jenkins/workspace/libyang/libyang-master20191010/libyang-master/src/log.c:90: log_store: Assertion `msg' failed.
Aborted
