### PR TITLE
libyang2: fix the include statement assertion failed problem

### DIFF
--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -748,8 +748,8 @@ lysp_load_module_check(struct ly_ctx *ctx, struct lysp_module *mod, struct lysp_
 }
 
 LY_ERR
-lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement, struct lys_parser_ctx *main_ctx,
-                     void **result)
+lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement,
+                     struct lys_parser_ctx *main_ctx, const char *main_name, void **result)
 {
     int fd;
     char *filepath = NULL;
@@ -776,6 +776,7 @@ lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision,
     check_data.name = name;
     check_data.revision = revision;
     check_data.path = filepath;
+    check_data.submoduleof = main_name;
     mod = lys_parse_fd_(ctx, fd, format, implement, main_ctx,
                         lysp_load_module_check, &check_data);
     close(fd);
@@ -874,7 +875,7 @@ search_clb:
 search_file:
             if (!(ctx->flags & LY_CTX_DISABLE_SEARCHDIRS)) {
                 /* module was not received from the callback or there is no callback set */
-                lys_module_localfile(ctx, name, revision, implement, NULL, (void **)mod);
+                lys_module_localfile(ctx, name, revision, implement, NULL, NULL, (void **)mod);
             }
             if (!(*mod) && (ctx->flags & LY_CTX_PREFER_SEARCHDIRS)) {
                 goto search_clb;
@@ -989,7 +990,7 @@ search_clb:
 search_file:
         if (!(ctx->ctx->flags & LY_CTX_DISABLE_SEARCHDIRS)) {
             /* submodule was not received from the callback or there is no callback set */
-            lys_module_localfile(ctx->ctx, inc->name, inc->rev[0] ? inc->rev : NULL, 0, ctx, (void**)&submod);
+            lys_module_localfile(ctx->ctx, inc->name, inc->rev[0] ? inc->rev : NULL, 0, ctx, mod->mod->name, (void**)&submod);
         }
         if (!submod && (ctx->ctx->flags & LY_CTX_PREFER_SEARCHDIRS)) {
             goto search_clb;

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -607,12 +607,13 @@ struct lys_module *lys_parse_path_(struct ly_ctx *ctx, const char *path, LYS_INF
  * @param[in] revision Optional revision of the (sub)module to load, if NULL the newest revision is being loaded.
  * @param[in] implement Flag if the (sub)module is supposed to be marked as implemented.
  * @param[in] main_ctx Parser context of the main module in case of loading submodule.
+ * @param[in] main_name Main module name in case of loading submodule.
  * @param[out] result Parsed YANG schema tree of the requested module (struct lys_module*) or submodule (struct lysp_submodule*).
  * If it is a module, it is already in the context!
  * @return LY_ERR value, in case of LY_SUCCESS, the \arg result is always provided.
  */
-LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement, struct lys_parser_ctx *main_ctx,
-                            void **result);
+LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement,
+                            struct lys_parser_ctx *main_ctx, const char *main_name, void **result);
 
 /**
  * @brief Create pre-compiled features array.


### PR DESCRIPTION
@rkrejci 
Hi Radek,
I find a problem when writing the printer_yin part.

If the module contains "include" statement, the following error happened:
```
yanglint: /data/libyang2/src/tree_schema_helpers.c:708: lysp_load_module_check: Assertion `info->submoduleof' failed.
```
I try to fix this problem by adding one parameter to the function `lys_module_localfile`, I don't know if it is the proper way.

   Thank you!
