### PR TITLE
Update python-devel req for RedHat/CentOS 8 support

### DIFF
--- a/packages/libyang.spec.in
+++ b/packages/libyang.spec.in
@@ -44,7 +44,11 @@ BuildRequires:  libcmocka-devel
 %if 0%{?suse_version} + 0%{?fedora} > 0
 BuildRequires:  python3-devel
 %else
+%if 0%{?rhel} && 0%{?rhel} > 7
+BuildRequires:  python36-devel
+%else
 BuildRequires:  python34-devel
+%endif
 %endif
 %endif
 


### PR DESCRIPTION
Update for Python Dependency to allow building on RedHat/CentOS 8

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>