### PR TITLE
libyang2: fix read_qstring escape issue

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -401,9 +401,11 @@ read_qstring(struct lys_parser_ctx *ctx, const char **data, enum yang_arg arg, c
             switch (**data) {
             case 'n':
                 c = "\n";
+                need_buf = 1;
                 break;
             case 't':
                 c = "\t";
+                need_buf = 1;
                 break;
             case '\"':
                 c = *data;

--- a/tests/src/test_parser_yang.c
+++ b/tests/src/test_parser_yang.c
@@ -322,9 +322,10 @@ test_arg(void **state)
 
     str = "\"hello\\n\\t\\\"\\\\\";";
     assert_int_equal(LY_SUCCESS, get_argument(&ctx, &str, Y_STR_ARG, NULL, &word, &buf, &len));
-    assert_null(buf);
+    assert_non_null(buf);
     assert_int_equal(9, len);
-    assert_string_equal("hello\\n\\t\\\"\\\\\";", word);
+    assert_string_equal("hello\n\t\"\\", word);
+    free(buf);
 
     ctx.indent = 14;
     str = "\"hello \t\n\t\t world!\"";


### PR DESCRIPTION
@rkrejci Hi, Radek, I find another issue in the parser when checking my `printer_yin` part .
The issue is as this:
I write an example module3
```
module module3{
  namespace "h\na";
  prefix m3;
}
```
then use  the yanglint print the module
`./yanglint -f yang ./module3.yang`

following is the output:
```
module module3 {
  namespace "h\\n";
  prefix m3;
}
```

As you see, the `\n` is incorrect and the last character `a` is missing!
Then I try to fix this issue. I find that when read `\n` or `\t`,  `need_buf` is also need to be set 1 in the function `read_qstring`.

Thank you very much.


