### PR TITLE
Resolve several cppcheck messages

### DIFF
--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -257,7 +257,7 @@ lyb_parse_model(const char *data, const struct lys_module **mod, struct lyb_stat
     LYB_HAVE_READ_GOTO(r, data, error);
 
     if (rev) {
-        sprintf(mod_rev, "%04u-%02u-%02u", ((rev & 0xFE00) >> 9) + 2000, (rev & 0x01E0) >> 5, (rev & 0x001F));
+        sprintf(mod_rev, "%04u-%02u-%02u", ((rev & 0xFE00) >> 9) + 2000, (rev & 0x01E0) >> 5, (unsigned int)(rev & 0x001F));
         *mod = ly_ctx_get_module(lybs->ctx, mod_name, mod_rev, 0);
     } else {
         *mod = ly_ctx_get_module(lybs->ctx, mod_name, NULL, 0);

--- a/src/parser_yang_bis.c
+++ b/src/parser_yang_bis.c
@@ -93,7 +93,7 @@
             free(s);                                                                     \
             YYABORT;                                                                     \
         }                                                                                \
-        memset(tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
+        memset((char *)tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
         (current_ptr) = tmp;                                                             \
     }                                                                                    \
     actual = &(current_ptr)[(size)++];                                                   \

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -550,7 +550,7 @@ xml_print_anydata(struct lyout *out, int level, const struct lyd_node *node, int
         if (any->value_type == LYD_ANYDATA_LYB) {
             /* parse into a data tree */
             iter = lyd_parse_mem(node->schema->module->ctx, any->value.mem, LYD_LYB, LYD_OPT_DATA | LYD_OPT_STRICT
-                                 | LYD_OPT_TRUSTED, NULL);
+                                 | LYD_OPT_TRUSTED, (char *)NULL);
             if (iter) {
                 /* successfully parsed */
                 free(any->value.mem);

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1552,7 +1552,7 @@ lys_ext_dup(struct ly_ctx *ctx, struct lys_module *mod, struct lys_ext_instance 
 
                 ((struct lys_ext_instance_complex*)result[u])->substmt = ((struct lyext_plugin_complex*)orig[u]->def->plugin)->substmt;
                 /* TODO duplicate data in extension instance content */
-                memcpy((void*)result[u] + sizeof(**orig), (void*)orig[u] + sizeof(**orig), len - sizeof(**orig));
+                memcpy((char *)result[u] + sizeof(**orig), (char *)orig[u] + sizeof(**orig), len - sizeof(**orig));
                 break;
             }
             /* generic part */

--- a/src/user_types/user_yang_types.c
+++ b/src/user_types/user_yang_types.c
@@ -217,7 +217,7 @@ date_and_time_store_clb(struct ly_ctx *UNUSED(ctx), const char *UNUSED(type_name
 
 error:
     if (ret == -1) {
-        err_msg = NULL;
+        *err_msg = NULL;
     }
     return 1;
 }

--- a/src/yang.y.in
+++ b/src/yang.y.in
@@ -47,7 +47,7 @@
             free(s);                                                                     \
             YYABORT;                                                                     \
         }                                                                                \
-        memset(tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
+        memset((char *)tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
         (current_ptr) = tmp;                                                             \
     }                                                                                    \
     actual = &(current_ptr)[(size)++];                                                   \


### PR DESCRIPTION
This pull request is to resolve the following cppcheck messages : 

```
[parser_lyb.c:260]: (warning) %u in format string (no. 3) requires 'unsigned int' but the argument type is 'signed int'.
[parser_yang_bis.c:3279]: (portability) 'tmp' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined.
...
[parser_yang_bis.c:4627]: (portability) 'tmp' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined.
[printer_xml.c:553]: (portability) Passing NULL after the last typed argument to a variadic function leads to undefined behaviour.
[tree_schema.c:1555]: (portability) '(void*)result[u]' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined.
[tree_schema.c:1555]: (portability) '(void*)orig[u]' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined.
[user_types/user_yang_types.c:220]: (warning) Assignment of function parameter has no effect outside the function. Did you forget dereferencing it?
...
