### PR TITLE
yang read string BUGFIX special characters read error

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -2804,20 +2804,14 @@ read_indent(const char *input, int indent, int size, int in_index, int *out_inde
         } else if (input[in_index] == '\t') {
             /* RFC 6020 6.1.3 tab character is treated as 8 space characters */
             k += 8;
-        } else  if (input[in_index] == '\\' && input[in_index + 1] == 't') {
-            /* RFC 6020 6.1.3 tab character is treated as 8 space characters */
-            k += 8;
-            ++in_index;
         } else {
             break;
         }
         ++in_index;
         if (k >= indent) {
             for (j = k - indent; j > 0; --j) {
+                ++(*out_index);
                 output[*out_index] = ' ';
-                if (j > 1) {
-                    ++(*out_index);
-                }
             }
             break;
         }
@@ -2844,26 +2838,21 @@ yang_read_string(struct ly_ctx *ctx, const char *input, char *output, int size, 
             ++space;
             break;
         case '\\':
+            space = 0;
             if (input[i + 1] == 'n') {
-                out_index -= space;
                 output[out_index] = '\n';
-                space = 0;
-                i = read_indent(input, indent, size, i + 2, &out_index, output);
             } else if (input[i + 1] == 't') {
                 output[out_index] = '\t';
-                ++i;
-                ++space;
             } else if (input[i + 1] == '\\') {
                 output[out_index] = '\\';
-                ++i;
             } else if ((i + 1) != size && input[i + 1] == '"') {
                 output[out_index] = '"';
-                ++i;
             } else {
                 /* backslash must not be followed by any other character */
                 LOGVAL(ctx, LYE_XML_INCHAR, LY_VLOG_NONE, NULL, input + i);
                 return NULL;
             }
+            ++i;
             break;
         default:
             output[out_index] = input[i];

--- a/tests/conformance/sec6_1_3/mod5.yang
+++ b/tests/conformance/sec6_1_3/mod5.yang
@@ -1,0 +1,20 @@
+module mod5 {
+  prefix abc;
+  namespace "urn:cesnet:mod5";
+   
+  /* LF should trim whitespace and repace TAB with 8 space in succeeding line header*/
+  description "a	
+		b";
+
+  /* LF should not trim whitespace before escaped whitespace immediately followed by LF*/
+  contact      "a  	\t
+ 	\tb";
+
+  /* LF should not trim escaped whitespace*/
+  reference   "a\t
+\tb";
+
+  /* escaped LF should not trim whitespace or escaped whitespace*/
+  organization "a\t  	\n  	\tb"; 
+}
+

--- a/tests/conformance/test_sec6_1_3.c
+++ b/tests/conformance/test_sec6_1_3.c
@@ -76,7 +76,7 @@ TEST_QUOTING(void **state)
     const struct lys_module *mod;
     char *dsc="Test for special characters: { } ; space /* multiple\nline comment */ // comment";
     char *ref="Test for special characters: { } ; space /* multiple line comment */ // comment";
-    char *contact="\"\" \\\\ \\ \n\t  \\n\\t ";
+    char *contact="\"\" \\\\ \\  \n\t  \\n\\t ";
 
     sprintf(buf, TESTS_DIR "/conformance/" TEST_DIR "/mod1.yang");
     mod = lys_parse_path(st->ctx, buf, TEST_SCHEMA_FORMAT);
@@ -84,6 +84,26 @@ TEST_QUOTING(void **state)
     assert_string_equal(mod->dsc, dsc);
     assert_string_equal(mod->ref, ref);
     assert_string_equal(mod->org, dsc);
+    assert_string_equal(mod->contact, contact);
+}
+
+static void
+TEST_ESCAPE_CHARACTER_IN_DOUBLE_QUOTING(void **state)
+{
+    struct state *st = (*state);
+    char buf[1024];
+    const struct lys_module *mod;
+    char *dsc="a\n b";
+    char *ref="a\t\n\tb";
+    char *org="a\t  \t\n  \t\tb";
+    char *contact="a  \t\t\n\tb";
+
+    sprintf(buf, TESTS_DIR "/conformance/" TEST_DIR "/mod5.yang");
+    mod = lys_parse_path(st->ctx, buf, TEST_SCHEMA_FORMAT);
+    assert_ptr_not_equal(mod, NULL);
+    assert_string_equal(mod->dsc, dsc);
+    assert_string_equal(mod->ref, ref);
+    assert_string_equal(mod->org, org);
     assert_string_equal(mod->contact, contact);
 }
 
@@ -124,6 +144,7 @@ main(void)
 {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(TEST_QUOTING, setup_f, teardown_f),
+        cmocka_unit_test_setup_teardown(TEST_ESCAPE_CHARACTER_IN_DOUBLE_QUOTING, setup_f, teardown_f),
         cmocka_unit_test_setup_teardown(TEST_DOUBLE_QUOTING, setup_f, teardown_f),
         cmocka_unit_test_setup_teardown(TEST_ILLEGAL_STRING, setup_f, teardown_f),
     };


### PR DESCRIPTION
@rkrejci @michalvasko 
Hi, Radek/Michal,
I find an issue in YANG read string for escaped characters.

As is described in [RFC7950 section 6.1.3](https://tools.ietf.org/html/rfc7950#section-6.1.3) 

> In double-quoted strings, whitespace trimming is done before
   substitution of backslash-escaped characters.  Concatenation is
   performed as the last step.

So, I think TAB/LF characters are not equal to escaped TAB(`\t`)/LF(`\n`) exactly in double quoted string.
TAB/LF characters will be trimmed in some case but escaped TAB(`\t`)/LF(`\n`) characters won't in any case when reading double quoted string.
For example, I have a `module1.yang`
```
module module1 {
  namespace "ns:m1";
  prefix m1;

/*there is a TAB after `a` and a TAB before `b`*/
  description "a	
	b";
  reference "a\t
\tb";
/*there is a TAB after `a` and a TAB before `b`*/
  organization "a	\n	b";
  contact "a\t\n\tb";
}
```
the yang format output should be: (I also use `pyang` for comparing this and `pyang` handle it correctly)
```
module module1 {
  namespace "ns:m1";
  prefix m1;

  description
    "a
     b";
  reference
    "a\t
     \tb";
  organization
    "a\t
     \tb";
  contact
    "a\t
     \tb";
}
```
But the libyang's output is this:
```
module module1 {
  namespace "ns:m1";
  prefix m1;

  organization
    "a
     b";
  contact
    "a
     b";
  description
    "a b";
  reference
    "a
     b";
}
```
**PS: The description's LF is missing is another bug in the reading function and it is also fixed in this PR.**

And I add some testcases for this.
Please review this, Thanks.

BTW, after doing this, I understand the issue I submit #912 , Both libyang and pyang print the special characters correctly and they should be printed as this.



