### PR TITLE
libyang2:tree schema BUGFIX unknown extension instance free coredump

### DIFF
--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -467,7 +467,7 @@ lysp_module_free(struct lysp_module *module)
 void
 lysc_ext_instance_free(struct ly_ctx *ctx, struct lysc_ext_instance *ext)
 {
-    if (ext->def->plugin && ext->def->plugin->free) {
+    if (ext->def && ext->def->plugin && ext->def->plugin->free) {
         ext->def->plugin->free(ctx, ext);
     }
     FREE_STRING(ctx, ext->argument);


### PR DESCRIPTION
This issue describe as this:

I have 2 modules `module1.yang` and `module2.yang`
```
module module1 {
  namespace "ns:m1";
  prefix m1;

  import module2{
    prefix m2;
  }

  m2:ex;    
}
```

```
module module2{
  namespace "ns:m2";
  prefix m2;
}
```
Then when I execute the command:
`yanglint -f yang module1.yang`

error happened:

> err : Extension instance "m2:ex" refers "module2" module that does not contain extension definitions.(/module1:{extension='m2:ex'})
Segmentation fault(core dumped)


