### PR TITLE
Fix libyang::Iffeature::features

### DIFF
--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -218,8 +218,8 @@ Iffeature::~Iffeature() {};
 std::vector<S_Feature> Iffeature::features() {
     std::vector<S_Feature> s_vector;
 
-    for (size_t i = 0; i < sizeof(*iffeature->features); i++) {
-        s_vector.push_back(std::make_shared<Feature>(iffeature->features[i], deleter));
+    for (auto it = iffeature->features; *it != nullptr; it++) {
+        s_vector.push_back(std::make_shared<Feature>(*it, deleter));
     }
 
     return s_vector;


### PR DESCRIPTION
This PR fixes `libyang::Iffeature::features`. The previous version was using `sizeof` on a pointer to determine the size of the original array. The new version correctly converts the array to `std::vector`.