### PR TITLE
conformance tests BUGFIX yin test should renew the context

### DIFF
--- a/tests/conformance/test_sec5_1.c
+++ b/tests/conformance/test_sec5_1.c
@@ -120,6 +120,12 @@ TEST_IMPORT_INCLUDE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            ly_ctx_destroy(st->ctx, NULL);
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec5_5.c
+++ b/tests/conformance/test_sec5_5.c
@@ -122,6 +122,12 @@ TEST_TYPEDEF_GROUPING(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            ly_ctx_destroy(st->ctx, NULL);
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec6_2.c
+++ b/tests/conformance/test_sec6_2.c
@@ -120,6 +120,11 @@ TEST_NAME(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec6_2_1.c
+++ b/tests/conformance/test_sec6_2_1.c
@@ -120,6 +120,11 @@ TEST_NAME(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_1.c
+++ b/tests/conformance/test_sec7_1.c
@@ -120,6 +120,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_10.c
+++ b/tests/conformance/test_sec7_10.c
@@ -123,6 +123,11 @@ TEST_ANYXML(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_11.c
+++ b/tests/conformance/test_sec7_11.c
@@ -123,6 +123,11 @@ TEST_GROUPING(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_12_1.c
+++ b/tests/conformance/test_sec7_12_1.c
@@ -123,6 +123,11 @@ TEST_USES(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_12_2.c
+++ b/tests/conformance/test_sec7_12_2.c
@@ -122,6 +122,11 @@ TEST_USES_REFINE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_13_1.c
+++ b/tests/conformance/test_sec7_13_1.c
@@ -123,6 +123,11 @@ TEST_RPC(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_13_2.c
+++ b/tests/conformance/test_sec7_13_2.c
@@ -136,6 +136,11 @@ TEST_RPC_INPUT(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_13_3.c
+++ b/tests/conformance/test_sec7_13_3.c
@@ -143,6 +143,11 @@ TEST_RPC_OUTPUT(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_15_1.c
+++ b/tests/conformance/test_sec7_15_1.c
@@ -121,6 +121,11 @@ TEST_ACTION(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_16_1.c
+++ b/tests/conformance/test_sec7_16_1.c
@@ -123,6 +123,11 @@ TEST_IDENTITY(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_16_2.c
+++ b/tests/conformance/test_sec7_16_2.c
@@ -122,6 +122,11 @@ TEST_IDENTITY_BASE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_18_1.c
+++ b/tests/conformance/test_sec7_18_1.c
@@ -122,6 +122,11 @@ TEST_FEATURE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_18_2.c
+++ b/tests/conformance/test_sec7_18_2.c
@@ -134,6 +134,11 @@ TEST_IFFEATURE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_19_1.c
+++ b/tests/conformance/test_sec7_19_1.c
@@ -122,6 +122,11 @@ TEST_CONFIG(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_19_2.c
+++ b/tests/conformance/test_sec7_19_2.c
@@ -123,6 +123,11 @@ TEST_STATUS(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_19_5.c
+++ b/tests/conformance/test_sec7_19_5.c
@@ -122,6 +122,11 @@ TEST_WHEN(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_2.c
+++ b/tests/conformance/test_sec7_2.c
@@ -120,6 +120,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_3.c
+++ b/tests/conformance/test_sec7_3.c
@@ -120,6 +120,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_3_1.c
+++ b/tests/conformance/test_sec7_3_1.c
@@ -120,6 +120,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_3_4.c
+++ b/tests/conformance/test_sec7_3_4.c
@@ -122,6 +122,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_5_2.c
+++ b/tests/conformance/test_sec7_5_2.c
@@ -120,6 +120,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_5_4.c
+++ b/tests/conformance/test_sec7_5_4.c
@@ -145,6 +145,11 @@ TEST_MODULE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_5_5.c
+++ b/tests/conformance/test_sec7_5_5.c
@@ -122,6 +122,11 @@ TEST_CONTAINER_PRESENCE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_6_2.c
+++ b/tests/conformance/test_sec7_6_2.c
@@ -122,6 +122,11 @@ TEST_LEAF(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_6_3.c
+++ b/tests/conformance/test_sec7_6_3.c
@@ -122,6 +122,11 @@ TEST_LEAF(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_6_4.c
+++ b/tests/conformance/test_sec7_6_4.c
@@ -137,6 +137,11 @@ TEST_LEAF_DEFAULT(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_6_5.c
+++ b/tests/conformance/test_sec7_6_5.c
@@ -122,6 +122,11 @@ TEST_LEAF_MANDATORY(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_7_2.c
+++ b/tests/conformance/test_sec7_7_2.c
@@ -122,6 +122,11 @@ TEST_LEAF_MANDATORY(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_7_3.c
+++ b/tests/conformance/test_sec7_7_3.c
@@ -122,6 +122,11 @@ TEST_LEAFLIST_MINELEMENTS(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_7_4.c
+++ b/tests/conformance/test_sec7_7_4.c
@@ -122,6 +122,11 @@ TEST_LEAFLIST_MINELEMENTS(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_7_5.c
+++ b/tests/conformance/test_sec7_7_5.c
@@ -134,6 +134,11 @@ TEST_LEAFLIST_ORDERED(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_8_1.c
+++ b/tests/conformance/test_sec7_8_1.c
@@ -122,6 +122,11 @@ TEST_LIST(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_8_2.c
+++ b/tests/conformance/test_sec7_8_2.c
@@ -122,6 +122,11 @@ TEST_LIST_KEYS(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_8_3.c
+++ b/tests/conformance/test_sec7_8_3.c
@@ -122,6 +122,11 @@ TEST_LIST_UNIQUE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_9_1.c
+++ b/tests/conformance/test_sec7_9_1.c
@@ -122,6 +122,11 @@ TEST_CHOICE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_9_2.c
+++ b/tests/conformance/test_sec7_9_2.c
@@ -122,6 +122,11 @@ TEST_CHOICE_CASE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_9_3.c
+++ b/tests/conformance/test_sec7_9_3.c
@@ -137,6 +137,11 @@ TEST_LEAF_DEFAULT(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec7_9_4.c
+++ b/tests/conformance/test_sec7_9_4.c
@@ -122,6 +122,11 @@ TEST_CHOICE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_10.c
+++ b/tests/conformance/test_sec9_10.c
@@ -122,6 +122,11 @@ TEST_IDENTITYREF(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_11.c
+++ b/tests/conformance/test_sec9_11.c
@@ -122,6 +122,11 @@ TEST_EMPTY(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_12.c
+++ b/tests/conformance/test_sec9_12.c
@@ -122,6 +122,11 @@ TEST_UNION(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_13.c
+++ b/tests/conformance/test_sec9_13.c
@@ -124,6 +124,11 @@ TEST_INSTANCE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_2.c
+++ b/tests/conformance/test_sec9_2.c
@@ -122,6 +122,11 @@ TEST_RANGE(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_3.c
+++ b/tests/conformance/test_sec9_3.c
@@ -122,6 +122,11 @@ TEST_DECIMAL64(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_4_4.c
+++ b/tests/conformance/test_sec9_4_4.c
@@ -122,6 +122,11 @@ TEST_STRING_LENGTH(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_4_6.c
+++ b/tests/conformance/test_sec9_4_6.c
@@ -122,6 +122,11 @@ TEST_STRING_PATTERN(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_5.c
+++ b/tests/conformance/test_sec9_5.c
@@ -122,6 +122,11 @@ TEST_BOOLEAN(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_6.c
+++ b/tests/conformance/test_sec9_6.c
@@ -122,6 +122,11 @@ TEST_ENUM(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_7.c
+++ b/tests/conformance/test_sec9_7.c
@@ -122,6 +122,11 @@ TEST_BITS(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_8.c
+++ b/tests/conformance/test_sec9_8.c
@@ -122,6 +122,11 @@ TEST_BINARY(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {

--- a/tests/conformance/test_sec9_9.c
+++ b/tests/conformance/test_sec9_9.c
@@ -122,6 +122,11 @@ TEST_LEAFREF(void **state)
             }
 
             schema_format = LYS_IN_YIN;
+            st->ctx = ly_ctx_new(TESTS_DIR "/conformance/" TEST_DIR, 0);
+            if (!st->ctx) {
+                fprintf(stderr, "Failed to create context.\n");
+                fail();
+            }
         } else {
             /* remove the modules */
             for (j = 0; j < TEST_SCHEMA_COUNT; ++j) {


### PR DESCRIPTION
Hi, We found that the test files in conformance should destroy and new context before YIN cycle.
except:
- (test_sec6_1_1.c、test_sec6_1_3.c) are not this test type.
- (test_sec7_18_3_1.c、test_sec7_15.c、test_sec7_18_3_2.c、test_sec7_14.c) are already done.