### PR TITLE
yin parser BUGFIX deviation statement default and mandatory coredump

### DIFF
--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -2788,7 +2788,7 @@ fill_yin_deviation(struct lys_module *module, struct lyxml_elem *yin, struct lys
                 /* check collision with mandatory/min-elements */
                 if ((dev_target->flags & LYS_MAND_TRUE) ||
                         (dev_target->nodetype == LYS_LEAFLIST && ((struct lys_node_leaflist *)dev_target)->min)) {
-                    LOGVAL(ctx, LYE_INCHILDSTMT, LY_VLOG_NONE, NULL, child->name, child->parent->name);
+                    LOGVAL(ctx, LYE_INCHILDSTMT, LY_VLOG_NONE, NULL, "default", "deviation");
                     LOGVAL(ctx, LYE_SPEC, LY_VLOG_NONE, NULL,
                            "Adding the \"default\" statement is forbidden on %s statement.",
                            (dev_target->flags & LYS_MAND_TRUE) ? "nodes with the \"mandatory\"" : "leaflists with non-zero \"min-elements\"");
@@ -2798,7 +2798,7 @@ fill_yin_deviation(struct lys_module *module, struct lyxml_elem *yin, struct lys
                 /* check that there was a value before */
                 if (((dev_target->nodetype & (LYS_LEAF | LYS_LEAFLIST)) && !((struct lys_node_leaf *)dev_target)->dflt) ||
                         (dev_target->nodetype == LYS_CHOICE && !((struct lys_node_choice *)dev_target)->dflt)) {
-                    LOGVAL(ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, child->name);
+                    LOGVAL(ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, "default");
                     LOGVAL(ctx, LYE_SPEC, LY_VLOG_NONE, NULL, "Replacing a property that does not exist.");
                     goto error;
                 }


### PR DESCRIPTION
Hi,
I have encountered a segment fault when I tried to write some testcases about yin parser.
`mod1.yin`

```
<?xml version="1.0" encoding="UTF-8"?>
<module name="mod1"
               xmlns="urn:ietf:params:xml:ns:yang:yin:1"
               xmlns:m1="urn:mod1"
               xmlns:m2="urn:mod2">
      <yang-version value="1.1"/>
      <namespace uri="urn:mod1"/>
      <prefix value="m1"/>
      <import module="mod2">
      <prefix value="m2"/>
          </import>
      <deviation target-node="/m2:con/m2:leaf1">
           <deviate value="add">
               <default value="Tom"/>
           </deviate>
      </deviation>
</module>

```
`mod2.yin`

```
<?xml version="1.0" encoding="UTF-8"?>
<module name="mod2"
               xmlns="urn:ietf:params:xml:ns:yang:yin:1"
               xmlns:m2="urn:mod2">
        <yang-version value="1.1"/>
        <namespace uri="urn:mod2"/>
        <prefix value="m2"/>
        <container name="con">
              <leaf name="leaf1">
                   <type name="string"/>
                   <mandatory value="true"/>
              </leaf>
              <leaf name="leaf2">
                    <type name="int8"/>
              </leaf>
              <list name="list1">
                    <key value="leaf3"/>
                    <leaf name="leaf3">
                         <type name="uint16"/>
                    </leaf>
                    <leaf name="leaf4">
                         <type name="uint8"/>
                    </leaf>
              </list>
        </container>
</module>

```
The result is that:
`Segmentation fault (core dumped)`


