### PR TITLE
Fix for multiple anyxml siblings not duplicated

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -214,6 +214,10 @@ lyxml_dup_elem(struct ly_ctx *ctx, struct lyxml_elem *elem, struct lyxml_elem *p
 
         if (parent) {
             lyxml_add_child(ctx, parent, dup);
+        } else if (result) {
+            dup->prev = result->prev;
+            dup->prev->next = dup;
+            result->prev = dup;
         }
 
         /* keep old namespace for now */


### PR DESCRIPTION
This is fix for the issue wherein if an anyxml node has a list of child node then only first child is duplicated in the data and rest are not by the current code which is also leading to memory leak.

Consider the following yang:
```
list student {
      key "name";
      leaf name {
        type string;
     }
}

notification message {
    anyxml data;
}
```
and corresponding data be like as follows:
```
<message>
   <data>
      <student>
         <name>abc</name>
      </student>
      <student>
         <name>def</name>
      </student>
      <student>
         <name>xyz</name>
      </student>
   </data>
</message>
```
if try to duplicate this data using let's say following code of netopeer2/server:
  `ntf_msg = nc_server_notif_new(ntf, datetime, NC_PARAMTYPE_DUP_AND_FREE);`
then you will find that ntf_msg has all the duplicate data of ntf but the anyxml node has only one entry i.e. node having name as `abc`.