### PR TITLE
Prevention check for crash if missing rpc name/namespace in received …

### DIFF
--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -667,6 +667,11 @@ lyd_parse_xml(struct ly_ctx *ctx, struct lyxml_elem **root, int options, ...)
         xmlstart = *root;
     }
 
+    if((options & LYD_OPT_RPC) && (!(xmlstart->name) || !(xmlstart->ns))) {
+        LOGERR(ctx, LY_EINVAL, "Either name or namespace is missing in received rpc");
+        goto error;
+    }
+
     if ((options & LYD_OPT_RPC)
             && !strcmp(xmlstart->name, "action") && !strcmp(xmlstart->ns->value, "urn:ietf:params:xml:ns:yang:1")) {
         /* it's an action, not a simple RPC */


### PR DESCRIPTION
This is fix for crash observed while executing codenomicon (a tool by Defensics) scan executed on Netconf server.

The crash was due to following anomaly packet received by the server. The rpc request has following format:
`<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">\r\n\\  <close-session/></rpc>]]>]]>`

The backtrace of the issue is as follows:
```
#0  .__strcmp_ppc () at ../sysdeps/powerpc/powerpc64/strcmp.S:51
#1  0x00003fff92470d6c in lyd_parse_xml (ctx=0x3fff48000b50, root=0x3fff4804a558, options=34320) at /usr/src/project/libyang/src/parser_xml.c:669
#2  0x00003fff90547820 in nc_server_recv_rpc_io (session=0x3fff487042f0, io_timeout=0, rpc=0x3fff6cbd9ba0) at /usr/src/project/libnetconf2/src/session_server.c:1173
#3  0x00003fff9054899c in nc_ps_poll (ps=0x3fff487a1e90, timeout=0, session=0x3fff6cbd9c40) at /usr/src/project/libnetconf2/src/session_server.c:1630
#4  0x00003fff920face8 in worker_thread (arg=0x3fff48794870) at /localdisk/project/ddm-netconf/ddf_netconf_im.c:619
#5  0x00003fff90d90d10 in start_thread (arg=0x3fff6cbda680) at /usr/src/project/glibc/nptl/pthread_create.c:465
#6  0x00003fff90cd2ba0 in .__clone () at ../sysdeps/unix/sysv/linux/powerpc/powerpc64/clone.S:82
```