### PR TITLE
libyang2: Fix static build issues caused by yangobj set_target_properties call.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,10 +272,11 @@ else()
 
     #link dl
     target_link_libraries(yang ${CMAKE_DL_LIBS})
+    
+    set_target_properties(yangobj PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")
 endif(ENABLE_STATIC)
 
 set_target_properties(yang PROPERTIES VERSION ${LIBYANG_SOVERSION_FULL} SOVERSION ${LIBYANG_SOVERSION})
-set_target_properties(yangobj PROPERTIES COMPILE_FLAGS "-fvisibility=hidden")
 
 # link math
 target_link_libraries(yang m)


### PR DESCRIPTION
Hello,

I was trying to build libyang as a static library on the libyang2 branch, however, the build failed with the following error:

```CMake Error at CMakeLists.txt:278 (set_target_properties): set_target_properties Can not find target to add properties to: yangobj```

I managed to fix the issue by moving the yangobj set_target_properties call so that it is only called for a shared library build, like on the master branch.

Regards,
Juraj