### PR TITLE
Print info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ set(libsrc
     src/tree_data_hash.c
     src/parser_xml.c
     src/parser_json.c
+    src/printer.c
     src/printer_data.c
     src/printer_xml.c
     src/printer_json.c
@@ -249,6 +250,7 @@ set(headers
     src/context.h
     src/tree.h
     src/tree_data.h
+    src/printer.h
     src/printer_data.h
     src/tree_schema.h
     src/printer_schema.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ if(DOXYGEN_FOUND)
     add_custom_target(doc
             COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    string(REPLACE ";" " " DOXY_HEADERS "${headers}")
     configure_file(Doxyfile.in Doxyfile)
 endif()
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -561,7 +561,7 @@ INLINE_INFO            = YES
 # name. If set to NO, the members will appear in declaration order.
 # The default value is: YES.
 
-SORT_MEMBER_DOCS       = NO
+SORT_MEMBER_DOCS       = YES
 
 # If the SORT_BRIEF_DOCS tag is set to YES then doxygen will sort the brief
 # descriptions of file, namespace and class members alphabetically by member
@@ -569,7 +569,7 @@ SORT_MEMBER_DOCS       = NO
 # this will also influence the order of the classes in the class list.
 # The default value is: NO.
 
-SORT_BRIEF_DOCS        = NO
+SORT_BRIEF_DOCS        = YES
 
 # If the SORT_MEMBERS_CTORS_1ST tag is set to YES then doxygen will sort the
 # (brief and detailed) documentation of class members so that constructors and
@@ -581,14 +581,14 @@ SORT_BRIEF_DOCS        = NO
 # detailed member documentation.
 # The default value is: NO.
 
-SORT_MEMBERS_CTORS_1ST = NO
+SORT_MEMBERS_CTORS_1ST = YES
 
 # If the SORT_GROUP_NAMES tag is set to YES then doxygen will sort the hierarchy
 # of group names into alphabetical order. If set to NO the group names will
 # appear in their defined order.
 # The default value is: NO.
 
-SORT_GROUP_NAMES       = NO
+SORT_GROUP_NAMES       = YES
 
 # If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
 # fully-qualified names, including namespaces. If set to NO, the class list will
@@ -781,16 +781,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ./src/libyang.h \
-			 ./src/context.h \
-			 ./src/tree.h \
-                         ./src/tree_schema.h \
-                         ./src/plugins_types.h \
-                         ./src/plugins_exts.h \
-                         ./src/tree_data.h \
-                         ./src/log.h \
-                         ./src/set.h \
-                         ./src/dict.h
+INPUT                  = @DOXY_HEADERS@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/libyang.h
+++ b/src/libyang.h
@@ -28,6 +28,8 @@ extern "C" {
 #include "tree.h"
 #include "tree_data.h"
 #include "tree_schema.h"
+#include "printer.h"
+#include "printer_data.h"
 #include "printer_schema.h"
 #include "printer_data.h"
 #include "plugins_types.h"

--- a/src/printer.c
+++ b/src/printer.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <assert.h>
 
@@ -143,61 +144,371 @@ ly_should_print(const struct lyd_node *node, int options)
     return 1;
 }
 
-LY_ERR
-ly_print(struct lyout *out, const char *format, ...)
+API LYP_OUT_TYPE
+lyp_out_type(const struct lyp_out *out)
+{
+    LY_CHECK_ARG_RET(NULL, out, LYP_OUT_ERROR);
+    return out->type;
+}
+
+API struct lyp_out *
+lyp_new_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg)
+{
+    struct lyp_out *out;
+
+    out = calloc(1, sizeof *out);
+    LY_CHECK_ERR_RET(!out, LOGMEM(NULL), NULL);
+
+    out->type = LYP_OUT_CALLBACK;
+    out->method.clb.func = writeclb;
+    out->method.clb.arg = arg;
+
+    return out;
+}
+
+API ssize_t (*lyp_clb(struct lyp_out *out, ssize_t (*writeclb)(void *arg, const void *buf, size_t count)))(void *arg, const void *buf, size_t count)
+{
+    void *prev_clb;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type == LYP_OUT_CALLBACK, NULL);
+
+    prev_clb = out->method.clb.func;
+
+    if (writeclb) {
+        out->method.clb.func = writeclb;
+    }
+
+    return prev_clb;
+}
+
+API void *
+lyp_clb_arg(struct lyp_out *out, void *arg)
+{
+    void *prev_arg;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type == LYP_OUT_CALLBACK, NULL);
+
+    prev_arg = out->method.clb.arg;
+
+    if (arg) {
+        out->method.clb.arg = arg;
+    }
+
+    return prev_arg;
+}
+
+API struct lyp_out *
+lyp_new_fd(int fd)
+{
+    struct lyp_out *out;
+
+    out = calloc(1, sizeof *out);
+    LY_CHECK_ERR_RET(!out, LOGMEM(NULL), NULL);
+
+#ifdef HAVE_VDPRINTF
+    out->type = LYP_OUT_FD;
+    out->method.fd = fd;
+#else
+    /* Without vdfprintf(), change the printing method to printing to a FILE stream.
+     * To preserve the original file descriptor, duplicate it and use it to open file stream. */
+    out->type = LYP_OUT_FDSTREAM;
+    out->method.fdstream.fd = fd;
+
+    fd = dup(out->method.fdstream.fd);
+    if (fd < 0) {
+        LOGERR(NULL, LY_ESYS, "Unable to duplicate provided file descriptor (%d) for printing the output (%s).",
+               out->method.fdstream.fd, strerror(errno));
+        free(out);
+        return NULL;
+    }
+    out->method.fdstream.f = fdopen(fd, "a");
+    if (!out->method.fdstream.f) {
+        LOGERR(NULL, LY_ESYS, "Unable to open provided file descriptor (%d) for printing the output (%s).",
+               out->method.fdstream.fd, strerror(errno));
+        free(out);
+        fclose(fd);
+        return NULL;
+    }
+#endif
+
+    return out;
+}
+
+API int
+lyp_fd(struct lyp_out *out, int fd)
+{
+    int prev_fd;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type <= LYP_OUT_FDSTREAM, -1);
+
+    if (out->type == LYP_OUT_FDSTREAM) {
+        prev_fd = out->method.fdstream.fd;
+    } else { /* LYP_OUT_FD */
+        prev_fd = out->method.fd;
+    }
+
+    if (fd != -1) {
+        /* replace output stream */
+        if (out->type == LYP_OUT_FDSTREAM) {
+            int streamfd;
+            FILE *stream;
+
+            streamfd = dup(fd);
+            if (streamfd < 0) {
+                LOGERR(NULL, LY_ESYS, "Unable to duplicate provided file descriptor (%d) for printing the output (%s).", fd, strerror(errno));
+                return -1;
+            }
+            stream = fdopen(streamfd, "a");
+            if (!stream) {
+                LOGERR(NULL, LY_ESYS, "Unable to open provided file descriptor (%d) for printing the output (%s).", fd, strerror(errno));
+                close(streamfd);
+                return -1;
+            }
+            /* close only the internally created stream, file descriptor is returned and supposed to be closed by the caller */
+            fclose(out->method.fdstream.f);
+            out->method.fdstream.f = stream;
+            out->method.fdstream.fd = streamfd;
+        } else { /* LYP_OUT_FD */
+            out->method.fd = fd;
+        }
+    }
+
+    return prev_fd;
+}
+
+API struct lyp_out *
+lyp_new_file(FILE *f)
+{
+    struct lyp_out *out;
+
+    out = calloc(1, sizeof *out);
+    LY_CHECK_ERR_RET(!out, LOGMEM(NULL), NULL);
+
+    out->type = LYP_OUT_FILE;
+    out->method.f = f;
+
+    return out;
+}
+
+API FILE *
+lyp_file(struct lyp_out *out, FILE *f)
+{
+    FILE *prev_f;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type == LYP_OUT_FILE, NULL);
+
+    prev_f = out->method.f;
+
+    if (f) {
+        out->method.f = f;
+    }
+
+    return prev_f;
+}
+
+API struct lyp_out *
+lyp_new_memory(char **strp, size_t size)
+{
+    struct lyp_out *out;
+
+    out = calloc(1, sizeof *out);
+    LY_CHECK_ERR_RET(!out, LOGMEM(NULL), NULL);
+
+    out->type = LYP_OUT_MEMORY;
+    out->method.mem.buf = strp;
+    if (!size) {
+        /* buffer is supposed to be allocated */
+        *strp = NULL;
+    } else if (*strp) {
+        /* there is already buffer to use */
+        out->method.mem.size = size;
+    }
+
+    return out;
+}
+
+char *
+lyp_memory(struct lyp_out *out, char **strp, size_t size)
+{
+    char *data;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type == LYP_OUT_MEMORY, NULL);
+
+    data = *out->method.mem.buf;
+
+    if (strp) {
+        out->method.mem.buf = strp;
+        out->method.mem.len = out->method.mem.size = 0;
+        out->printed = 0;
+        if (!size) {
+            /* buffer is supposed to be allocated */
+            *strp = NULL;
+        } else if (*strp) {
+            /* there is already buffer to use */
+            out->method.mem.size = size;
+        }
+    }
+
+    return data;
+}
+
+API LY_ERR
+lyp_out_reset(struct lyp_out *out)
+{
+    LY_CHECK_ARG_RET(NULL, out, LY_EINVAL);
+
+    switch(out->type) {
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
+        return LY_EINT;
+    case LYP_OUT_FD:
+        if ((lseek(out->method.fd, 0, SEEK_SET) == -1) && errno != ESPIPE) {
+            LOGERR(NULL, LY_ESYS, "Seeking output file descriptor failed (%s).", strerror(errno));
+            return LY_ESYS;
+        }
+        break;
+    case LYP_OUT_FDSTREAM:
+    case LYP_OUT_FILE:
+    case LYP_OUT_FILEPATH:
+        if ((fseek(out->method.f, 0, SEEK_SET) == -1) && errno != ESPIPE) {
+            LOGERR(NULL, LY_ESYS, "Seeking output file stream failed (%s).", strerror(errno));
+            return LY_ESYS;
+        }
+        break;
+    case LYP_OUT_MEMORY:
+        out->printed = 0;
+        out->method.mem.len = 0;
+        break;
+    case LYP_OUT_CALLBACK:
+        /* nothing to do (not seekable) */
+        break;
+    }
+
+    return LY_SUCCESS;
+}
+
+API struct lyp_out *
+lyp_new_filepath(const char *filepath)
+{
+    struct lyp_out *out;
+
+    out = calloc(1, sizeof *out);
+    LY_CHECK_ERR_RET(!out, LOGMEM(NULL), NULL);
+
+    out->type = LYP_OUT_FILEPATH;
+    out->method.fpath.f = fopen(filepath, "w");
+    if (!out->method.fpath.f) {
+        LOGERR(NULL, LY_ESYS, "Failed to open file \"%s\" (%s).", filepath, strerror(errno));
+        return NULL;
+    }
+    out->method.fpath.filepath = strdup(filepath);
+    return out;
+}
+
+API const char *
+lyp_filepath(struct lyp_out *out, const char *filepath)
+{
+    FILE *f;
+
+    LY_CHECK_ARG_RET(NULL, out, out->type == LYP_OUT_FILEPATH, filepath ? NULL : ((void *)-1));
+
+    if (!filepath) {
+        return out->method.fpath.filepath;
+    }
+
+    /* replace filepath */
+    f = out->method.fpath.f;
+    out->method.fpath.f = fopen(filepath, "w");
+    if (!out->method.fpath.f) {
+        LOGERR(NULL, LY_ESYS, "Failed to open file \"%s\" (%s).", filepath, strerror(errno));
+        out->method.fpath.f = f;
+        return ((void *)-1);
+    }
+    fclose(f);
+    free(out->method.fpath.filepath);
+    out->method.fpath.filepath = strdup(filepath);
+
+    return NULL;
+}
+
+API void
+lyp_free(struct lyp_out *out, void (*clb_arg_destructor)(void *arg), int destroy)
+{
+    if (!out) {
+        return;
+    }
+
+    switch (out->type) {
+    case LYP_OUT_CALLBACK:
+        if (clb_arg_destructor) {
+            clb_arg_destructor(out->method.clb.arg);
+        }
+        break;
+    case LYP_OUT_FDSTREAM:
+        fclose(out->method.fdstream.f);
+        if (destroy) {
+            close(out->method.fdstream.fd);
+        }
+        break;
+    case LYP_OUT_FD:
+        if (destroy) {
+            close(out->method.fd);
+        }
+        break;
+    case LYP_OUT_FILE:
+        if (destroy) {
+            fclose(out->method.f);
+        }
+        break;
+    case LYP_OUT_MEMORY:
+        if (destroy) {
+            free(*out->method.mem.buf);
+        }
+        break;
+    case LYP_OUT_FILEPATH:
+        free(out->method.fpath.filepath);
+        if (destroy) {
+            fclose(out->method.fpath.f);
+        }
+        break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
+    }
+    free(out);
+}
+
+API LY_ERR
+lyp_print(struct lyp_out *out, const char *format, ...)
 {
     int count = 0;
     char *msg = NULL, *aux;
     va_list ap;
-#ifndef HAVE_VDPRINTF
-    int fd;
-    FILE *stream;
-#endif
 
     LYOUT_CHECK(out, out->status);
 
     va_start(ap, format);
 
     switch (out->type) {
-    case LYOUT_FD:
+    case LYP_OUT_FD:
 #ifdef HAVE_VDPRINTF
         count = vdprintf(out->method.fd, format, ap);
         break;
 #else
-        /* Without vdfprintf(), change the printing method to printing to a FILE stream.
-         * To preserve the original file descriptor, duplicate it and use it to open file stream.
-         * Due to a standalone LYOUT_FDSTREAM, ly*_print_fd() functions are supposed to detect the
-         * change and close the stream on their exit. */
-        fd = dup(out->method.fd);
-        if (fd < 0) {
-            LOGERR(NULL, LY_ESYS, "Unable to duplicate provided file descriptor (%d) for printing the output (%s).",
-                   out->method.fd, strerror(errno));
-            va_end(ap);
-            out->status = LY_ESYS;
-            return LY_ESYS;
-        }
-        stream = fdopen(fd, "a");
-        if (!stream) {
-            LOGERR(NULL, LY_ESYS, "Unable to open provided file descriptor (%d) for printing the output (%s).",
-                   out->method.fd, strerror(errno));
-            va_end(ap);
-            out->status = LY_ESYS;
-            return LY_ESYS;
-        }
-        out->method.f = stream;
-        out->type = LYOUT_FDSTREAM;
+        /* never should be here since lyp_fd() is supposed to set type to LYP_OUT_FDSTREAM in case vdprintf() is missing */
+        LOGINT(NULL);
+        return LY_EINT;
 #endif
-        /* fall through */
-    case LYOUT_FDSTREAM:
-    case LYOUT_STREAM:
+    case LYP_OUT_FDSTREAM:
+    case LYP_OUT_FILEPATH:
+    case LYP_OUT_FILE:
         count = vfprintf(out->method.f, format, ap);
         break;
-    case LYOUT_MEMORY:
+    case LYP_OUT_MEMORY:
         if ((count = vasprintf(&msg, format, ap)) < 0) {
             break;
         }
         if (out->method.mem.len + count + 1 > out->method.mem.size) {
-            aux = ly_realloc(out->method.mem.buf, out->method.mem.len + count + 1);
+            aux = ly_realloc(*out->method.mem.buf, out->method.mem.len + count + 1);
             if (!aux) {
                 out->method.mem.buf = NULL;
                 out->method.mem.len = 0;
@@ -206,21 +517,23 @@ ly_print(struct lyout *out, const char *format, ...)
                 va_end(ap);
                 return LY_EMEM;
             }
-            out->method.mem.buf = aux;
+            *out->method.mem.buf = aux;
             out->method.mem.size = out->method.mem.len + count + 1;
         }
-        memcpy(&out->method.mem.buf[out->method.mem.len], msg, count);
+        memcpy(&(*out->method.mem.buf)[out->method.mem.len], msg, count);
         out->method.mem.len += count;
-        out->method.mem.buf[out->method.mem.len] = '\0';
+        (*out->method.mem.buf)[out->method.mem.len] = '\0';
         free(msg);
         break;
-    case LYOUT_CALLBACK:
+    case LYP_OUT_CALLBACK:
         if ((count = vasprintf(&msg, format, ap)) < 0) {
             break;
         }
-        count = out->method.clb.f(out->method.clb.arg, msg, count);
+        count = out->method.clb.func(out->method.clb.arg, msg, count);
         free(msg);
         break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
     }
 
     va_end(ap);
@@ -230,34 +543,45 @@ ly_print(struct lyout *out, const char *format, ...)
         out->status = LY_ESYS;
         return LY_ESYS;
     } else {
+        if (out->type == LYP_OUT_FDSTREAM) {
+            /* move the original file descriptor to the end of the output file */
+            lseek(out->method.fdstream.fd, 0, SEEK_END);
+        }
         out->printed += count;
         return LY_SUCCESS;
     }
 }
 
 void
-ly_print_flush(struct lyout *out)
+ly_print_flush(struct lyp_out *out)
 {
     switch (out->type) {
-    case LYOUT_FDSTREAM:
-    case LYOUT_STREAM:
+    case LYP_OUT_FDSTREAM:
+        /* move the original file descriptor to the end of the output file */
+        lseek(out->method.fdstream.fd, 0, SEEK_END);
+        fflush(out->method.fdstream.f);
+        break;
+    case LYP_OUT_FILEPATH:
+    case LYP_OUT_FILE:
         fflush(out->method.f);
         break;
-    case LYOUT_FD:
+    case LYP_OUT_FD:
         fsync(out->method.fd);
         break;
-    case LYOUT_MEMORY:
-    case LYOUT_CALLBACK:
+    case LYP_OUT_MEMORY:
+    case LYP_OUT_CALLBACK:
         /* nothing to do */
         break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
     }
 
     free(out->buffered);
     out->buf_size = out->buf_len = 0;
 }
 
-LY_ERR
-ly_write(struct lyout *out, const char *buf, size_t len)
+API LY_ERR
+lyp_write(struct lyp_out *out, const char *buf, size_t len)
 {
     int written = 0;
 
@@ -282,32 +606,35 @@ ly_write(struct lyout *out, const char *buf, size_t len)
 
 repeat:
     switch (out->type) {
-    case LYOUT_MEMORY:
+    case LYP_OUT_MEMORY:
         if (out->method.mem.len + len + 1 > out->method.mem.size) {
-            out->method.mem.buf = ly_realloc(out->method.mem.buf, out->method.mem.len + len + 1);
-            if (!out->method.mem.buf) {
+            *out->method.mem.buf = ly_realloc(*out->method.mem.buf, out->method.mem.len + len + 1);
+            if (!*out->method.mem.buf) {
                 out->method.mem.len = 0;
                 out->method.mem.size = 0;
                 LOGMEM_RET(NULL);
             }
             out->method.mem.size = out->method.mem.len + len + 1;
         }
-        memcpy(&out->method.mem.buf[out->method.mem.len], buf, len);
+        memcpy(&(*out->method.mem.buf)[out->method.mem.len], buf, len);
         out->method.mem.len += len;
-        out->method.mem.buf[out->method.mem.len] = '\0';
+        (*out->method.mem.buf)[out->method.mem.len] = '\0';
 
         out->printed += len;
         return LY_SUCCESS;
-    case LYOUT_FD:
+    case LYP_OUT_FD:
         written = write(out->method.fd, buf, len);
         break;
-    case LYOUT_FDSTREAM:
-    case LYOUT_STREAM:
+    case LYP_OUT_FDSTREAM:
+    case LYP_OUT_FILEPATH:
+    case LYP_OUT_FILE:
         written =  fwrite(buf, sizeof *buf, len, out->method.f);
         break;
-    case LYOUT_CALLBACK:
-        written = out->method.clb.f(out->method.clb.arg, buf, len);
+    case LYP_OUT_CALLBACK:
+        written = out->method.clb.func(out->method.clb.arg, buf, len);
         break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
     }
 
     if (written < 0) {
@@ -322,21 +649,25 @@ repeat:
         out->status = LY_ESYS;
         return LY_ESYS;
     } else {
+        if (out->type == LYP_OUT_FDSTREAM) {
+            /* move the original file descriptor to the end of the output file */
+            lseek(out->method.fdstream.fd, 0, SEEK_END);
+        }
         out->printed += written;
         return LY_SUCCESS;
     }
 }
 
 LY_ERR
-ly_write_skip(struct lyout *out, size_t count, size_t *position)
+ly_write_skip(struct lyp_out *out, size_t count, size_t *position)
 {
     LYOUT_CHECK(out, out->status);
 
     switch (out->type) {
-    case LYOUT_MEMORY:
+    case LYP_OUT_MEMORY:
         if (out->method.mem.len + count > out->method.mem.size) {
-            out->method.mem.buf = ly_realloc(out->method.mem.buf, out->method.mem.len + count);
-            if (!out->method.mem.buf) {
+            *out->method.mem.buf = ly_realloc(*out->method.mem.buf, out->method.mem.len + count);
+            if (!(*out->method.mem.buf)) {
                 out->method.mem.len = 0;
                 out->method.mem.size = 0;
                 out->status = LY_ESYS;
@@ -354,10 +685,11 @@ ly_write_skip(struct lyout *out, size_t count, size_t *position)
         /* update printed bytes counter despite we actually printed just a hole */
         out->printed += count;
         break;
-    case LYOUT_FD:
-    case LYOUT_FDSTREAM:
-    case LYOUT_STREAM:
-    case LYOUT_CALLBACK:
+    case LYP_OUT_FD:
+    case LYP_OUT_FDSTREAM:
+    case LYP_OUT_FILEPATH:
+    case LYP_OUT_FILE:
+    case LYP_OUT_CALLBACK:
         /* buffer the hole */
         if (out->buf_len + count > out->buf_size) {
             out->buffered = ly_realloc(out->buffered, out->buf_len + count);
@@ -378,27 +710,32 @@ ly_write_skip(struct lyout *out, size_t count, size_t *position)
 
         /* increase hole counter */
         ++out->hole_count;
+
+        break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
     }
 
     return LY_SUCCESS;
 }
 
 LY_ERR
-ly_write_skipped(struct lyout *out, size_t position, const char *buf, size_t count)
+ly_write_skipped(struct lyp_out *out, size_t position, const char *buf, size_t count)
 {
     LY_ERR ret = LY_SUCCESS;
 
     LYOUT_CHECK(out, out->status);
 
     switch (out->type) {
-    case LYOUT_MEMORY:
+    case LYP_OUT_MEMORY:
         /* write */
-        memcpy(&out->method.mem.buf[position], buf, count);
+        memcpy(&(*out->method.mem.buf)[position], buf, count);
         break;
-    case LYOUT_FD:
-    case LYOUT_FDSTREAM:
-    case LYOUT_STREAM:
-    case LYOUT_CALLBACK:
+    case LYP_OUT_FD:
+    case LYP_OUT_FDSTREAM:
+    case LYP_OUT_FILEPATH:
+    case LYP_OUT_FILE:
+    case LYP_OUT_CALLBACK:
         if (out->buf_len < position + count) {
             out->status = LY_ESYS;
             LOGMEM_RET(NULL);
@@ -413,11 +750,17 @@ ly_write_skipped(struct lyout *out, size_t position, const char *buf, size_t cou
         if (!out->hole_count) {
             /* all holes filled, we can write the buffer,
              * printed bytes counter is updated by ly_write() */
-            ret = ly_write(out, out->buffered, out->buf_len);
+            ret = lyp_write(out, out->buffered, out->buf_len);
             out->buf_len = 0;
         }
         break;
+    case LYP_OUT_ERROR:
+        LOGINT(NULL);
     }
 
+    if (out->type == LYP_OUT_FILEPATH) {
+        /* move the original file descriptor to the end of the output file */
+        lseek(out->method.fdstream.fd, 0, SEEK_END);
+    }
     return ret;
 }

--- a/src/printer.h
+++ b/src/printer.h
@@ -1,0 +1,208 @@
+/**
+ * @file printer.h
+ * @author Radek Krejci <rkrejci@cesnet.cz>
+ * @brief Generic libyang printer structures and functions
+ *
+ * Copyright (c) 2015-2019 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#ifndef LY_PRINTER_H_
+#define LY_PRINTER_H_
+
+#include <unistd.h>
+
+/**
+ * @brief Printer output structure specifying where the data are printed.
+ */
+struct lyp_out;
+
+/**
+ * @brief Types of the printer's output
+ */
+typedef enum LYP_OUT_TYPE {
+    LYP_OUT_ERROR = -1,  /**< error value to indicate failure of the functions returning LYP_OUT_TYPE */
+    LYP_OUT_FD,          /**< file descriptor printer */
+    LYP_OUT_FDSTREAM,    /**< internal replacement for LYP_OUT_FD in case vdprintf() is not available */
+    LYP_OUT_FILE,        /**< FILE stream printer */
+    LYP_OUT_FILEPATH,    /**< filepath printer */
+    LYP_OUT_MEMORY,      /**< memory printer */
+    LYP_OUT_CALLBACK     /**< callback printer */
+} LYP_OUT_TYPE;
+
+/**
+ * @brief Get output type of the printer handler.
+ *
+ * @param[in] out Printer handler.
+ * @return Type of the printer's output.
+ */
+LYP_OUT_TYPE lyp_out_type(const struct lyp_out *out);
+
+/**
+ * @brief Reset the output medium to write from its beginning, so the following printer function will rewrite the current data
+ * instead of appending.
+ *
+ * Note that in case the underlying output is not seekable (stream referring a pipe/FIFO/socket or the callback output type),
+ * nothing actually happens despite the function succeeds. Also note that the medium is not returned to the state it was when
+ * the handler was created. For example, file is seeked into the offset zero, not to the offset where it was opened when
+ * lyp_new_file() was called.
+ *
+ * @param[in] out Printer handler.
+ * @return LY_SUCCESS in case of success
+ * @return LY_ESYS in case of failure
+ */
+LY_ERR lyp_out_reset(struct lyp_out *out);
+
+/**
+ * @brief Create printer handler using callback printer function.
+ *
+ * @param[in] writeclb Pointer to the printer callback function writing the data (see write(2)).
+ * @param[in] arg Optional caller-specific argument to be passed to the @p writeclb callback.
+ * @return NULL in case of memory allocation error.
+ * @return Created printer handler supposed to be passed to different ly*_print_*() functions.
+ */
+struct lyp_out *lyp_new_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg);
+
+/**
+ * @brief Get or reset callback function associated with a callback printer handler.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] fd Optional value of a new file descriptor for the handler. If -1, only the current file descriptor value is returned.
+ * @return Previous value of the file descriptor.
+ */
+ssize_t (*lyp_clb(struct lyp_out *out, ssize_t (*writeclb)(void *arg, const void *buf, size_t count)))(void *arg, const void *buf, size_t count);
+
+/**
+ * @brief Get or reset callback function's argument aasociated with a callback printer handler.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] arg caller-specific argument to be passed to the callback function associated with the printer handler.
+ * If NULL, only the current file descriptor value is returned.
+ * @return The previous callback argument.
+ */
+void *lyp_clb_arg(struct lyp_out *out, void *arg);
+
+/**
+ * @brief Create printer handler using file descriptor.
+ *
+ * @param[in] fd File descriptor to use.
+ * @return NULL in case of error.
+ * @return Created printer handler supposed to be passed to different ly*_print_*() functions.
+ */
+struct lyp_out *lyp_new_fd(int fd);
+
+/**
+ * @brief Get or reset file descriptor printer handler.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] fd Optional value of a new file descriptor for the handler. If -1, only the current file descriptor value is returned.
+ * @return Previous value of the file descriptor. Note that caller is responsible for closing the returned file descriptor in case of setting new descriptor @p fd.
+ * @return -1 in case of error when setting up the new file descriptor.
+ */
+int lyp_fd(struct lyp_out *out, int fd);
+
+/**
+ * @brief Create printer handler using file stream.
+ *
+ * @param[in] f File stream to use.
+ * @return NULL in case of error.
+ * @return Created printer handler supposed to be passed to different ly*_print_*() functions.
+ */
+struct lyp_out *lyp_new_file(FILE *f);
+
+/**
+ * @brief Get or reset file stream printer handler.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] f Optional new file stream for the handler. If NULL, only the current file stream is returned.
+ * @return Previous file stream of the handler. Note that caller is responsible for closing the returned stream in case of setting new stream @p f.
+ */
+FILE *lyp_file(struct lyp_out *out, FILE *f);
+
+/**
+ * @brief Create printer handler using memory to dump data.
+ *
+ * @param[in] strp Pointer to store the resulting data. If it points to a pointer to an allocated buffer and
+ * @p size of the buffer is set, the buffer is used (and extended if needed) to store the printed data.
+ * @param[in] size Size of the buffer provided via @p strp. In case it is 0, the buffer for the printed data
+ * is newly allocated even if @p strp points to a pointer to an existing buffer.
+ * @return NULL in case of error.
+ * @return Created printer handler supposed to be passed to different ly*_print_*() functions.
+ */
+struct lyp_out *lyp_new_memory(char **strp, size_t size);
+
+/**
+ * @brief Get or change memory where the data are dumped.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] strp A new string pointer to store the resulting data, same rules as in lyp_new_memory() are applied.
+ * @param[in] size Size of the buffer provided via @p strp. In case it is 0, the buffer for the printed data
+ * is newly allocated even if @p strp points to a pointer to an existing buffer.
+ * @return Previous dumped data. Note that the caller is responsible to free the data in case of changing string pointer @p strp.
+ */
+char *lyp_memory(struct lyp_out *out, char **strp, size_t size);
+
+/**
+ * @brief Create printer handler file of the given filename.
+ *
+ * @param[in] filepath Path of the file where to write data.
+ * @return NULL in case of error.
+ * @return Created printer handler supposed to be passed to different ly*_print_*() functions.
+ */
+struct lyp_out *lyp_new_filepath(const char *filepath);
+
+/**
+ * @brief Get or change the filepath of the file where the printer prints the data.
+ *
+ * Note that in case of changing the filepath, the current file is closed and a new one is
+ * created/opened instead of renaming the previous file. Also note that the previous filepath
+ * string is returned only in case of not changing it's value.
+ *
+ * @param[in] out Printer handler.
+ * @param[in] filepath Optional new filepath for the handler. If and only if NULL, the current filepath string is returned.
+ * @return Previous filepath string in case the @p filepath argument is NULL.
+ * @return NULL if changing filepath succeedes and ((void *)-1) otherwise.
+ */
+const char *lyp_filepath(struct lyp_out *out, const char *filepath);
+
+/**
+ * @brief Generic printer of the given format string into the specified output.
+ *
+ * Alternatively, lyp_write() can be used.
+ *
+ * @param[in] out Output specification.
+ * @param[in] format format string to be printed.
+ * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
+ */
+LY_ERR lyp_print(struct lyp_out *out, const char *format, ...);
+
+/**
+ * @brief Generic printer of the given string buffer into the specified output.
+ *
+ * Alternatively, lyp_print() can be used.
+ *
+ * As an extension for printing holes (skipping some data until they are known),
+ * ly_write_skip() and ly_write_skipped() can be used.
+ *
+ * @param[in] out Output specification.
+ * @param[in] buf Memory buffer with the data to print.
+ * @param[in] len Length of the data to print in the @p buf.
+ * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
+ */
+LY_ERR lyp_write(struct lyp_out *out, const char *buf, size_t len);
+
+/**
+ * @brief Free the printer handler.
+ * @param[in] out Printer handler to free.
+ * @param[in] clb_arg_destructor Freeing function for printer callback (LYP_OUT_CALLBACK) argument.
+ * @param[in] destroy Flag to free allocated buffer (for LYP_OUT_MEMORY) or to
+ * close stream/file descriptor (for LYP_OUT_FD, LYP_OUT_FDSTREAM and LYP_OUT_FILE)
+ */
+void lyp_free(struct lyp_out *out, void (*clb_arg_destructor)(void *arg), int destroy);
+
+#endif /* LY_PRINTER_H_ */

--- a/src/printer_data.h
+++ b/src/printer_data.h
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include "tree_data.h"
+#include "printer.h"
 
 /**
  * @defgroup dataprinterflags Data printer flags
@@ -50,71 +51,15 @@
  */
 
 /**
- * @brief Print data tree in the specified format into a memory block.
- * It is up to caller to free the returned string by free().
+ * @brief Common YANG data printer.
  *
- * @param[out] strp Pointer to store the resulting dump.
- * @param[in] root Root node of the data tree to print. It can be actually any (not only real root)
- * node of the data tree to print the specific subtree.
- * @param[in] format Data output format.
+ * @param[in] out Printer handler for a specific output. Use lyp_*() functions to create the handler and lyp_free() to remove the handler.
+ * @param[in] root The root element of the (sub)tree to print.
+ * @param[in] format Output format.
  * @param[in] options [Data printer flags](@ref dataprinterflags). With \p format LYD_LYB, only #LYP_WITHSIBLINGS option is accepted.
  * @return Number of printed characters (excluding the null byte used to end the string) in case of success.
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
-ssize_t lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, int options);
-
-/**
- * @brief Print data tree in the specified format into a file descriptor.
- *
- * @param[in] fd File descriptor where to print the data.
- * @param[in] root Root node of the data tree to print. It can be actually any (not only real root)
- * node of the data tree to print the specific subtree.
- * @param[in] format Data output format.
- * @param[in] options [Data printer flags](@ref dataprinterflags). With \p format LYD_LYB, only #LYP_WITHSIBLINGS option is accepted.
- * @return Number of printed characters (excluding the null byte used to end the string) in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, int options);
-
-/**
- * @brief Print data tree in the specified format into a file stream.
- *
- * @param[in] f File stream where to print the schema.
- * @param[in] root Root node of the data tree to print. It can be actually any (not only real root)
- * node of the data tree to print the specific subtree.
- * @param[in] format Data output format.
- * @param[in] options [Data printer flags](@ref dataprinterflags). With \p format LYD_LYB, only #LYP_WITHSIBLINGS option is accepted.
- * @return Number of printed characters (excluding the null byte used to end the string) in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, int options);
-
-/**
- * @brief Print data tree in the specified format into a file.
- *
- * @param[in] path File where to print the schema.
- * @param[in] root Root node of the data tree to print. It can be actually any (not only real root)
- * node of the data tree to print the specific subtree.
- * @param[in] format Data output format.
- * @param[in] options [Data printer flags](@ref dataprinterflags). With \p format LYD_LYB, only #LYP_WITHSIBLINGS option is accepted.
- * @return Number of printed characters (excluding the null byte used to end the string) in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format, int options);
-
-/**
- * @brief Print data tree in the specified format using the provided callback.
- *
- * @param[in] writeclb Callback function to write the data (see write(2)).
- * @param[in] arg Optional caller-specific argument to be passed to the \p writeclb callback.
- * @param[in] root Root node of the data tree to print. It can be actually any (not only real root)
- * node of the data tree to print the specific subtree.
- * @param[in] format Data output format.
- * @param[in] options [Data printer flags](@ref dataprinterflags). With \p format LYD_LYB, only #LYP_WITHSIBLINGS option is accepted.
- * @return Number of printed characters (excluding the null byte used to end the string) in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lyd_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg, const struct lyd_node *root,
-                      LYD_FORMAT format, int options);
+ssize_t lyd_print(struct lyp_out *out, const struct lyd_node *root, LYD_FORMAT format, int options);
 
 #endif /* LY_PRINTER_DATA_H_ */

--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -96,9 +96,24 @@ LY_ERR yang_print_parsed(struct lyout *out, const struct lys_module *module);
  *
  * @param[in] out Output specification.
  * @param[in] module Schema to be printed (the compiled member is used).
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yang_print_compiled(struct lyout *out, const struct lys_module *module);
+LY_ERR yang_print_compiled(struct lyout *out, const struct lys_module *module, int options);
+
+/**
+ * @brief YANG printer of the compiled schema node
+ *
+ * This printer provides information about modules how they are understood by libyang.
+ * Despite the format is inspired by YANG, it is not fully compatible and should not be
+ * used as a standard YANG format.
+ *
+ * @param[in] out Output specification.
+ * @param[in] node Schema node to be printed including all its substatements.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
+ */
+LY_ERR yang_print_compiled_node(struct lyout *out, const struct lysc_node *node, int options);
 
 /**
  * @brief YIN printer of the parsed schemas. Full YIN printer.

--- a/src/printer_schema.c
+++ b/src/printer_schema.c
@@ -34,7 +34,7 @@
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
 static LY_ERR
-lys_print_(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT format, int UNUSED(line_length), int UNUSED(options))
+lys_print_module(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT format, int UNUSED(line_length), int options)
 {
     LY_ERR ret;
 
@@ -43,7 +43,7 @@ lys_print_(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT for
         ret = yang_print_parsed(out, module);
         break;
     case LYS_OUT_YANG_COMPILED:
-        ret = yang_print_compiled(out, module);
+        ret = yang_print_compiled(out, module, options);
         break;
     case LYS_OUT_YIN:
         ret = yin_print_parsed(out, module);
@@ -55,9 +55,6 @@ lys_print_(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT for
     case LYS_OUT_INFO:
         ret = info_print_model(out, module, target_node);
         break;
-    case LYS_OUT_JSON:
-        ret = jsons_print_model(out, module, target_node);
-        break;
     */
     default:
         LOGERR(module->ctx, LY_EINVAL, "Unknown output format.");
@@ -66,6 +63,76 @@ lys_print_(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT for
     }
 
     return ret;
+}
+
+/**
+ * @brief Common schema node printer.
+ *
+ * @param[in] out Prepared structure defining the type and details of the printer output.
+ * @param[in] ctx libyang context to search for top-level nodes.
+ * @param[in] context_node Context node in the case of relative @p target_node path.
+ * @param[in] format Output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
+ */
+static LY_ERR
+lys_print_target(struct lyout *out, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                 const char *target_node, int UNUSED(line_length), int options)
+{
+    LY_ERR ret;
+    const struct lysc_node *node;
+
+    /* resolve the target_node */
+    node = lys_find_node(ctx, context_node, target_node);
+    if (!node) {
+        return LY_EINVAL;
+    }
+
+    switch (format) {
+    case LYS_OUT_YANG_COMPILED:
+        ret = yang_print_compiled_node(out, node, options);
+        break;
+    /* TODO not yet implemented
+    case LYS_OUT_YIN:
+        ret = yin_print_parsed(out, module);
+        break;
+    case LYS_OUT_TREE:
+        ret = tree_print_model(out, module, target_node, line_length, options);
+        break;
+    */
+    default:
+        LOGERR(ctx, LY_EINVAL, "Unknown output format.");
+        ret = LY_EINVAL;
+        break;
+    }
+
+    return ret;
+}
+
+API ssize_t
+lys_node_print_file(FILE *f, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                    const char *target_node, int line_length, int options)
+{
+    struct lyout out;
+    LY_ERR ret;
+
+    LY_CHECK_ARG_RET(NULL, f, ctx || context_node, LY_EINVAL);
+
+    memset(&out, 0, sizeof out);
+    out.ctx = ctx ? ctx : context_node->module->ctx;
+    out.type = LYOUT_STREAM;
+    out.method.f = f;
+
+    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
+    if (ret) {
+        /* error */
+        return (-1) * ret;
+    } else {
+        /* success */
+        return (ssize_t)out.printed;
+    }
 }
 
 API ssize_t
@@ -81,7 +148,7 @@ lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, i
     out.type = LYOUT_STREAM;
     out.method.f = f;
 
-    ret = lys_print_(&out, module, format, line_length, options);
+    ret = lys_print_module(&out, module, format, line_length, options);
     if (ret) {
         /* error */
         return (-1) * ret;
@@ -89,6 +156,26 @@ lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, i
         /* success */
         return (ssize_t)out.printed;
     }
+}
+
+API ssize_t
+lys_node_print_path(const char *path,  struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                    const char *target_node, int line_length, int options)
+{
+    FILE *f;
+    ssize_t ret;
+
+    LY_CHECK_ARG_RET(NULL, path, ctx || context_node, LY_EINVAL);
+
+    f = fopen(path, "w");
+    if (!f) {
+        LOGERR(ctx ? ctx : context_node->module->ctx, LY_ESYS, "Failed to open file \"%s\" (%s).", path, strerror(errno));
+        return LY_ESYS;
+    }
+
+    ret = lys_node_print_file(f, ctx, context_node, format, target_node, line_length, options);
+    fclose(f);
+    return ret;
 }
 
 API ssize_t
@@ -111,19 +198,20 @@ lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT 
 }
 
 API ssize_t
-lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
+lys_node_print_fd(int fd, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                  const char *target_node, int line_length, int options)
 {
     LY_ERR ret;
     struct lyout out;
 
-    LY_CHECK_ARG_RET(NULL, fd >= 0, module, LY_EINVAL);
+    LY_CHECK_ARG_RET(NULL, fd >= 0, ctx || context_node, LY_EINVAL);
 
     memset(&out, 0, sizeof out);
-    out.ctx = module->ctx;
+    out.ctx = ctx ? ctx : context_node->module->ctx;
     out.type = LYOUT_FD;
     out.method.fd = fd;
 
-    ret = lys_print_(&out, module, format, line_length, options);
+    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
 
     if (out.type == LYOUT_FDSTREAM) {
         /* close temporary stream based on the given file descriptor */
@@ -142,6 +230,62 @@ lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int 
 }
 
 API ssize_t
+lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
+{
+    LY_ERR ret;
+    struct lyout out;
+
+    LY_CHECK_ARG_RET(NULL, fd >= 0, module, LY_EINVAL);
+
+    memset(&out, 0, sizeof out);
+    out.ctx = module->ctx;
+    out.type = LYOUT_FD;
+    out.method.fd = fd;
+
+    ret = lys_print_module(&out, module, format, line_length, options);
+
+    if (out.type == LYOUT_FDSTREAM) {
+        /* close temporary stream based on the given file descriptor */
+        fclose(out.method.f);
+        /* move the original file descriptor to the end of the output file */
+        lseek(fd, 0, SEEK_END);
+    }
+
+    if (ret) {
+        /* error */
+        return (-1) * ret;
+    } else {
+        /* success */
+        return (ssize_t)out.printed;
+    }
+}
+
+API ssize_t
+lys_node_print_mem(char **strp, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                   const char *target_node, int line_length, int options)
+{
+    struct lyout out;
+    LY_ERR ret;
+
+    LY_CHECK_ARG_RET(NULL, strp, ctx || context_node, LY_EINVAL);
+
+    memset(&out, 0, sizeof out);
+    out.ctx = ctx ? ctx : context_node->module->ctx;
+    out.type = LYOUT_MEMORY;
+
+    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
+    if (ret) {
+        /* error */
+        *strp = NULL;
+        return (-1) * ret;
+    } else {
+        /* success */
+        *strp = out.method.mem.buf;
+        return (ssize_t)out.printed;
+    }
+}
+
+API ssize_t
 lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
 {
     struct lyout out;
@@ -153,7 +297,7 @@ lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format
     out.ctx = module->ctx;
     out.type = LYOUT_MEMORY;
 
-    ret = lys_print_(&out, module, format, line_length, options);
+    ret = lys_print_module(&out, module, format, line_length, options);
     if (ret) {
         /* error */
         *strp = NULL;
@@ -161,6 +305,32 @@ lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format
     } else {
         /* success */
         *strp = out.method.mem.buf;
+        return (ssize_t)out.printed;
+    }
+}
+
+API ssize_t
+lys_node_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
+                   struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                   const char *target_node, int line_length, int options)
+{
+    LY_ERR ret;
+    struct lyout out;
+
+    LY_CHECK_ARG_RET(NULL, writeclb, ctx || context_node, LY_EINVAL);
+
+    memset(&out, 0, sizeof out);
+    out.ctx = ctx ? ctx : context_node->module->ctx;
+    out.type = LYOUT_CALLBACK;
+    out.method.clb.f = writeclb;
+    out.method.clb.arg = arg;
+
+    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
+    if (ret) {
+        /* error */
+        return (-1) * ret;
+    } else {
+        /* success */
         return (ssize_t)out.printed;
     }
 }
@@ -180,7 +350,7 @@ lys_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), voi
     out.method.clb.f = writeclb;
     out.method.clb.arg = arg;
 
-    ret = lys_print_(&out, module, format, line_length, options);
+    ret = lys_print_module(&out, module, format, line_length, options);
     if (ret) {
         /* error */
         return (-1) * ret;

--- a/src/printer_schema.c
+++ b/src/printer_schema.c
@@ -20,23 +20,19 @@
 #include <unistd.h>
 
 #include "log.h"
+#include "printer.h"
 #include "printer_internal.h"
 #include "tree_schema.h"
 
-/**
- * @brief Common schema printer.
- *
- * @param[in] out Prepared structure defining the type and details of the printer output.
- * @param[in] module Schema to print.
- * @param[in] format Output format.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
- */
-static LY_ERR
-lys_print_module(struct lyout *out, const struct lys_module *module, LYS_OUTFORMAT format, int UNUSED(line_length), int options)
+API ssize_t
+lys_print(struct lyp_out *out, const struct lys_module *module, LYS_OUTFORMAT format, int UNUSED(line_length), int options)
 {
     LY_ERR ret;
+    size_t printed_prev;
+
+    LY_CHECK_ARG_RET(NULL, out, module, -LY_EINVAL);
+
+    printed_prev = out->printed;
 
     switch (format) {
     case LYS_OUT_YANG:
@@ -57,38 +53,29 @@ lys_print_module(struct lyout *out, const struct lys_module *module, LYS_OUTFORM
         break;
     */
     default:
-        LOGERR(module->ctx, LY_EINVAL, "Unknown output format.");
+        LOGERR(module->ctx, LY_EINVAL, "Unsupported output format.");
         ret = LY_EINVAL;
         break;
     }
 
-    return ret;
+    if (ret) {
+        /* error */
+        return (-1) * ret;
+    } else {
+        /* success */
+        return (ssize_t)(out->printed - printed_prev);
+    }
 }
 
-/**
- * @brief Common schema node printer.
- *
- * @param[in] out Prepared structure defining the type and details of the printer output.
- * @param[in] ctx libyang context to search for top-level nodes.
- * @param[in] context_node Context node in the case of relative @p target_node path.
- * @param[in] format Output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
- */
-static LY_ERR
-lys_print_target(struct lyout *out, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                 const char *target_node, int UNUSED(line_length), int options)
+API ssize_t
+lys_print_node(struct lyp_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, int UNUSED(line_length), int options)
 {
     LY_ERR ret;
-    const struct lysc_node *node;
+    size_t printed_prev;
 
-    /* resolve the target_node */
-    node = lys_find_node(ctx, context_node, target_node);
-    if (!node) {
-        return LY_EINVAL;
-    }
+    LY_CHECK_ARG_RET(NULL, out, node, -LY_EINVAL);
+
+    printed_prev = out->printed;
 
     switch (format) {
     case LYS_OUT_YANG_COMPILED:
@@ -103,259 +90,17 @@ lys_print_target(struct lyout *out, struct ly_ctx *ctx, const struct lysc_node *
         break;
     */
     default:
-        LOGERR(ctx, LY_EINVAL, "Unknown output format.");
+        LOGERR(NULL, LY_EINVAL, "Unsupported output format.");
         ret = LY_EINVAL;
         break;
     }
 
-    return ret;
-}
-
-API ssize_t
-lys_node_print_file(FILE *f, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                    const char *target_node, int line_length, int options)
-{
-    struct lyout out;
-    LY_ERR ret;
-
-    LY_CHECK_ARG_RET(NULL, f, ctx || context_node, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = ctx ? ctx : context_node->module->ctx;
-    out.type = LYOUT_STREAM;
-    out.method.f = f;
-
-    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
     if (ret) {
         /* error */
         return (-1) * ret;
     } else {
         /* success */
-        return (ssize_t)out.printed;
+        return (ssize_t)(out->printed - printed_prev);
     }
 }
 
-API ssize_t
-lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
-{
-    struct lyout out;
-    LY_ERR ret;
-
-    LY_CHECK_ARG_RET(NULL, f, module, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = module->ctx;
-    out.type = LYOUT_STREAM;
-    out.method.f = f;
-
-    ret = lys_print_module(&out, module, format, line_length, options);
-    if (ret) {
-        /* error */
-        return (-1) * ret;
-    } else {
-        /* success */
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_node_print_path(const char *path,  struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                    const char *target_node, int line_length, int options)
-{
-    FILE *f;
-    ssize_t ret;
-
-    LY_CHECK_ARG_RET(NULL, path, ctx || context_node, LY_EINVAL);
-
-    f = fopen(path, "w");
-    if (!f) {
-        LOGERR(ctx ? ctx : context_node->module->ctx, LY_ESYS, "Failed to open file \"%s\" (%s).", path, strerror(errno));
-        return LY_ESYS;
-    }
-
-    ret = lys_node_print_file(f, ctx, context_node, format, target_node, line_length, options);
-    fclose(f);
-    return ret;
-}
-
-API ssize_t
-lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
-{
-    FILE *f;
-    ssize_t ret;
-
-    LY_CHECK_ARG_RET(NULL, path, module, LY_EINVAL);
-
-    f = fopen(path, "w");
-    if (!f) {
-        LOGERR(module->ctx, LY_ESYS, "Failed to open file \"%s\" (%s).", path, strerror(errno));
-        return LY_ESYS;
-    }
-
-    ret = lys_print_file(f, module, format, line_length, options);
-    fclose(f);
-    return ret;
-}
-
-API ssize_t
-lys_node_print_fd(int fd, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                  const char *target_node, int line_length, int options)
-{
-    LY_ERR ret;
-    struct lyout out;
-
-    LY_CHECK_ARG_RET(NULL, fd >= 0, ctx || context_node, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = ctx ? ctx : context_node->module->ctx;
-    out.type = LYOUT_FD;
-    out.method.fd = fd;
-
-    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
-
-    if (out.type == LYOUT_FDSTREAM) {
-        /* close temporary stream based on the given file descriptor */
-        fclose(out.method.f);
-        /* move the original file descriptor to the end of the output file */
-        lseek(fd, 0, SEEK_END);
-    }
-
-    if (ret) {
-        /* error */
-        return (-1) * ret;
-    } else {
-        /* success */
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
-{
-    LY_ERR ret;
-    struct lyout out;
-
-    LY_CHECK_ARG_RET(NULL, fd >= 0, module, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = module->ctx;
-    out.type = LYOUT_FD;
-    out.method.fd = fd;
-
-    ret = lys_print_module(&out, module, format, line_length, options);
-
-    if (out.type == LYOUT_FDSTREAM) {
-        /* close temporary stream based on the given file descriptor */
-        fclose(out.method.f);
-        /* move the original file descriptor to the end of the output file */
-        lseek(fd, 0, SEEK_END);
-    }
-
-    if (ret) {
-        /* error */
-        return (-1) * ret;
-    } else {
-        /* success */
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_node_print_mem(char **strp, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                   const char *target_node, int line_length, int options)
-{
-    struct lyout out;
-    LY_ERR ret;
-
-    LY_CHECK_ARG_RET(NULL, strp, ctx || context_node, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = ctx ? ctx : context_node->module->ctx;
-    out.type = LYOUT_MEMORY;
-
-    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
-    if (ret) {
-        /* error */
-        *strp = NULL;
-        return (-1) * ret;
-    } else {
-        /* success */
-        *strp = out.method.mem.buf;
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options)
-{
-    struct lyout out;
-    LY_ERR ret;
-
-    LY_CHECK_ARG_RET(NULL, strp, module, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = module->ctx;
-    out.type = LYOUT_MEMORY;
-
-    ret = lys_print_module(&out, module, format, line_length, options);
-    if (ret) {
-        /* error */
-        *strp = NULL;
-        return (-1) * ret;
-    } else {
-        /* success */
-        *strp = out.method.mem.buf;
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_node_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
-                   struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                   const char *target_node, int line_length, int options)
-{
-    LY_ERR ret;
-    struct lyout out;
-
-    LY_CHECK_ARG_RET(NULL, writeclb, ctx || context_node, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = ctx ? ctx : context_node->module->ctx;
-    out.type = LYOUT_CALLBACK;
-    out.method.clb.f = writeclb;
-    out.method.clb.arg = arg;
-
-    ret = lys_print_target(&out, ctx, context_node, format, target_node, line_length, options);
-    if (ret) {
-        /* error */
-        return (-1) * ret;
-    } else {
-        /* success */
-        return (ssize_t)out.printed;
-    }
-}
-
-API ssize_t
-lys_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg, const struct lys_module *module,
-              LYS_OUTFORMAT format, int line_length, int options)
-{
-    LY_ERR ret;
-    struct lyout out;
-
-    LY_CHECK_ARG_RET(NULL, writeclb, module, LY_EINVAL);
-
-    memset(&out, 0, sizeof out);
-    out.ctx = module->ctx;
-    out.type = LYOUT_CALLBACK;
-    out.method.clb.f = writeclb;
-    out.method.clb.arg = arg;
-
-    ret = lys_print_module(&out, module, format, line_length, options);
-    if (ret) {
-        /* error */
-        return (-1) * ret;
-    } else {
-        /* success */
-        return (ssize_t)out.printed;
-    }
-}

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -27,7 +27,7 @@
  *
  * @{
  */
-#define LYS_OUTPUT_NO_SUBST          0x10 /**< Print only top-level/referede node information,
+#define LYS_OUTPUT_NO_SUBSTMT        0x10 /**< Print only top-level/referede node information,
                                                do not print information from the substatements */
 //#define LYS_OUTOPT_TREE_RFC        0x01 /**< Conform to the RFC TODO tree output (only for tree format) */
 //#define LYS_OUTOPT_TREE_GROUPING   0x02 /**< Print groupings separately (only for tree format) */

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#include "printer.h"
 #include "tree_schema.h"
 
 
@@ -38,157 +39,30 @@
  * @} schemaprinterflags
  */
 
-
 /**
- * @brief Print schema tree in the specified format into a memory block.
- * It is up to caller to free the returned string by free().
+ * @brief Schema module printer.
  *
- * @param[out] strp Pointer to store the resulting dump.
- * @param[in] module Schema tree to print.
- * @param[in] format Schema output format.
+ * @param[in] out Printer handler for a specific output. Use lyp_*() functions to create the handler and lyp_free() to remove the handler.
+ * @param[in] module Schema to print.
+ * @param[in] format Output format.
  * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return Number of printed bytes in case of success.
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
-ssize_t lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
+ssize_t lys_print(struct lyp_out *out, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
 
 /**
- * @brief Print schema node in the specified format into a memory block.
- * It is up to caller to free the returned string by free().
+ * @brief Schema node printer.
  *
- * @param[out] strp Pointer to store the resulting dump.
- * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
- * @param[in] context_node Context node in case of the relative @p target_node path.
- * @param[in] format Schema output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] out Printer handler for a specific output. Use lyp_*() functions to create the handler and lyp_free() to remove the handler.
+ * @param[in] node Schema node to print, lys_find_node() can be used to get it from a path string.
+ * @param[in] format Output format.
  * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return Number of printed bytes in case of success.
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
-ssize_t lys_node_print_mem(char **strp, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                           const char *target_node, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format into a file descriptor.
- *
- * @param[in] fd File descriptor where to print the data.
- * @param[in] module Schema tree to print.
- * @param[in] format Schema output format.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE format.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format into a file descriptor.
- *
- * @param[in] fd File descriptor where to print the data.
- * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
- * @param[in] context_node Context node in case of the relative @p target_node path.
- * @param[in] format Schema output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE format.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_node_print_fd(int fd, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                          const char *target_node, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format into a file stream.
- *
- * @param[in] module Schema tree to print.
- * @param[in] f File stream where to print the schema.
- * @param[in] format Schema output format.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format,
-                       int line_length, int options);
-
-/**
- * @brief Print schema node in the specified format into a file stream.
- *
- * @param[in] f File stream where to print the schema.
- * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
- * @param[in] context_node Context node in case of the relative @p target_node path.
- * @param[in] format Schema output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_node_print_file(FILE *f, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                            const char *target_node, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format into a file.
- *
- * @param[in] path File where to print the schema.
- * @param[in] module Schema tree to print.
- * @param[in] format Schema output format.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format into a file.
- *
- * @param[in] path File where to print the schema.
- * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
- * @param[in] context_node Context node in case of the relative @p target_node path.
- * @param[in] format Schema output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_node_print_path(const char *path,  struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                            const char *target_node, int line_length, int options);
-
-/**
- * @brief Print schema tree in the specified format using a provided callback.
- *
- * @param[in] writeclb Callback function to write the data (see write(1)).
- * @param[in] arg Optional caller-specific argument to be passed to the \p writeclb callback.
- * @param[in] module Schema tree to print.
- * @param[in] format Schema output format.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
-                     const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
-
-/**
- * @brief Print schema node in the specified format using a provided callback.
- *
- * @param[in] writeclb Callback function to write the data (see write(1)).
- * @param[in] arg Optional caller-specific argument to be passed to the \p writeclb callback.
- * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
- * @param[in] context_node Context node in case of the relative @p target_node path.
- * @param[in] format Schema output format.
- * @param[in] target_node Schema node path, use full module names as node's prefixes.
- * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
- * @param[in] options Schema output options (see @ref schemaprinterflags).
- * @return Number of printed bytes in case of success.
- * @return Negative value failure (absolute value corresponds to LY_ERR values).
- */
-ssize_t lys_node_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
-                           struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
-                           const char *target_node, int line_length, int options);
+ssize_t lys_print_node(struct lyp_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, int line_length, int options);
 
 #endif /* LY_PRINTER_SCHEMA_H_ */

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -20,6 +20,25 @@
 
 #include "tree_schema.h"
 
+
+/**
+ * @defgroup schemaprinterflags Schema output options
+ * @ingroup schema
+ *
+ * @{
+ */
+#define LYS_OUTPUT_NO_SUBST          0x10 /**< Print only top-level/referede node information,
+                                               do not print information from the substatements */
+//#define LYS_OUTOPT_TREE_RFC        0x01 /**< Conform to the RFC TODO tree output (only for tree format) */
+//#define LYS_OUTOPT_TREE_GROUPING   0x02 /**< Print groupings separately (only for tree format) */
+//#define LYS_OUTOPT_TREE_USES       0x04 /**< Print only uses instead the resolved grouping nodes (only for tree format) */
+//#define LYS_OUTOPT_TREE_NO_LEAFREF 0x08 /**< Do not print the target of leafrefs (only for tree format) */
+
+/**
+ * @} schemaprinterflags
+ */
+
+
 /**
  * @brief Print schema tree in the specified format into a memory block.
  * It is up to caller to free the returned string by free().
@@ -35,10 +54,27 @@
 ssize_t lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
 
 /**
+ * @brief Print schema node in the specified format into a memory block.
+ * It is up to caller to free the returned string by free().
+ *
+ * @param[out] strp Pointer to store the resulting dump.
+ * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
+ * @param[in] context_node Context node in case of the relative @p target_node path.
+ * @param[in] format Schema output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return Number of printed bytes in case of success.
+ * @return Negative value failure (absolute value corresponds to LY_ERR values).
+ */
+ssize_t lys_node_print_mem(char **strp, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                           const char *target_node, int line_length, int options);
+
+/**
  * @brief Print schema tree in the specified format into a file descriptor.
  *
- * @param[in] module Schema tree to print.
  * @param[in] fd File descriptor where to print the data.
+ * @param[in] module Schema tree to print.
  * @param[in] format Schema output format.
  * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE format.
  * @param[in] options Schema output options (see @ref schemaprinterflags).
@@ -46,6 +82,22 @@ ssize_t lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMA
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
 ssize_t lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
+
+/**
+ * @brief Print schema tree in the specified format into a file descriptor.
+ *
+ * @param[in] fd File descriptor where to print the data.
+ * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
+ * @param[in] context_node Context node in case of the relative @p target_node path.
+ * @param[in] format Schema output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE format.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return Number of printed bytes in case of success.
+ * @return Negative value failure (absolute value corresponds to LY_ERR values).
+ */
+ssize_t lys_node_print_fd(int fd, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                          const char *target_node, int line_length, int options);
 
 /**
  * @brief Print schema tree in the specified format into a file stream.
@@ -58,7 +110,24 @@ ssize_t lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT form
  * @return Number of printed bytes in case of success.
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
-ssize_t lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
+ssize_t lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format,
+                       int line_length, int options);
+
+/**
+ * @brief Print schema node in the specified format into a file stream.
+ *
+ * @param[in] f File stream where to print the schema.
+ * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
+ * @param[in] context_node Context node in case of the relative @p target_node path.
+ * @param[in] format Schema output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return Number of printed bytes in case of success.
+ * @return Negative value failure (absolute value corresponds to LY_ERR values).
+ */
+ssize_t lys_node_print_file(FILE *f, struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                            const char *target_node, int line_length, int options);
 
 /**
  * @brief Print schema tree in the specified format into a file.
@@ -74,11 +143,27 @@ ssize_t lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT f
 ssize_t lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
 
 /**
+ * @brief Print schema tree in the specified format into a file.
+ *
+ * @param[in] path File where to print the schema.
+ * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
+ * @param[in] context_node Context node in case of the relative @p target_node path.
+ * @param[in] format Schema output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return Number of printed bytes in case of success.
+ * @return Negative value failure (absolute value corresponds to LY_ERR values).
+ */
+ssize_t lys_node_print_path(const char *path,  struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                            const char *target_node, int line_length, int options);
+
+/**
  * @brief Print schema tree in the specified format using a provided callback.
  *
- * @param[in] module Schema tree to print.
  * @param[in] writeclb Callback function to write the data (see write(1)).
  * @param[in] arg Optional caller-specific argument to be passed to the \p writeclb callback.
+ * @param[in] module Schema tree to print.
  * @param[in] format Schema output format.
  * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
  * @param[in] options Schema output options (see @ref schemaprinterflags).
@@ -87,5 +172,23 @@ ssize_t lys_print_path(const char *path, const struct lys_module *module, LYS_OU
  */
 ssize_t lys_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
                      const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
+
+/**
+ * @brief Print schema node in the specified format using a provided callback.
+ *
+ * @param[in] writeclb Callback function to write the data (see write(1)).
+ * @param[in] arg Optional caller-specific argument to be passed to the \p writeclb callback.
+ * @param[in] ctx libyang context to get schema node in case of missing @p context_node.
+ * @param[in] context_node Context node in case of the relative @p target_node path.
+ * @param[in] format Schema output format.
+ * @param[in] target_node Schema node path, use full module names as node's prefixes.
+ * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for #LYS_OUT_TREE printer.
+ * @param[in] options Schema output options (see @ref schemaprinterflags).
+ * @return Number of printed bytes in case of success.
+ * @return Negative value failure (absolute value corresponds to LY_ERR values).
+ */
+ssize_t lys_node_print_clb(ssize_t (*writeclb)(void *arg, const void *buf, size_t count), void *arg,
+                           struct ly_ctx *ctx, const struct lysc_node *context_node, LYS_OUTFORMAT format,
+                           const char *target_node, int line_length, int options);
 
 #endif /* LY_PRINTER_SCHEMA_H_ */

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -21,11 +21,13 @@
 #include "printer.h"
 #include "tree_schema.h"
 
+/**
+ * @addtogroup schematree
+ * @{
+ */
 
 /**
  * @defgroup schemaprinterflags Schema output options
- * @ingroup schema
- *
  * @{
  */
 #define LYS_OUTPUT_NO_SUBSTMT        0x10 /**< Print only top-level/referede node information,
@@ -35,9 +37,7 @@
 //#define LYS_OUTOPT_TREE_USES       0x04 /**< Print only uses instead the resolved grouping nodes (only for tree format) */
 //#define LYS_OUTOPT_TREE_NO_LEAFREF 0x08 /**< Do not print the target of leafrefs (only for tree format) */
 
-/**
- * @} schemaprinterflags
- */
+/** @} schemaprinterflags */
 
 /**
  * @brief Schema module printer.
@@ -64,5 +64,7 @@ ssize_t lys_print(struct lyp_out *out, const struct lys_module *module, LYS_OUTF
  * @return Negative value failure (absolute value corresponds to LY_ERR values).
  */
 ssize_t lys_print_node(struct lyp_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, int line_length, int options);
+
+/** @} schematree */
 
 #endif /* LY_PRINTER_SCHEMA_H_ */

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -32,7 +32,7 @@
  * @brief XML printer context.
  */
 struct xmlpr_ctx {
-    struct lyout *out;  /**< output specification */
+    struct lyp_out *out;  /**< output specification */
     unsigned int level; /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
     int options;        /**< [Data printer flags](@ref dataprinterflags) */
     const struct ly_ctx *ctx; /**< libyang context */
@@ -89,7 +89,7 @@ xml_print_ns(struct xmlpr_ctx *ctx, const char *ns, const char *new_prefix, int 
 
     if (i == -1) {
         /* suitable namespace not found, must be printed */
-        ly_print(ctx->out, " xmlns%s%s=\"%s\"", new_prefix ? ":" : "", new_prefix ? new_prefix : "", ns);
+        lyp_print(ctx->out, " xmlns%s%s=\"%s\"", new_prefix ? ":" : "", new_prefix ? new_prefix : "", ns);
 
         /* and added into namespaces */
         if (new_prefix) {
@@ -144,7 +144,7 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
             /* we have implicit OR explicit default node, print attribute only if context include with-defaults schema */
             mod = ly_ctx_get_module_latest(node->schema->module->ctx, "ietf-netconf-with-defaults");
             if (mod) {
-                ly_print(ctx->out, " %s:default=\"true\"", xml_print_ns(ctx, mod->ns, mod->prefix, 0));
+                lyp_print(ctx->out, " %s:default=\"true\"", xml_print_ns(ctx, mod->ns, mod->prefix, 0));
             }
         }
     }
@@ -177,17 +177,17 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
                 }
 
                 for (i = 0; i < ns_count; ++i) {
-                    ly_print(out, " xmlns:%s=\"%s\"", prefs[i], nss[i]);
+                    lyp_print(out, " xmlns:%s=\"%s\"", prefs[i], nss[i]);
                 }
                 free(prefs);
                 free(nss);
             }
-            ly_print(out, " %s=\"", meta->name);
+            lyp_print(out, " %s=\"", meta->name);
         } else {
 #endif
             /* print the metadata with its namespace */
             mod = meta->annotation->module;
-            ly_print(ctx->out, " %s:%s=\"", xml_print_ns(ctx, mod->ns, mod->prefix, 1), meta->name);
+            lyp_print(ctx->out, " %s:%s=\"", xml_print_ns(ctx, mod->ns, mod->prefix, 1), meta->name);
 #if 0
         }
 #endif
@@ -196,7 +196,7 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
         if (value && value[0]) {
             lyxml_dump_text(ctx->out, value, 1);
         }
-        ly_print(ctx->out, "\"");
+        lyp_print(ctx->out, "\"");
         if (dynamic) {
             free((void *)value);
         }
@@ -215,7 +215,7 @@ static void
 xml_print_node_open(struct xmlpr_ctx *ctx, const struct lyd_node *node)
 {
     /* print node name */
-    ly_print(ctx->out, "%*s<%s", INDENT, node->schema->name);
+    lyp_print(ctx->out, "%*s<%s", INDENT, node->schema->name);
 
     /* print default namespace */
     xml_print_ns(ctx, node->schema->module->ns, NULL, 0);
@@ -254,7 +254,7 @@ xml_print_attr(struct xmlpr_ctx *ctx, const struct lyd_node_opaq *node)
         }
 
         /* print the attribute with its prefix and value */
-        ly_print(ctx->out, " %s%s%s=\"%s\"", pref ? pref : "", pref ? ":" : "", attr->name, attr->value);
+        lyp_print(ctx->out, " %s%s%s=\"%s\"", pref ? pref : "", pref ? ":" : "", attr->name, attr->value);
     }
 
     return LY_SUCCESS;
@@ -264,7 +264,7 @@ static LY_ERR
 xml_print_opaq_open(struct xmlpr_ctx *ctx, const struct lyd_node_opaq *node)
 {
     /* print node name */
-    ly_print(ctx->out, "%*s<%s", INDENT, node->name);
+    lyp_print(ctx->out, "%*s<%s", INDENT, node->name);
 
     /* print default namespace */
     switch (node->format) {
@@ -305,16 +305,16 @@ xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
     /* print namespaces connected with the values's prefixes */
     for (u = 0; u < ns_list.count; ++u) {
         const struct lys_module *mod = (const struct lys_module *)ns_list.objs[u];
-        ly_print(ctx->out, " xmlns:%s=\"%s\"", mod->prefix, mod->ns);
+        lyp_print(ctx->out, " xmlns:%s=\"%s\"", mod->prefix, mod->ns);
     }
     ly_set_erase(&ns_list, NULL);
 
     if (!value || !value[0]) {
-        ly_print(ctx->out, "/>%s", LEVEL ? "\n" : "");
+        lyp_print(ctx->out, "/>%s", LEVEL ? "\n" : "");
     } else {
-        ly_print(ctx->out, ">");
+        lyp_print(ctx->out, ">");
         lyxml_dump_text(ctx->out, value, 0);
-        ly_print(ctx->out, "</%s>%s", node->schema->name, LEVEL ? "\n" : "");
+        lyp_print(ctx->out, "</%s>%s", node->schema->name, LEVEL ? "\n" : "");
     }
     if (dynamic) {
         free((void *)value);
@@ -337,12 +337,12 @@ xml_print_inner(struct xmlpr_ctx *ctx, const struct lyd_node_inner *node)
     xml_print_node_open(ctx, (struct lyd_node *)node);
 
     if (!node->child) {
-        ly_print(ctx->out, "/>%s", ctx->level ? "\n" : "");
+        lyp_print(ctx->out, "/>%s", ctx->level ? "\n" : "");
         return LY_SUCCESS;
     }
 
     /* children */
-    ly_print(ctx->out, ">%s", ctx->level ? "\n" : "");
+    lyp_print(ctx->out, ">%s", ctx->level ? "\n" : "");
 
     LEVEL_INC;
     LY_LIST_FOR(node->child, child) {
@@ -351,7 +351,7 @@ xml_print_inner(struct xmlpr_ctx *ctx, const struct lyd_node_inner *node)
     }
     LEVEL_DEC;
 
-    ly_print(ctx->out, "%*s</%s>%s", INDENT, node->schema->name, LEVEL ? "\n" : "");
+    lyp_print(ctx->out, "%*s</%s>%s", INDENT, node->schema->name, LEVEL ? "\n" : "");
 
     return LY_SUCCESS;
 }
@@ -369,7 +369,7 @@ xml_print_anydata(struct xmlpr_ctx *ctx, const struct lyd_node_any *node)
     if (!any->value.tree) {
         /* no content */
 no_content:
-        ly_print(ctx->out, "/>%s", LEVEL ? "\n" : "");
+        lyp_print(ctx->out, "/>%s", LEVEL ? "\n" : "");
         return LY_SUCCESS;
     } else {
         switch (any->value_type) {
@@ -379,7 +379,7 @@ no_content:
             ctx->options &= ~LYDP_WITHSIBLINGS;
             LEVEL_INC;
 
-            ly_print(ctx->out, ">%s", LEVEL ? "\n" : "");
+            lyp_print(ctx->out, ">%s", LEVEL ? "\n" : "");
             LY_LIST_FOR(any->value.tree, iter) {
                 ret = xml_print_node(ctx, iter);
                 LY_CHECK_ERR_RET(ret, LEVEL_DEC, ret);
@@ -394,7 +394,7 @@ no_content:
                 goto no_content;
             }
             /* close opening tag and print data */
-            ly_print(ctx->out, ">");
+            lyp_print(ctx->out, ">");
             lyxml_dump_text(ctx->out, any->value.str, 0);
             break;
         case LYD_ANYDATA_XML:
@@ -402,7 +402,7 @@ no_content:
             if (!any->value.str[0]) {
                 goto no_content;
             }
-            ly_print(ctx->out, ">%s", any->value.str);
+            lyp_print(ctx->out, ">%s", any->value.str);
             break;
         case LYD_ANYDATA_JSON:
 #if 0 /* TODO LYB format */
@@ -415,9 +415,9 @@ no_content:
 
         /* closing tag */
         if (any->value_type == LYD_ANYDATA_DATATREE) {
-            ly_print(ctx->out, "%*s</%s>%s", INDENT, node->schema->name, LEVEL ? "\n" : "");
+            lyp_print(ctx->out, "%*s</%s>%s", INDENT, node->schema->name, LEVEL ? "\n" : "");
         } else {
-            ly_print(ctx->out, "</%s>%s", node->schema->name, LEVEL ? "\n" : "");
+            lyp_print(ctx->out, "</%s>%s", node->schema->name, LEVEL ? "\n" : "");
         }
     }
 
@@ -441,13 +441,13 @@ xml_print_opaq(struct xmlpr_ctx *ctx, const struct lyd_node_opaq *node)
             }
         }
 
-        ly_print(ctx->out, ">%s", node->value);
+        lyp_print(ctx->out, ">%s", node->value);
     }
 
     if (node->child) {
         /* children */
         if (!node->value[0]) {
-            ly_print(ctx->out, ">%s", ctx->level ? "\n" : "");
+            lyp_print(ctx->out, ">%s", ctx->level ? "\n" : "");
         }
 
         LEVEL_INC;
@@ -457,12 +457,12 @@ xml_print_opaq(struct xmlpr_ctx *ctx, const struct lyd_node_opaq *node)
         }
         LEVEL_DEC;
 
-        ly_print(ctx->out, "%*s</%s>%s", INDENT, node->name, LEVEL ? "\n" : "");
+        lyp_print(ctx->out, "%*s</%s>%s", INDENT, node->name, LEVEL ? "\n" : "");
     } else if (node->value[0]) {
-        ly_print(ctx->out, "</%s>%s", node->name, LEVEL ? "\n" : "");
+        lyp_print(ctx->out, "</%s>%s", node->name, LEVEL ? "\n" : "");
     } else {
         /* no value or children */
-        ly_print(ctx->out, "/>%s", ctx->level ? "\n" : "");
+        lyp_print(ctx->out, "/>%s", ctx->level ? "\n" : "");
     }
 
     return LY_SUCCESS;
@@ -526,14 +526,14 @@ xml_print_node(struct xmlpr_ctx *ctx, const struct lyd_node *node)
 }
 
 LY_ERR
-xml_print_data(struct lyout *out, const struct lyd_node *root, int options)
+xml_print_data(struct lyp_out *out, const struct lyd_node *root, int options)
 {
     const struct lyd_node *node;
     struct xmlpr_ctx ctx = {0};
 
     if (!root) {
-        if (out->type == LYOUT_MEMORY || out->type == LYOUT_CALLBACK) {
-            ly_print(out, "");
+        if (out->type == LYP_OUT_MEMORY || out->type == LYP_OUT_CALLBACK) {
+            lyp_print(out, "");
         }
         goto finish;
     }

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -1185,7 +1185,7 @@ yprc_inout(struct ypr_ctx *ctx, const struct lysc_action *action, const struct l
         yprc_must(ctx, &inout->musts[u], NULL);
     }
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         LY_LIST_FOR(inout->data, data) {
             yprc_node(ctx, data);
         }
@@ -1258,7 +1258,7 @@ yprc_notification(struct ypr_ctx *ctx, const struct lysc_notif *notif)
     ypr_description(ctx, notif->dsc, notif->exts, &flag);
     ypr_reference(ctx, notif->ref, notif->exts, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         LY_LIST_FOR(notif->data, data) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, data);
@@ -1445,7 +1445,7 @@ yprc_container(struct ypr_ctx *ctx, const struct lysc_node *node)
 
     yprc_node_common2(ctx, node, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         LY_LIST_FOR(cont->child, child) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -1494,7 +1494,7 @@ yprc_case(struct ypr_ctx *ctx, const struct lysc_node_case *cs)
     yprc_node_common1(ctx, (struct lysc_node*)cs, &flag);
     yprc_node_common2(ctx, (struct lysc_node*)cs, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         for (child = cs->child; child && child->parent == (struct lysc_node*)cs; child = child->next) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -1795,7 +1795,7 @@ yprc_list(struct ypr_ctx *ctx, const struct lysc_node *node)
     ypr_description(ctx, node->dsc, node->exts, NULL);
     ypr_reference(ctx, node->ref, node->exts, NULL);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         LY_LIST_FOR(list->child, child) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -2376,7 +2376,7 @@ yang_print_compiled(struct lyout *out, const struct lys_module *module, int opti
         yprc_identity(ctx, &modc->identities[u]);
     }
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBST)) {
+    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
         LY_LIST_FOR(modc->data, data) {
             yprc_node(ctx, data);
         }

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -41,7 +41,7 @@ enum schema_type {
  * @brief YANG printer context.
  */
 struct ypr_ctx {
-    struct lyout *out;               /**< output specification */
+    struct lyp_out *out;               /**< output specification */
     unsigned int level;              /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
     const struct lys_module *module; /**< schema to print */
     enum schema_type schema;         /**< type of the schema to print */
@@ -64,7 +64,7 @@ struct ypr_ctx {
  * the @p text is printed completely as a NULL-terminated string.
  */
 static void
-ypr_encode(struct lyout *out, const char *text, int len)
+ypr_encode(struct lyp_out *out, const char *text, int len)
 {
     int i, start_len;
     const char *start;
@@ -94,19 +94,19 @@ ypr_encode(struct lyout *out, const char *text, int len)
         }
 
         if (special) {
-            ly_write(out, start, start_len);
+            lyp_write(out, start, start_len);
             switch (special) {
             case '\n':
-                ly_write(out, "\\n", 2);
+                lyp_write(out, "\\n", 2);
                 break;
             case '\t':
-                ly_write(out, "\\t", 2);
+                lyp_write(out, "\\t", 2);
                 break;
             case '\"':
-                ly_write(out, "\\\"", 2);
+                lyp_write(out, "\\\"", 2);
                 break;
             case '\\':
-                ly_write(out, "\\\\", 2);
+                lyp_write(out, "\\\\", 2);
                 break;
             }
 
@@ -117,15 +117,15 @@ ypr_encode(struct lyout *out, const char *text, int len)
         }
     }
 
-    ly_write(out, start, start_len);
+    lyp_write(out, start, start_len);
 }
 
 static void
-ypr_open(struct lyout *out, int *flag)
+ypr_open(struct lyp_out *out, int *flag)
 {
     if (flag && !*flag) {
         *flag = 1;
-        ly_print(out, " {\n");
+        lyp_print(out, " {\n");
     }
 }
 
@@ -133,9 +133,9 @@ static void
 ypr_close(struct ypr_ctx *ctx, int flag)
 {
     if (flag) {
-        ly_print(ctx->out, "%*s}\n", INDENT);
+        lyp_print(ctx->out, "%*s}\n", INDENT);
     } else {
-        ly_print(ctx->out, ";\n");
+        lyp_print(ctx->out, ";\n");
     }
 }
 
@@ -145,28 +145,28 @@ ypr_text(struct ypr_ctx *ctx, const char *name, const char *text, int singleline
     const char *s, *t;
 
     if (singleline) {
-        ly_print(ctx->out, "%*s%s \"", INDENT, name);
+        lyp_print(ctx->out, "%*s%s \"", INDENT, name);
     } else {
-        ly_print(ctx->out, "%*s%s\n", INDENT, name);
+        lyp_print(ctx->out, "%*s%s\n", INDENT, name);
         LEVEL++;
 
-        ly_print(ctx->out, "%*s\"", INDENT);
+        lyp_print(ctx->out, "%*s\"", INDENT);
     }
     t = text;
     while ((s = strchr(t, '\n'))) {
         ypr_encode(ctx->out, t, s - t);
-        ly_print(ctx->out, "\n");
+        lyp_print(ctx->out, "\n");
         t = s + 1;
         if (*t != '\n') {
-            ly_print(ctx->out, "%*s ", INDENT);
+            lyp_print(ctx->out, "%*s ", INDENT);
         }
     }
 
     ypr_encode(ctx->out, t, strlen(t));
     if (closed) {
-        ly_print(ctx->out, "\";\n");
+        lyp_print(ctx->out, "\";\n");
     } else {
-        ly_print(ctx->out, "\"");
+        lyp_print(ctx->out, "\"");
     }
     if (!singleline) {
         LEVEL--;
@@ -181,26 +181,26 @@ yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
 
     if (stmt->arg) {
         if (stmt->flags) {
-            ly_print(ctx->out, "%*s%s\n", INDENT, stmt->stmt);
+            lyp_print(ctx->out, "%*s%s\n", INDENT, stmt->stmt);
             LEVEL++;
-            ly_print(ctx->out, "%*s%c", INDENT, (stmt->flags & LYS_DOUBLEQUOTED) ? '\"' : '\'');
+            lyp_print(ctx->out, "%*s%c", INDENT, (stmt->flags & LYS_DOUBLEQUOTED) ? '\"' : '\'');
             t = stmt->arg;
             while ((s = strchr(t, '\n'))) {
                 ypr_encode(ctx->out, t, s - t);
-                ly_print(ctx->out, "\n");
+                lyp_print(ctx->out, "\n");
                 t = s + 1;
                 if (*t != '\n') {
-                    ly_print(ctx->out, "%*s ", INDENT);
+                    lyp_print(ctx->out, "%*s ", INDENT);
                 }
             }
             LEVEL--;
             ypr_encode(ctx->out, t, strlen(t));
-            ly_print(ctx->out, "%c%s", (stmt->flags & LYS_DOUBLEQUOTED) ? '\"' : '\'', stmt->child ? " {\n" : ";\n");
+            lyp_print(ctx->out, "%c%s", (stmt->flags & LYS_DOUBLEQUOTED) ? '\"' : '\'', stmt->child ? " {\n" : ";\n");
         } else {
-            ly_print(ctx->out, "%*s%s %s%s", INDENT, stmt->stmt, stmt->arg, stmt->child ? " {\n" : ";\n");
+            lyp_print(ctx->out, "%*s%s %s%s", INDENT, stmt->stmt, stmt->arg, stmt->child ? " {\n" : ";\n");
         }
     } else {
-        ly_print(ctx->out, "%*s%s%s", INDENT, stmt->stmt, stmt->child ? " {\n" : ";\n");
+        lyp_print(ctx->out, "%*s%s%s", INDENT, stmt->stmt, stmt->child ? " {\n" : ";\n");
     }
 
     if (stmt->child) {
@@ -209,7 +209,7 @@ yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
             yprp_stmt(ctx, childstmt);
         }
         LEVEL--;
-        ly_print(ctx->out, "%*s}\n", INDENT);
+        lyp_print(ctx->out, "%*s}\n", INDENT);
     }
 }
 
@@ -239,7 +239,7 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
         }
 
         if (!ext->compiled && ext->yin) {
-            ly_print(ctx->out, "%*s%s; // Model comes from different input format, extensions must be resolved first.\n", INDENT, ext[u].name);
+            lyp_print(ctx->out, "%*s%s; // Model comes from different input format, extensions must be resolved first.\n", INDENT, ext[u].name);
             continue;
         }
 
@@ -252,11 +252,11 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
             argument = ext[u].argument;
         }
         if (argument) {
-            ly_print(ctx->out, "%*s%s \"", INDENT, ext[u].name);
+            lyp_print(ctx->out, "%*s%s \"", INDENT, ext[u].name);
             ypr_encode(ctx->out, argument, -1);
-            ly_print(ctx->out, "\"");
+            lyp_print(ctx->out, "\"");
         } else {
-            ly_print(ctx->out, "%*s%s", INDENT, ext[u].name);
+            lyp_print(ctx->out, "%*s%s", INDENT, ext[u].name);
         }
 
         child_presence = 0;
@@ -266,16 +266,16 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
                 continue;
             }
             if (!child_presence) {
-                ly_print(ctx->out, " {\n");
+                lyp_print(ctx->out, " {\n");
                 child_presence = 1;
             }
             yprp_stmt(ctx, stmt);
         }
         LEVEL--;
         if (child_presence) {
-            ly_print(ctx->out, "%*s}\n", INDENT);
+            lyp_print(ctx->out, "%*s}\n", INDENT);
         } else {
-            ly_print(ctx->out, ";\n");
+            lyp_print(ctx->out, ";\n");
         }
     }
 }
@@ -318,7 +318,7 @@ ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, c
     }
 
     if (ext_substmt_info[substmt].flags & SUBST_FLAG_ID) {
-        ly_print(ctx->out, "%*s%s %s", INDENT, ext_substmt_info[substmt].name, text);
+        lyp_print(ctx->out, "%*s%s %s", INDENT, ext_substmt_info[substmt].name, text);
     } else {
         ypr_text(ctx, ext_substmt_info[substmt].name, text,
                  (ext_substmt_info[substmt].flags & SUBST_FLAG_YIN) ? 0 : 1, 0);
@@ -373,15 +373,15 @@ static void
 yprp_revision(struct ypr_ctx *ctx, const struct lysp_revision *rev)
 {
     if (rev->dsc || rev->ref || rev->exts) {
-        ly_print(ctx->out, "%*srevision %s {\n", INDENT, rev->date);
+        lyp_print(ctx->out, "%*srevision %s {\n", INDENT, rev->date);
         LEVEL++;
         yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, rev->exts, NULL, 0);
         ypr_substmt(ctx, LYEXT_SUBSTMT_DESCRIPTION, 0, rev->dsc, rev->exts);
         ypr_substmt(ctx, LYEXT_SUBSTMT_REFERENCE, 0, rev->ref, rev->exts);
         LEVEL--;
-        ly_print(ctx->out, "%*s}\n", INDENT);
+        lyp_print(ctx->out, "%*s}\n", INDENT);
     } else {
-        ly_print(ctx->out, "%*srevision %s;\n", INDENT, rev->date);
+        lyp_print(ctx->out, "%*srevision %s;\n", INDENT, rev->date);
     }
 }
 
@@ -450,7 +450,7 @@ yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance 
         ypr_open(ctx->out, flag);
         extflag = 0;
 
-        ly_print(ctx->out, "%*sif-feature \"%s\"", INDENT, iff[u]);
+        lyp_print(ctx->out, "%*sif-feature \"%s\"", INDENT, iff[u]);
 
         /* extensions */
         LEVEL++;
@@ -477,14 +477,14 @@ yprc_iffeature(struct ypr_ctx *ctx, struct lysc_iffeature *feat, int *index_e, i
     switch (op) {
     case LYS_IFF_F:
         if (ctx->module == feat->features[*index_f]->module) {
-            ly_print(ctx->out, "%s", feat->features[*index_f]->name);
+            lyp_print(ctx->out, "%s", feat->features[*index_f]->name);
         } else {
-            ly_print(ctx->out, "%s:%s", feat->features[*index_f]->module->prefix, feat->features[*index_f]->name);
+            lyp_print(ctx->out, "%s:%s", feat->features[*index_f]->module->prefix, feat->features[*index_f]->name);
         }
         (*index_f)++;
         break;
     case LYS_IFF_NOT:
-        ly_print(ctx->out, "not ");
+        lyp_print(ctx->out, "not ");
         yprc_iffeature(ctx, feat, index_e, index_f);
         break;
     case LYS_IFF_AND:
@@ -497,13 +497,13 @@ yprc_iffeature(struct ypr_ctx *ctx, struct lysc_iffeature *feat, int *index_e, i
         /* falls through */
     case LYS_IFF_OR:
         if (brackets_flag) {
-            ly_print(ctx->out, "(");
+            lyp_print(ctx->out, "(");
         }
         yprc_iffeature(ctx, feat, index_e, index_f);
-        ly_print(ctx->out, " %s ", op == LYS_IFF_OR ? "or" : "and");
+        lyp_print(ctx->out, " %s ", op == LYS_IFF_OR ? "or" : "and");
         yprc_iffeature(ctx, feat, index_e, index_f);
         if (brackets_flag) {
-            ly_print(ctx->out, ")");
+            lyp_print(ctx->out, ")");
         }
     }
 }
@@ -520,9 +520,9 @@ yprc_iffeatures(struct ypr_ctx *ctx, struct lysc_iffeature *iff, struct lysc_ext
         ypr_open(ctx->out, flag);
         extflag = 0;
 
-        ly_print(ctx->out, "%*sif-feature \"", INDENT);
+        lyp_print(ctx->out, "%*sif-feature \"", INDENT);
         yprc_iffeature(ctx, iff, &index_e, &index_f);
-        ly_print(ctx->out, "\"");
+        lyp_print(ctx->out, "\"");
 
         /* extensions */
         LEVEL++;
@@ -543,7 +543,7 @@ yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
     int flag = 0, flag2 = 0;
     LY_ARRAY_SIZE_TYPE u;
 
-    ly_print(ctx->out, "%*sextension %s", INDENT, ext->name);
+    lyp_print(ctx->out, "%*sextension %s", INDENT, ext->name);
     LEVEL++;
 
     if (ext->exts) {
@@ -552,7 +552,7 @@ yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 
     if (ext->argument) {
         ypr_open(ctx->out, &flag);
-        ly_print(ctx->out, "%*sargument %s", INDENT, ext->argument);
+        lyp_print(ctx->out, "%*sargument %s", INDENT, ext->argument);
         LEVEL++;
         if (ext->exts) {
             u = -1;
@@ -582,7 +582,7 @@ yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 {
     int flag = 0;
 
-    ly_print(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
+    lyp_print(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
     LEVEL++;
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, feat->exts, &flag, 0);
     yprp_iffeatures(ctx, feat->iffeatures, feat->exts, &flag);
@@ -598,7 +598,7 @@ yprc_feature(struct ypr_ctx *ctx, const struct lysc_feature *feat)
 {
     int flag = 0;
 
-    ly_print(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
+    lyp_print(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, feat->exts, &flag, 0);
     yprc_iffeatures(ctx, feat->iffeatures, feat->exts, &flag);
@@ -615,7 +615,7 @@ yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
     int flag = 0;
     LY_ARRAY_SIZE_TYPE u;
 
-    ly_print(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
+    lyp_print(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, ident->exts, &flag, 0);
@@ -640,7 +640,7 @@ yprc_identity(struct ypr_ctx *ctx, const struct lysc_ident *ident)
     int flag = 0;
     LY_ARRAY_SIZE_TYPE u;
 
-    ly_print(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
+    lyp_print(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
     LEVEL++;
 
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, ident->exts, &flag, 0);
@@ -649,9 +649,9 @@ yprc_identity(struct ypr_ctx *ctx, const struct lysc_ident *ident)
     LY_ARRAY_FOR(ident->derived, u) {
         ypr_open(ctx->out, &flag);
         if (ctx->module != ident->derived[u]->module) {
-            ly_print(ctx->out, "%*sderived %s:%s;\n", INDENT, ident->derived[u]->module->prefix, ident->derived[u]->name);
+            lyp_print(ctx->out, "%*sderived %s:%s;\n", INDENT, ident->derived[u]->module->prefix, ident->derived[u]->name);
         } else {
-            ly_print(ctx->out, "%*sderived %s;\n", INDENT, ident->derived[u]->name);
+            lyp_print(ctx->out, "%*sderived %s;\n", INDENT, ident->derived[u]->name);
         }
     }
 
@@ -673,9 +673,9 @@ yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name
     }
 
     ypr_open(ctx->out, flag);
-    ly_print(ctx->out, "%*s%s \"", INDENT, name);
+    lyp_print(ctx->out, "%*s%s \"", INDENT, name);
     ypr_encode(ctx->out, (restr->arg[0] != 0x15 && restr->arg[0] != 0x06) ? restr->arg : &restr->arg[1], -1);
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, restr->exts, &inner_flag, 0);
@@ -705,9 +705,9 @@ yprc_must(struct ypr_ctx *ctx, const struct lysc_must *must, int *flag)
     int inner_flag = 0;
 
     ypr_open(ctx->out, flag);
-    ly_print(ctx->out, "%*smust \"", INDENT);
+    lyp_print(ctx->out, "%*smust \"", INDENT);
     ypr_encode(ctx->out, must->cond->expr, -1);
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, must->exts, &inner_flag, 0);
@@ -737,26 +737,26 @@ yprc_range(struct ypr_ctx *ctx, const struct lysc_range *range, LY_DATA_TYPE bas
     }
 
     ypr_open(ctx->out, flag);
-    ly_print(ctx->out, "%*s%s \"", INDENT, (basetype == LY_TYPE_STRING || basetype == LY_TYPE_BINARY) ? "length" : "range");
+    lyp_print(ctx->out, "%*s%s \"", INDENT, (basetype == LY_TYPE_STRING || basetype == LY_TYPE_BINARY) ? "length" : "range");
     LY_ARRAY_FOR(range->parts, u) {
         if (u > 0) {
-            ly_print(ctx->out, " | ");
+            lyp_print(ctx->out, " | ");
         }
         if (range->parts[u].max_64 == range->parts[u].min_64) {
             if (basetype <= LY_TYPE_STRING) { /* unsigned values */
-                ly_print(ctx->out, "%"PRIu64, range->parts[u].max_u64);
+                lyp_print(ctx->out, "%"PRIu64, range->parts[u].max_u64);
             } else { /* signed values */
-                ly_print(ctx->out, "%"PRId64, range->parts[u].max_64);
+                lyp_print(ctx->out, "%"PRId64, range->parts[u].max_64);
             }
         } else {
             if (basetype <= LY_TYPE_STRING) { /* unsigned values */
-                ly_print(ctx->out, "%"PRIu64"..%"PRIu64, range->parts[u].min_u64, range->parts[u].max_u64);
+                lyp_print(ctx->out, "%"PRIu64"..%"PRIu64, range->parts[u].min_u64, range->parts[u].max_u64);
             } else { /* signed values */
-                ly_print(ctx->out, "%"PRId64"..%"PRId64, range->parts[u].min_64, range->parts[u].max_64);
+                lyp_print(ctx->out, "%"PRId64"..%"PRId64, range->parts[u].min_64, range->parts[u].max_64);
             }
         }
     }
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, range->exts, &inner_flag, 0);
@@ -781,9 +781,9 @@ yprc_pattern(struct ypr_ctx *ctx, const struct lysc_pattern *pattern, int *flag)
     int inner_flag = 0;
 
     ypr_open(ctx->out, flag);
-    ly_print(ctx->out, "%*spattern \"", INDENT);
+    lyp_print(ctx->out, "%*spattern \"", INDENT);
     ypr_encode(ctx->out, pattern->expr, -1);
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, pattern->exts, &inner_flag, 0);
@@ -817,9 +817,9 @@ yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int *flag)
     }
     ypr_open(ctx->out, flag);
 
-    ly_print(ctx->out, "%*swhen \"", INDENT);
+    lyp_print(ctx->out, "%*swhen \"", INDENT);
     ypr_encode(ctx->out, when->cond, -1);
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, when->exts, &inner_flag, 0);
@@ -839,9 +839,9 @@ yprc_when(struct ypr_ctx *ctx, struct lysc_when *when, int *flag)
     }
     ypr_open(ctx->out, flag);
 
-    ly_print(ctx->out, "%*swhen \"", INDENT);
+    lyp_print(ctx->out, "%*swhen \"", INDENT);
     ypr_encode(ctx->out, when->cond->expr, -1);
-    ly_print(ctx->out, "\"");
+    lyp_print(ctx->out, "\"");
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, when->exts, &inner_flag, 0);
@@ -860,11 +860,11 @@ yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE 
     LY_ARRAY_FOR(items, u) {
         ypr_open(ctx->out, flag);
         if (type == LY_TYPE_BITS) {
-            ly_print(ctx->out, "%*sbit %s", INDENT, items[u].name);
+            lyp_print(ctx->out, "%*sbit %s", INDENT, items[u].name);
         } else { /* LY_TYPE_ENUM */
-            ly_print(ctx->out, "%*senum \"", INDENT);
+            lyp_print(ctx->out, "%*senum \"", INDENT);
             ypr_encode(ctx->out, items[u].name, -1);
-            ly_print(ctx->out, "\"");
+            lyp_print(ctx->out, "\"");
         }
         inner_flag = 0;
         LEVEL++;
@@ -891,7 +891,7 @@ yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
     LY_ARRAY_SIZE_TYPE u;
     int flag = 0;
 
-    ly_print(ctx->out, "%*stype %s", INDENT, type->name);
+    lyp_print(ctx->out, "%*stype %s", INDENT, type->name);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, type->exts, &flag, 0);
@@ -947,7 +947,7 @@ yprc_type(struct ypr_ctx *ctx, const struct lysc_type *type)
     LY_ARRAY_SIZE_TYPE u;
     int flag = 0;
 
-    ly_print(ctx->out, "%*stype %s", INDENT, lys_datatype2str(type->basetype));
+    lyp_print(ctx->out, "%*stype %s", INDENT, lys_datatype2str(type->basetype));
     LEVEL++;
 
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, type->exts, &flag, 0);
@@ -991,9 +991,9 @@ yprc_type(struct ypr_ctx *ctx, const struct lysc_type *type)
             int inner_flag = 0;
 
             ypr_open(ctx->out, &flag);
-            ly_print(ctx->out, "%*s%s \"", INDENT, type->basetype == LY_TYPE_BITS ? "bit" : "enum");
+            lyp_print(ctx->out, "%*s%s \"", INDENT, type->basetype == LY_TYPE_BITS ? "bit" : "enum");
             ypr_encode(ctx->out, item->name, -1);
-            ly_print(ctx->out, "\"");
+            lyp_print(ctx->out, "\"");
             LEVEL++;
             yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, item->exts, &inner_flag, 0);
             yprc_iffeatures(ctx, item->iffeatures, item->exts, &inner_flag);
@@ -1065,7 +1065,7 @@ yprp_typedef(struct ypr_ctx *ctx, const struct lysp_tpdf *tpdf)
 {
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "\n%*stypedef %s {\n", INDENT, tpdf->name);
+    lyp_print(ctx->out, "\n%*stypedef %s {\n", INDENT, tpdf->name);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, tpdf->exts, NULL, 0);
@@ -1084,7 +1084,7 @@ yprp_typedef(struct ypr_ctx *ctx, const struct lysp_tpdf *tpdf)
     ypr_reference(ctx, tpdf->ref, tpdf->exts, NULL);
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
 }
 
 static void yprp_node(struct ypr_ctx *ctx, const struct lysp_node *node);
@@ -1100,7 +1100,7 @@ yprp_grouping(struct ypr_ctx *ctx, const struct lysp_grp *grp)
 
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "\n%*sgrouping %s", INDENT, grp->name);
+    lyp_print(ctx->out, "\n%*sgrouping %s", INDENT, grp->name);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, grp->exts, &flag, 0);
@@ -1143,7 +1143,7 @@ yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, int *flag
     }
     ypr_open(ctx->out, flag);
 
-    ly_print(ctx->out, "\n%*s%s {\n", INDENT, (inout->nodetype == LYS_INPUT ? "input" : "output"));
+    lyp_print(ctx->out, "\n%*s%s {\n", INDENT, (inout->nodetype == LYS_INPUT ? "input" : "output"));
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, inout->exts, NULL, 0);
@@ -1177,7 +1177,7 @@ yprc_inout(struct ypr_ctx *ctx, const struct lysc_action *action, const struct l
     }
     ypr_open(ctx->out, flag);
 
-    ly_print(ctx->out, "\n%*s%s {\n", INDENT, (&action->input == inout) ? "input" : "output");
+    lyp_print(ctx->out, "\n%*s%s {\n", INDENT, (&action->input == inout) ? "input" : "output");
     LEVEL++;
 
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, (&action->input == inout) ? action->input_exts : action->output_exts, NULL, 0);
@@ -1204,7 +1204,7 @@ yprp_notification(struct ypr_ctx *ctx, const struct lysp_notif *notif)
 
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "%*snotification %s", INDENT, notif->name);
+    lyp_print(ctx->out, "%*snotification %s", INDENT, notif->name);
 
     LEVEL++;
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, notif->exts, &flag, 0);
@@ -1245,7 +1245,7 @@ yprc_notification(struct ypr_ctx *ctx, const struct lysc_notif *notif)
 
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "%*snotification %s", INDENT, notif->name);
+    lyp_print(ctx->out, "%*snotification %s", INDENT, notif->name);
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, notif->exts, &flag, 0);
@@ -1277,7 +1277,7 @@ yprp_action(struct ypr_ctx *ctx, const struct lysp_action *action)
 
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
+    lyp_print(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
 
     LEVEL++;
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, action->exts, &flag, 0);
@@ -1310,7 +1310,7 @@ yprc_action(struct ypr_ctx *ctx, const struct lysc_action *action)
 
     LYOUT_CHECK(ctx->out);
 
-    ly_print(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
+    lyp_print(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
 
     LEVEL++;
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, action->exts, &flag, 0);
@@ -1329,7 +1329,7 @@ yprc_action(struct ypr_ctx *ctx, const struct lysc_action *action)
 static void
 yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int *flag)
 {
-    ly_print(ctx->out, "%*s%s %s%s", INDENT, lys_nodetype2str(node->nodetype), node->name, flag ? "" : " {\n");
+    lyp_print(ctx->out, "%*s%s %s%s", INDENT, lys_nodetype2str(node->nodetype), node->name, flag ? "" : " {\n");
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, node->exts, flag, 0);
@@ -1342,7 +1342,7 @@ yprc_node_common1(struct ypr_ctx *ctx, const struct lysc_node *node, int *flag)
 {
     LY_ARRAY_SIZE_TYPE u;
 
-    ly_print(ctx->out, "%*s%s %s%s", INDENT, lys_nodetype2str(node->nodetype), node->name, flag ? "" : " {\n");
+    lyp_print(ctx->out, "%*s%s %s%s", INDENT, lys_nodetype2str(node->nodetype), node->name, flag ? "" : " {\n");
     LEVEL++;
 
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, node->exts, flag, 0);
@@ -1573,7 +1573,7 @@ yprp_leaf(struct ypr_ctx *ctx, const struct lysp_node *node)
     yprp_node_common2(ctx, node, NULL);
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
 }
 
 static void
@@ -1597,7 +1597,7 @@ yprc_leaf(struct ypr_ctx *ctx, const struct lysc_node *node)
     yprc_node_common2(ctx, node, NULL);
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
 }
 
 static void
@@ -1639,7 +1639,7 @@ yprp_leaflist(struct ypr_ctx *ctx, const struct lysp_node *node)
     ypr_reference(ctx, node->ref, node->exts, NULL);
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
 }
 
 static void
@@ -1675,7 +1675,7 @@ yprc_leaflist(struct ypr_ctx *ctx, const struct lysc_node *node)
     ypr_reference(ctx, node->ref, node->exts, NULL);
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
 }
 
 static void
@@ -1765,17 +1765,17 @@ yprc_list(struct ypr_ctx *ctx, const struct lysc_node *node)
     }
     if (!(list->flags & LYS_KEYLESS)) {
         ypr_open(ctx->out, &flag);
-        ly_print(ctx->out, "%*skey \"", INDENT);
+        lyp_print(ctx->out, "%*skey \"", INDENT);
         for (struct lysc_node *key = list->child; key && key->nodetype == LYS_LEAF && (key->flags & LYS_KEY); key = key->next) {
-            ly_print(ctx->out, "%s%s", u > 0 ? ", " : "", key->name);
+            lyp_print(ctx->out, "%s%s", u > 0 ? ", " : "", key->name);
         }
-        ly_print(ctx->out, "\";\n");
+        lyp_print(ctx->out, "\";\n");
     }
     LY_ARRAY_FOR(list->uniques, u) {
         ypr_open(ctx->out, &flag);
-        ly_print(ctx->out, "%*sunique \"", INDENT);
+        lyp_print(ctx->out, "%*sunique \"", INDENT);
         LY_ARRAY_FOR(list->uniques[u], v) {
-            ly_print(ctx->out, "%s%s", v > 0 ? ", " : "", list->uniques[u][v]->name);
+            lyp_print(ctx->out, "%s%s", v > 0 ? ", " : "", list->uniques[u][v]->name);
         }
         ypr_close(ctx, 0);
     }
@@ -1822,7 +1822,7 @@ yprp_refine(struct ypr_ctx *ctx, struct lysp_refine *refine)
     LY_ARRAY_SIZE_TYPE u;
     int flag = 0;
 
-    ly_print(ctx->out, "%*srefine \"%s\"", INDENT, refine->nodeid);
+    lyp_print(ctx->out, "%*srefine \"%s\"", INDENT, refine->nodeid);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, refine->exts, &flag, 0);
@@ -1872,7 +1872,7 @@ yprp_augment(struct ypr_ctx *ctx, const struct lysp_augment *aug)
     LY_ARRAY_SIZE_TYPE u;
     struct lysp_node *child;
 
-    ly_print(ctx->out, "%*saugment \"%s\" {\n", INDENT, aug->nodeid);
+    lyp_print(ctx->out, "%*saugment \"%s\" {\n", INDENT, aug->nodeid);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, aug->exts, NULL, 0);
@@ -2038,7 +2038,7 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
     struct lysp_deviate_del *del;
     struct lysp_deviate *elem;
 
-    ly_print(ctx->out, "%*sdeviation \"%s\" {\n", INDENT, deviation->nodeid);
+    lyp_print(ctx->out, "%*sdeviation \"%s\" {\n", INDENT, deviation->nodeid);
     LEVEL++;
 
     yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, deviation->exts, NULL, 0);
@@ -2046,20 +2046,20 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
     ypr_reference(ctx, deviation->ref, deviation->exts, NULL);
 
     LY_LIST_FOR(deviation->deviates, elem) {
-        ly_print(ctx->out, "%*sdeviate ", INDENT);
+        lyp_print(ctx->out, "%*sdeviate ", INDENT);
         if (elem->mod == LYS_DEV_NOT_SUPPORTED) {
             if (elem->exts) {
-                ly_print(ctx->out, "not-supported {\n");
+                lyp_print(ctx->out, "not-supported {\n");
                 LEVEL++;
 
                 yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, elem->exts, NULL, 0);
             } else {
-                ly_print(ctx->out, "not-supported;\n");
+                lyp_print(ctx->out, "not-supported;\n");
                 continue;
             }
         } else if (elem->mod == LYS_DEV_ADD) {
             add = (struct lysp_deviate_add*)elem;
-            ly_print(ctx->out, "add {\n");
+            lyp_print(ctx->out, "add {\n");
             LEVEL++;
 
             yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, add->exts, NULL, 0);
@@ -2087,7 +2087,7 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
             }
         } else if (elem->mod == LYS_DEV_REPLACE) {
             rpl = (struct lysp_deviate_rpl*)elem;
-            ly_print(ctx->out, "replace {\n");
+            lyp_print(ctx->out, "replace {\n");
             LEVEL++;
 
             yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, rpl->exts, NULL, 0);
@@ -2110,7 +2110,7 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
             }
         } else if (elem->mod == LYS_DEV_DELETE) {
             del = (struct lysp_deviate_del*)elem;
-            ly_print(ctx->out, "delete {\n");
+            lyp_print(ctx->out, "delete {\n");
             LEVEL++;
 
             yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, del->exts, NULL, 0);
@@ -2155,7 +2155,7 @@ ypr_missing_format(struct ypr_ctx *ctx, const struct lys_module *module)
 
     /* meta-stmts */
     if (module->org || module->contact || module->dsc || module->ref) {
-        ly_print(ctx->out, "\n");
+        lyp_print(ctx->out, "\n");
     }
     ypr_substmt(ctx, LYEXT_SUBSTMT_ORGANIZATION, 0, module->org, NULL);
     ypr_substmt(ctx, LYEXT_SUBSTMT_CONTACT, 0, module->contact, NULL);
@@ -2164,29 +2164,29 @@ ypr_missing_format(struct ypr_ctx *ctx, const struct lys_module *module)
 
     /* revision-stmts */
     if (module->revision) {
-        ly_print(ctx->out, "\n%*srevision %s;\n", INDENT, module->revision);
+        lyp_print(ctx->out, "\n%*srevision %s;\n", INDENT, module->revision);
     }
 
     LEVEL--;
-    ly_print(ctx->out, "%*s}\n", INDENT);
+    lyp_print(ctx->out, "%*s}\n", INDENT);
     ly_print_flush(ctx->out);
 
     return LY_SUCCESS;
 }
 
 LY_ERR
-yang_print_parsed(struct lyout *out, const struct lys_module *module)
+yang_print_parsed(struct lyp_out *out, const struct lys_module *module)
 {
     LY_ARRAY_SIZE_TYPE u;
     struct lysp_node *data;
     struct lysp_module *modp = module->parsed;
     struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .schema = YPR_PARSED}, *ctx = &ctx_;
 
-    ly_print(ctx->out, "%*smodule %s {\n", INDENT, module->name);
+    lyp_print(ctx->out, "%*smodule %s {\n", INDENT, module->name);
     LEVEL++;
 
     if (!modp) {
-        ly_print(ctx->out, "%*s/* PARSED INFORMATION ARE NOT FULLY PRESENT */\n", INDENT);
+        lyp_print(ctx->out, "%*s/* PARSED INFORMATION ARE NOT FULLY PRESENT */\n", INDENT);
         return ypr_missing_format(ctx, module);
     }
 
@@ -2201,7 +2201,7 @@ yang_print_parsed(struct lyout *out, const struct lys_module *module)
 
     /* linkage-stmts */
     LY_ARRAY_FOR(modp->imports, u) {
-        ly_print(out, "%s%*simport %s {\n", u ? "" : "\n", INDENT, modp->imports[u].module->name);
+        lyp_print(out, "%s%*simport %s {\n", u ? "" : "\n", INDENT, modp->imports[u].module->name);
         LEVEL++;
         yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, modp->imports[u].exts, NULL, 0);
         ypr_substmt(ctx, LYEXT_SUBSTMT_PREFIX, 0, modp->imports[u].prefix, modp->imports[u].exts);
@@ -2211,11 +2211,11 @@ yang_print_parsed(struct lyout *out, const struct lys_module *module)
         ypr_substmt(ctx, LYEXT_SUBSTMT_DESCRIPTION, 0, modp->imports[u].dsc, modp->imports[u].exts);
         ypr_substmt(ctx, LYEXT_SUBSTMT_REFERENCE, 0, modp->imports[u].ref, modp->imports[u].exts);
         LEVEL--;
-        ly_print(out, "%*s}\n", INDENT);
+        lyp_print(out, "%*s}\n", INDENT);
     }
     LY_ARRAY_FOR(modp->includes, u) {
         if (modp->includes[u].rev[0] || modp->includes[u].dsc || modp->includes[u].ref || modp->includes[u].exts) {
-            ly_print(out, "%s%*sinclude %s {\n", u ? "" : "\n",  INDENT, modp->includes[u].submodule->name);
+            lyp_print(out, "%s%*sinclude %s {\n", u ? "" : "\n",  INDENT, modp->includes[u].submodule->name);
             LEVEL++;
             yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, modp->includes[u].exts, NULL, 0);
             if (modp->includes[u].rev[0]) {
@@ -2224,15 +2224,15 @@ yang_print_parsed(struct lyout *out, const struct lys_module *module)
             ypr_substmt(ctx, LYEXT_SUBSTMT_DESCRIPTION, 0, modp->includes[u].dsc, modp->includes[u].exts);
             ypr_substmt(ctx, LYEXT_SUBSTMT_REFERENCE, 0, modp->includes[u].ref, modp->includes[u].exts);
             LEVEL--;
-            ly_print(out, "%*s}\n", INDENT);
+            lyp_print(out, "%*s}\n", INDENT);
         } else {
-            ly_print(out, "\n%*sinclude \"%s\";\n", INDENT, modp->includes[u].submodule->name);
+            lyp_print(out, "\n%*sinclude \"%s\";\n", INDENT, modp->includes[u].submodule->name);
         }
     }
 
     /* meta-stmts */
     if (module->org || module->contact || module->dsc || module->ref) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
     }
     ypr_substmt(ctx, LYEXT_SUBSTMT_ORGANIZATION, 0, module->org, modp->exts);
     ypr_substmt(ctx, LYEXT_SUBSTMT_CONTACT, 0, module->contact, modp->exts);
@@ -2241,18 +2241,18 @@ yang_print_parsed(struct lyout *out, const struct lys_module *module)
 
     /* revision-stmts */
     if (modp->revs) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
     }
     LY_ARRAY_FOR(modp->revs, u) {
         yprp_revision(ctx, &modp->revs[u]);
     }
     /* body-stmts */
     LY_ARRAY_FOR(modp->extensions, u) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
         yprp_extension(ctx, &modp->extensions[u]);
     }
     if (modp->exts) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
         yprp_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, module->parsed->exts, NULL, 0);
     }
 
@@ -2293,14 +2293,14 @@ yang_print_parsed(struct lyout *out, const struct lys_module *module)
     }
 
     LEVEL--;
-    ly_print(out, "%*s}\n", INDENT);
+    lyp_print(out, "%*s}\n", INDENT);
     ly_print_flush(out);
 
     return LY_SUCCESS;
 }
 
 LY_ERR
-yang_print_compiled_node(struct lyout *out, const struct lysc_node *node, int options)
+yang_print_compiled_node(struct lyp_out *out, const struct lysc_node *node, int options)
 {
     struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = node->module, .options = options}, *ctx = &ctx_;
 
@@ -2311,18 +2311,18 @@ yang_print_compiled_node(struct lyout *out, const struct lysc_node *node, int op
 }
 
 LY_ERR
-yang_print_compiled(struct lyout *out, const struct lys_module *module, int options)
+yang_print_compiled(struct lyp_out *out, const struct lys_module *module, int options)
 {
     LY_ARRAY_SIZE_TYPE u;
     struct lysc_node *data;
     struct lysc_module *modc = module->compiled;
     struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
 
-    ly_print(ctx->out, "%*smodule %s {\n", INDENT, module->name);
+    lyp_print(ctx->out, "%*smodule %s {\n", INDENT, module->name);
     LEVEL++;
 
     if (!modc) {
-        ly_print(ctx->out, "%*s/* COMPILED INFORMATION ARE NOT PRESENT */\n", INDENT);
+        lyp_print(ctx->out, "%*s/* COMPILED INFORMATION ARE NOT PRESENT */\n", INDENT);
         return ypr_missing_format(ctx, module);
     }
 
@@ -2337,7 +2337,7 @@ yang_print_compiled(struct lyout *out, const struct lys_module *module, int opti
 
     /* linkage-stmts */
     LY_ARRAY_FOR(modc->imports, u) {
-        ly_print(out, "\n%*simport %s {\n", INDENT, modc->imports[u].module->name);
+        lyp_print(out, "\n%*simport %s {\n", INDENT, modc->imports[u].module->name);
         LEVEL++;
         yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, modc->imports[u].exts, NULL, 0);
         ypr_substmt(ctx, LYEXT_SUBSTMT_PREFIX, 0, modc->imports[u].prefix, modc->imports[u].exts);
@@ -2345,12 +2345,12 @@ yang_print_compiled(struct lyout *out, const struct lys_module *module, int opti
             ypr_substmt(ctx, LYEXT_SUBSTMT_REVISIONDATE, 0, modc->imports[u].module->revision, modc->imports[u].exts);
         }
         LEVEL--;
-        ly_print(out, "%*s}\n", INDENT);
+        lyp_print(out, "%*s}\n", INDENT);
     }
 
     /* meta-stmts */
     if (module->org || module->contact || module->dsc || module->ref) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
     }
     ypr_substmt(ctx, LYEXT_SUBSTMT_ORGANIZATION, 0, module->org, modc->exts);
     ypr_substmt(ctx, LYEXT_SUBSTMT_CONTACT, 0, module->contact, modc->exts);
@@ -2359,12 +2359,12 @@ yang_print_compiled(struct lyout *out, const struct lys_module *module, int opti
 
     /* revision-stmts */
     if (module->revision) {
-        ly_print(ctx->out, "\n%*srevision %s;\n", INDENT, module->revision);
+        lyp_print(ctx->out, "\n%*srevision %s;\n", INDENT, module->revision);
     }
 
     /* body-stmts */
     if (modc->exts) {
-        ly_print(out, "\n");
+        lyp_print(out, "\n");
         yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, module->compiled->exts, NULL, 0);
     }
 
@@ -2391,7 +2391,7 @@ yang_print_compiled(struct lyout *out, const struct lys_module *module, int opti
     }
 
     LEVEL--;
-    ly_print(out, "%*s}\n", INDENT);
+    lyp_print(out, "%*s}\n", INDENT);
     ly_print_flush(out);
 
     return LY_SUCCESS;

--- a/src/tree.h
+++ b/src/tree.h
@@ -24,6 +24,14 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup trees Trees
+ *
+ * Generic macros, functions, etc. to work with both [schema](@ref schematree) and [data](@ref datatree) trees.
+ *
+ * @{
+ */
+
+/**
  * @brief Type (i.e. size) of the [sized array](@ref sizedarrays)'s size counter.
  *
  * To print the value via a print format, use LY_PRI_ARRAY_SIZE_TYPE specifier.
@@ -68,13 +76,6 @@ extern "C" {
     for (INDEX = 0; \
          ARRAY && INDEX < (*((LY_ARRAY_SIZE_TYPE*)(ARRAY) - 1)); \
          ++INDEX)
-
-/**
- * @defgroup schematree Schema Tree
- * @{
- *
- * Data structures and functions to manipulate and access schema tree.
- */
 
 /**
  * @brief Get a number of records in the ARRAY.
@@ -165,7 +166,7 @@ typedef enum
  */
 extern const char* ly_data_type2str[LY_DATA_TYPE_COUNT];
 
-/** @} */
+/** @} trees */
 
 #ifdef __cplusplus
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -31,6 +31,7 @@ extern "C" {
 
 /**
  * @defgroup datatree Data Tree
+ * @ingroup trees
  * @{
  *
  * Data structures and functions to manipulate and access instance data tree.

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -186,6 +186,73 @@ check:
 }
 
 API const struct lysc_node *
+lys_find_node(struct ly_ctx *ctx, const struct lysc_node *context_node, const char *qpath)
+{
+    const char *id = qpath;
+    const char *prefix, *name;
+    size_t prefix_len, name_len;
+    unsigned int u;
+    const struct lysc_node *node = context_node;
+    struct lys_module *mod = NULL;
+
+    LY_CHECK_ARG_RET(ctx, qpath, NULL);
+
+    while(*id) {
+        if (id[0] == '/') {
+            ++id;
+        }
+        /* precess ".." in relative paths */
+        while (!strncmp("../", id, 3)) {
+            id += 3;
+            if (!node) {
+                LOGERR(ctx, LY_EINVAL, "Invalid qpath \"%s\" - too many \"..\" in the path.", qpath);
+                return NULL;
+            }
+            node = node->parent;
+        }
+
+        if (ly_parse_nodeid(&id, &prefix, &prefix_len, &name, &name_len) != LY_SUCCESS) {
+            LOGERR(ctx, LY_EINVAL, "Invalid qpath \"%s\" - invalid nodeid \"%.*s\".", qpath, id- qpath, qpath);
+            return NULL;
+        }
+        if (prefix) {
+            if (context_node) {
+                mod = lys_module_find_prefix(context_node->module, prefix, prefix_len);
+            } else {
+                for (u = 0; u < ctx->list.count; ++u) {
+                    if (!ly_strncmp(((struct lys_module *)ctx->list.objs[u])->name, prefix, prefix_len)) {
+                        struct lys_module *m = (struct lys_module *)ctx->list.objs[u];
+                        if (mod) {
+                            if (m->implemented) {
+                                mod = m;
+                                break;
+                            } else if (m->latest_revision) {
+                                mod = m;
+                            }
+                        } else {
+                            mod = m;
+                        }
+                    }
+                }
+            }
+        }
+        if (!mod) {
+            LOGERR(ctx, LY_EINVAL, "Invalid qpath - unable to find module connected with the prefix of the node \"%.*s\".",
+                   id - qpath, qpath);
+            return NULL;
+        }
+
+        node = lys_find_child(node, mod, name, name_len, 0, LYS_GETNEXT_NOSTATECHECK);
+        if (!node) {
+            LOGERR(ctx, LY_EINVAL, "Invalid qpath - unable to find \"%.*s\".", id - qpath, qpath);
+            return NULL;
+        }
+    }
+
+    return node;
+}
+
+API const struct lysc_node *
 lys_find_child(const struct lysc_node *parent, const struct lys_module *module, const char *name, size_t name_len,
                uint16_t nodetype, int options)
 {

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -134,8 +134,6 @@ typedef enum {
     LYS_OUT_YIN = 3,     /**< YIN schema output format */
 
     LYS_OUT_TREE,        /**< Tree schema output format, for more information see the [printers](@ref howtoschemasprinters) page */
-    LYS_OUT_INFO,        /**< Info schema output format, for more information see the [printers](@ref howtoschemasprinters) page */
-    LYS_OUT_JSON,        /**< JSON schema output format, reflecting YIN format with conversion of attributes to object's members */
 } LYS_OUTFORMAT;
 
 #define LY_REV_SIZE 11   /**< revision data string length (including terminating NULL byte) */

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1938,6 +1938,25 @@ const struct lysc_node *lys_find_child(const struct lysc_node *parent, const str
                                        const char *name, size_t name_len, uint16_t nodetype, int options);
 
 /**
+ * @brief Get schema node specified by the schema path.
+ *
+ * In case the @p qpath uses prefixes (from imports or of the schema itself), the @p context_node must be specified
+ * even if the path is absolute. In case the @p context_node is not provided, the names of the schemas are expected as the
+ * node's prefixes in the @qpath. It also means that the relative paths are accepted only with the schema prefixes,
+ * not the full names.
+ *
+ * @param[in] ctx libyang context for logging and getting the correct schema if @p contet_node not provided.
+ * @param[in] context_node Context node for relative paths and/or as a source of the context module to resolve node's
+ * prefixes in @qpath.
+ * @param[in] qpath Schema path to be resolved. Not prefixed nodes inherits the prefix from its parent nodes. It means
+ * that the first node in the path must be prefixed. Both, import prefixes as well as full schema names are accepted as
+ * prefixes according to the @p context_node parameter presence.
+ * @return NULL in case of invalid path.
+ * @return found schema node.
+ */
+const struct lysc_node *lys_find_node(struct ly_ctx *ctx, const struct lysc_node *context_node, const char *qpath);
+
+/**
  * @brief Make the specific module implemented.
  *
  * @param[in] mod Module to make implemented. It is not an error

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -32,6 +32,14 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup schematree Schema Tree
+ * @ingroup trees
+ * @{
+ *
+ * Data structures and functions to manipulate and access schema tree.
+ */
+
+/**
  * @brief Macro to iterate via all elements in a schema tree which can be instantiated in data tree
  * (skips cases, input, output). This is the opening part to the #LYSC_TREE_DFS_END - they always have to be used together.
  *
@@ -577,7 +585,7 @@ struct lysp_augment {
 #define LYS_DEV_ADD 2                /**< deviate type add */
 #define LYS_DEV_DELETE 3             /**< deviate type delete */
 #define LYS_DEV_REPLACE 4            /**< deviate type replace */
-/** @} */
+/** @} deviatetypes */
 
 /**
  * @brief Generic deviate structure to get type and cast to lysp_deviate_* structure
@@ -740,7 +748,6 @@ struct lysp_deviation {
 
 /**
  * @defgroup snodeflags Schema nodes flags
- * @ingroup schematree
  * @{
  */
 #define LYS_CONFIG_W     0x01        /**< config true; also set for input children nodes */
@@ -805,7 +812,7 @@ struct lysp_deviation {
 #define LYS_ISENUM       0x200       /**< flag to simply distinguish type in struct lysc_type_bitenum_item */
 
 #define LYS_FLAGS_COMPILED_MASK 0xff /**< mask for flags that maps to the compiled structures */
-/** @} */
+/** @} snodeflags */
 
 /**
  * @brief Generic YANG data node
@@ -1206,9 +1213,7 @@ struct lysc_feature {
 #define LYS_IFF_AND  0x01 /**< operand "and" */
 #define LYS_IFF_OR   0x02 /**< operand "or" */
 #define LYS_IFF_F    0x03 /**< feature */
-/**
- * @}
- */
+/** @} ifftokens */
 
 /**
  * @brief Compiled YANG revision statement
@@ -1906,8 +1911,6 @@ const struct lysc_node *lys_getnext(const struct lysc_node *last, const struct l
 
 /**
  * @defgroup sgetnextflags lys_getnext() flags
- * @ingroup schematree
- *
  * @{
  */
 #define LYS_GETNEXT_WITHCHOICE   0x01 /**< lys_getnext() option to allow returning #LYS_CHOICE nodes instead of looking into them */
@@ -2002,7 +2005,7 @@ LY_ERR lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node
  */
 const char *lys_nodetype2str(uint16_t nodetype);
 
-/** @} */
+/** @} schematree */
 
 #ifdef __cplusplus
 }

--- a/src/xml.c
+++ b/src/xml.c
@@ -1025,7 +1025,7 @@ lyxml_ctx_free(struct lyxml_ctx *xmlctx)
 }
 
 LY_ERR
-lyxml_dump_text(struct lyout *out, const char *text, int attribute)
+lyxml_dump_text(struct lyp_out *out, const char *text, int attribute)
 {
     LY_ERR ret = LY_SUCCESS;
     unsigned int u;
@@ -1037,23 +1037,23 @@ lyxml_dump_text(struct lyout *out, const char *text, int attribute)
     for (u = 0; text[u]; u++) {
         switch (text[u]) {
         case '&':
-            ret = ly_print(out, "&amp;");
+            ret = lyp_print(out, "&amp;");
             break;
         case '<':
-            ret = ly_print(out, "&lt;");
+            ret = lyp_print(out, "&lt;");
             break;
         case '>':
             /* not needed, just for readability */
-            ret = ly_print(out, "&gt;");
+            ret = lyp_print(out, "&gt;");
             break;
         case '"':
             if (attribute) {
-                ret = ly_print(out, "&quot;");
+                ret = lyp_print(out, "&quot;");
                 break;
             }
             /* falls through */
         default:
-            ly_write(out, &text[u], 1);
+            lyp_write(out, &text[u], 1);
         }
     }
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -22,7 +22,7 @@
 #include "set.h"
 #include "tree_schema.h"
 
-struct lyout;
+struct lyp_out;
 struct ly_prefix;
 
 /* Macro to test if character is whitespace */
@@ -128,7 +128,7 @@ const struct lyxml_ns *lyxml_ns_get(struct lyxml_ctx *xmlctx, const char *prefix
  * @param[in] attribute Flag for attribute's value where a double quotes must be replaced.
  * @return LY_ERR values.
  */
-LY_ERR lyxml_dump_text(struct lyout *out, const char *text, int attribute);
+LY_ERR lyxml_dump_text(struct lyp_out *out, const char *text, int attribute);
 
 /**
  * @brief Remove the allocated working memory of the context.

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -400,6 +400,8 @@ cast_string_recursive(const struct lyd_node *node, int fake_cont, enum lyxp_node
             buf = strdup("");
             LY_CHECK_ERR_RET(!buf, LOGMEM(LYD_NODE_CTX(node)), LY_EMEM);
         } else {
+            struct lyp_out *out;
+
             switch (any->value_type) {
             case LYD_ANYDATA_STRING:
             case LYD_ANYDATA_XML:
@@ -408,8 +410,10 @@ cast_string_recursive(const struct lyd_node *node, int fake_cont, enum lyxp_node
                 LY_CHECK_ERR_RET(!buf, LOGMEM(LYD_NODE_CTX(node)), LY_EMEM);
                 break;
             case LYD_ANYDATA_DATATREE:
-                rc = lyd_print_mem(&buf, any->value.tree, LYD_XML, LYDP_WITHSIBLINGS);
-                LY_CHECK_RET(rc);
+                out = lyp_new_memory(&buf, 0);
+                rc = lyd_print(out, any->value.tree, LYD_XML, LYDP_WITHSIBLINGS);
+                lyp_free(out, NULL, 0);
+                LY_CHECK_RET(rc < 0, -rc);
                 break;
             /* TODO case LYD_ANYDATA_LYB:
                 LOGERR(LYD_NODE_CTX(node), LY_EINVAL, "Cannot convert LYB anydata into string.");

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -175,6 +175,9 @@ test_anydata(void **state)
     char *str;
     struct lyd_node *tree;
 
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
+
     data =
     "<any xmlns=\"urn:tests:a\">"
         "<element1>"
@@ -187,7 +190,7 @@ test_anydata(void **state)
     assert_int_equal(LYS_ANYDATA, tree->schema->nodetype);
     assert_string_equal("any", tree->schema->name);
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str,
         "<any xmlns=\"urn:tests:a\">"
             "<element1>"
@@ -196,9 +199,11 @@ test_anydata(void **state)
             "<element1a/>"
         "</any>"
     );
-    free(str);
+    lyp_out_reset(out);
 
     lyd_free_all(tree);
+    lyp_free(out, NULL, 1);
+
     *state = NULL;
 }
 
@@ -319,6 +324,9 @@ test_opaq(void **state)
     char *str;
     struct lyd_node *tree;
 
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
+
     /* invalid value, no flags */
     data = "<foo3 xmlns=\"urn:tests:a\"/>";
     assert_int_equal(LY_EVALID, lyd_parse_xml_data(ctx, data, LYD_VALOPT_DATA_ONLY, &tree));
@@ -332,9 +340,9 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "foo3");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str, "<foo3 xmlns=\"urn:tests:a\"/>");
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* missing key, no flags */
@@ -350,9 +358,9 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str, data);
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* invalid key, no flags */
@@ -368,15 +376,17 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str, data);
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* opaq flag and fail */
     assert_int_equal(LY_EVALID, lyd_parse_xml_data(ctx, "<a xmlns=\"ns\"><b>x</b><c xml:id=\"D\">1</c></a>",
             LYD_OPT_OPAQ | LYD_VALOPT_DATA_ONLY, &tree));
     assert_null(tree);
+
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }
@@ -390,6 +400,9 @@ test_rpc(void **state)
     char *str;
     struct lyd_node *tree, *op;
     const struct lyd_node *node;
+
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
 
     data =
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
@@ -434,7 +447,7 @@ test_rpc(void **state)
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "z");
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str,
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
             "<edit-config>"
@@ -453,11 +466,13 @@ test_rpc(void **state)
                 "</config>"
             "</edit-config>"
         "</rpc>");
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* wrong namespace, element name, whatever... */
     /* TODO */
+
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }
@@ -471,6 +486,9 @@ test_action(void **state)
     char *str;
     struct lyd_node *tree, *op;
     const struct lyd_node *node;
+
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
 
     data =
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
@@ -496,7 +514,7 @@ test_action(void **state)
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "action");
     assert_null(((struct lyd_node_opaq *)node)->attr);
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str,
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
             "<action xmlns=\"urn:ietf:params:xml:ns:yang:1\">"
@@ -507,11 +525,13 @@ test_action(void **state)
                 "</c>"
             "</action>"
         "</rpc>");
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* wrong namespace, element name, whatever... */
     /* TODO */
+
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }
@@ -525,6 +545,9 @@ test_notification(void **state)
     char *str;
     struct lyd_node *tree, *ntf;
     const struct lyd_node *node;
+
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
 
     data =
         "<notification xmlns=\"urn:ietf:params:xml:ns:netconf:notification:1.0\">"
@@ -553,9 +576,9 @@ test_notification(void **state)
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "c");
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str, data);
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* top-level notif without envelope */
@@ -568,13 +591,15 @@ test_notification(void **state)
     assert_non_null(tree);
     assert_ptr_equal(ntf, tree);
 
-    lyd_print_mem(&str, tree, LYD_XML, 0);
+    lyd_print(out, tree, LYD_XML, 0);
     assert_string_equal(str, data);
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* wrong namespace, element name, whatever... */
     /* TODO */
+
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }
@@ -588,6 +613,9 @@ test_reply(void **state)
     char *str;
     struct lyd_node *request, *tree, *op;
     const struct lyd_node *node;
+
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
 
     data =
         "<c xmlns=\"urn:tests:a\">"
@@ -619,14 +647,16 @@ test_reply(void **state)
     assert_string_equal(node->schema->name, "c");
 
     /* TODO print only rpc-reply node and then output subtree */
-    lyd_print_mem(&str, lyd_node_children(op), LYD_XML, 0);
+    lyd_print(out, lyd_node_children(op), LYD_XML, 0);
     assert_string_equal(str,
         "<al xmlns=\"urn:tests:a\">25</al>");
-    free(str);
+    lyp_out_reset(out);
     lyd_free_all(tree);
 
     /* wrong namespace, element name, whatever... */
     /* TODO */
+
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -1019,13 +1019,16 @@ test_defaults(void **state)
     struct lyd_node *tree, *node;
     const struct lys_module *mod = ly_ctx_get_module_latest(ctx, "f");
 
+    struct lyp_out *out;
+    assert_non_null(out = lyp_new_memory(&str, 0));
+
     /* get defaults */
     tree = NULL;
     assert_int_equal(lyd_validate_modules(&tree, &mod, 1, 0), LY_SUCCESS);
     assert_non_null(tree);
 
     /* check all defaults exist */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<ll1 xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def1</ll1>"
         "<ll1 xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def2</ll1>"
@@ -1041,7 +1044,7 @@ test_defaults(void **state)
             "<ll2 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">dflt1</ll2>"
             "<ll2 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">dflt2</ll2>"
         "</cont>");
-    free(str);
+    lyp_out_reset(out);
 
     /* create another explicit case and validate */
     node = lyd_new_term(NULL, mod, "l", "value");
@@ -1050,7 +1053,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate(&tree, ctx, LYD_VALOPT_DATA_ONLY), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<d xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">dflt1</ll2>"
@@ -1064,7 +1067,7 @@ test_defaults(void **state)
             "<ll2 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">dflt2</ll2>"
         "</cont>"
         "<l xmlns=\"urn:tests:f\">value</l>");
-    free(str);
+    lyp_out_reset(out);
 
     /* create explicit leaf-list and leaf and validate */
     node = lyd_new_term(NULL, mod, "d", "15");
@@ -1076,7 +1079,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate(&tree, ctx, LYD_VALOPT_DATA_ONLY), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<cont xmlns=\"urn:tests:f\">"
             "<ll1 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def1</ll1>"
@@ -1089,7 +1092,7 @@ test_defaults(void **state)
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\">dflt2</ll2>");
-    free(str);
+    lyp_out_reset(out);
 
     /* create first explicit container, which should become implicit */
     node = lyd_new_inner(NULL, mod, "cont");
@@ -1099,7 +1102,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate(&tree, ctx, LYD_VALOPT_DATA_ONLY), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<cont xmlns=\"urn:tests:f\">"
             "<ll1 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def1</ll1>"
@@ -1112,7 +1115,7 @@ test_defaults(void **state)
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\">dflt2</ll2>");
-    free(str);
+    lyp_out_reset(out);
 
     /* create second explicit container, which should become implicit, so the first tree node should be removed */
     node = lyd_new_inner(NULL, mod, "cont");
@@ -1121,7 +1124,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate(&tree, ctx, LYD_VALOPT_DATA_ONLY), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<cont xmlns=\"urn:tests:f\">"
             "<ll1 xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def1</ll1>"
@@ -1134,7 +1137,7 @@ test_defaults(void **state)
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\">dflt2</ll2>");
-    free(str);
+    lyp_out_reset(out);
 
     /* similar changes for nested defaults */
     assert_non_null(lyd_new_term(tree, NULL, "ll1", "def3"));
@@ -1143,7 +1146,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate(&tree, ctx, LYD_VALOPT_DATA_ONLY), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_mem(&str, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
+    lyd_print(out, tree, LYD_XML, LYDP_WITHSIBLINGS | LYDP_WD_IMPL_TAG);
     assert_string_equal(str,
         "<cont xmlns=\"urn:tests:f\">"
             "<ll1>def3</ll1>"
@@ -1153,9 +1156,10 @@ test_defaults(void **state)
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\">dflt2</ll2>");
-    free(str);
+    lyp_out_reset(out);
 
     lyd_free_siblings(tree);
+    lyp_free(out, NULL, 1);
 
     *state = NULL;
 }

--- a/tests/utests/schema/test_printer_yang.c
+++ b/tests/utests/schema/test_printer_yang.c
@@ -131,16 +131,19 @@ test_module(void **state)
             "    \"some reference\";\n"
             "}\n";
     char *printed;
+    struct lyp_out *out;
+    size_t size = 0;
 
+    assert_non_null(out = lyp_new_memory(&printed, 0));
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0, &ctx));
 
     assert_non_null(mod = lys_parse_mem(ctx, orig, LYS_IN_YANG));
-    assert_int_equal(strlen(orig), lys_print_mem(&printed, mod, LYS_OUT_YANG, 0, 0));
+    assert_int_equal(strlen(orig), size = lys_print(out, mod, LYS_OUT_YANG, 0, 0));
     assert_string_equal(printed, orig);
-    free(printed);
-    assert_int_equal(strlen(compiled), lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0, 0));
+    lyp_out_reset(out);
+    assert_int_equal(strlen(compiled), lys_print(out, mod, LYS_OUT_YANG_COMPILED, 0, 0));
     assert_string_equal(printed, compiled);
-    free(printed);
+    lyp_out_reset(out);
 
     orig = "module b {\n"
             "  yang-version 1.1;\n"
@@ -184,12 +187,12 @@ test_module(void **state)
             "  }\n"
             "}\n";
     assert_non_null(mod = lys_parse_mem(ctx, orig, LYS_IN_YANG));
-    assert_int_equal(strlen(orig), lys_print_mem(&printed, mod, LYS_OUT_YANG, 0, 0));
+    assert_int_equal(strlen(orig), lys_print(out, mod, LYS_OUT_YANG, 0, 0));
     assert_string_equal(printed, orig);
-    free(printed);
-    assert_int_equal(strlen(compiled), lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0, 0));
+    lyp_out_reset(out);
+    assert_int_equal(strlen(compiled), lys_print(out, mod, LYS_OUT_YANG_COMPILED, 0, 0));
     assert_string_equal(printed, compiled);
-    free(printed);
+    lyp_out_reset(out);
 
     orig = compiled ="module c {\n"
             "  yang-version 1.1;\n"
@@ -209,14 +212,15 @@ test_module(void **state)
             "  }\n"
             "}\n";
     assert_non_null(mod = lys_parse_mem(ctx, orig, LYS_IN_YANG));
-    assert_int_equal(strlen(orig), lys_print_mem(&printed, mod, LYS_OUT_YANG, 0, 0));
+    assert_int_equal(strlen(orig), lys_print(out, mod, LYS_OUT_YANG, 0, 0));
     assert_string_equal(printed, orig);
-    free(printed);
-    assert_int_equal(strlen(compiled), lys_print_mem(&printed, mod, LYS_OUT_YANG, 0, 0));
+    lyp_out_reset(out);
+    assert_int_equal(strlen(compiled), lys_print(out, mod, LYS_OUT_YANG, 0, 0));
     assert_string_equal(printed, compiled);
-    free(printed);
+    /* missing free(printed); which is done in the following lyp_free() */
 
     *state = NULL;
+    lyp_free(out, NULL, 1);
     ly_ctx_destroy(ctx, NULL);
 }
 

--- a/tests/utests/schema/test_printer_yin.c
+++ b/tests/utests/schema/test_printer_yin.c
@@ -578,20 +578,27 @@ test_module(void **state)
             "  </rpc>\n"
             "</module>\n";
 
-    char * printed;
+    char *printed;
+    struct lyp_out *out;
+
+    assert_non_null(out = lyp_new_memory(&printed, 0));
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0, &ctx));
 
     assert_non_null(mod = lys_parse_mem(ctx, orig, LYS_IN_YANG));
-    assert_int_equal(strlen(ori_res), lys_print_mem(&printed, mod, LYS_OUT_YIN, 0, 0));
+    assert_int_equal(strlen(ori_res), lys_print(out, mod, LYS_OUT_YIN, 0, 0));
     assert_string_equal(printed, ori_res);
-    free(printed);
+
     /*
+    lyp_memory_clean(out);
     assert_int_equal(strlen(compiled), lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0, 0));
     assert_string_equal(printed, compiled);
-    free(printed);
     */
 
+    /* note that the printed is freed here, so it must not be freed via lyp_free()! */
+    free(printed);
+
     *state = NULL;
+    lyp_free(out, NULL, 0);
     ly_ctx_destroy(ctx, NULL);
 }
 

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -435,7 +435,7 @@ cmd_print(const char *arg)
             target_path = optarg;
             break;
         case 's':
-            output_opts |= LYS_OUTPUT_NO_SUBST;
+            output_opts |= LYS_OUTPUT_NO_SUBSTMT;
             break;
 #if 0
         case 'L':

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -346,7 +346,7 @@ cmd_print(const char *arg)
     const char *out_path = NULL, *target_path = NULL;
     const struct lys_module *module;
     LYS_OUTFORMAT format = LYS_OUT_TREE;
-    FILE *output = stdout;
+    struct lyp_out *out = NULL;
     static struct option long_options[] = {
         {"help", no_argument, 0, 'h'},
         {"format", required_argument, 0, 'f'},
@@ -494,26 +494,31 @@ cmd_print(const char *arg)
     }
 
     if (out_path) {
-        output = fopen(out_path, "w");
-        if (!output) {
-            fprintf(stderr, "Could not open the output file (%s).\n", strerror(errno));
-            goto cleanup;
-        }
+        out = lyp_new_filepath(out_path);
+    } else {
+        out = lyp_new_file(stdout);
+    }
+    if (!out) {
+        fprintf(stderr, "Could not open the output file (%s).\n", strerror(errno));
+        goto cleanup;
     }
 
     if (target_path) {
-        ret = lys_node_print_file(output, ctx, NULL, format, target_path, tree_ll, output_opts);
+        const struct lysc_node *node = lys_find_node(ctx, NULL, target_path);
+        if (node) {
+            ret = lys_print_node(out, node, format, tree_ll, output_opts);
+        } else {
+            fprintf(stderr, "The requested schema node \"%s\" does not exists.\n", target_path);
+        }
     } else {
-        ret = lys_print_file(output, module, format, tree_ll, output_opts);
+        ret = lys_print(out, module, format, tree_ll, output_opts);
     }
 
 cleanup:
     free(*argv);
     free(argv);
 
-    if (output && (output != stdout)) {
-        fclose(output);
-    }
+    lyp_free(out, NULL, out_path ? 1 : 0);
 
     return ret;
 }
@@ -693,8 +698,9 @@ cmd_data(const char *arg)
     const char *out_path = NULL;
     struct lyd_node *data = NULL;
     struct lyd_node *tree = NULL;
+    const struct lyd_node **trees = NULL;
     LYD_FORMAT outformat = 0;
-    FILE *output = stdout;
+    struct lyp_out *out = NULL;
     static struct option long_options[] = {
         {"defaults", required_argument, 0, 'd'},
         {"help", no_argument, 0, 'h'},
@@ -829,15 +835,17 @@ cmd_data(const char *arg)
     }
 
     if (out_path) {
-        output = fopen(out_path, "w");
-        if (!output) {
-            fprintf(stderr, "Could not open the output file (%s).\n", strerror(errno));
-            goto cleanup;
-        }
+        out = lyp_new_filepath(out_path);
+    } else {
+        out = lyp_new_file(stdout);
+    }
+    if (!out) {
+        fprintf(stderr, "Could not open the output file (%s).\n", strerror(errno));
+        goto cleanup;
     }
 
     if (outformat) {
-        lyd_print_file(output, data, outformat, LYDP_WITHSIBLINGS | LYDP_FORMAT | printopt);
+        lyd_print(out, data, outformat, LYDP_WITHSIBLINGS | LYDP_FORMAT | printopt);
     }
 
     ret = 0;
@@ -846,9 +854,7 @@ cleanup:
     free(*argv);
     free(argv);
 
-    if (output && (output != stdout)) {
-        fclose(output);
-    }
+    lyp_free(out, NULL, out_path ? 1 : 0);
 
     lyd_free_all(data);
 

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -125,7 +125,12 @@ help(int shortout)
         "                        Print only the specified subtree.\n"
         "  --tree-line-length=LINE_LENGTH\n"
         "                        Wrap lines if longer than the specified length (it is not a strict limit, longer lines\n"
-        "                        can often appear).\n"
+        "                        can often appear).\n\n"
+        "Info output specific options:\n"
+        "  -P INFOPATH, --info-path=INFOPATH\n"
+        "                        - Schema path with full module names used as node's prefixes, the path identify the root\n"
+        "                          node of the subtree to print information about.\n"
+        "  --single-node         - Print information about a single node instead of a subtree."
         "\n");
 }
 
@@ -280,10 +285,12 @@ main_ni(int argc, char* argv[])
 #endif
         {"output",           required_argument, NULL, 'o'},
         {"path",             required_argument, NULL, 'p'},
+        {"info-path",        required_argument, NULL, 'P'},
 #if 0
         {"running",          required_argument, NULL, 'r'},
         {"operational",      required_argument, NULL, 'O'},
 #endif
+        {"single-node",      no_argument,       NULL, 'q'},
         {"strict",           no_argument,       NULL, 's'},
         {"type",             required_argument, NULL, 't'},
         {"version",          no_argument,       NULL, 'v'},
@@ -422,9 +429,11 @@ main_ni(int argc, char* argv[])
         case 'n':
             outoptions_s |= LYS_OUTOPT_TREE_NO_LEAFREF;
             break;
+#endif
         case 'P':
             outtarget_s = optarg;
             break;
+#if 0
         case 'L':
             outline_length_s = atoi(optarg);
             break;
@@ -752,11 +761,15 @@ main_ni(int argc, char* argv[])
 
     /* convert (print) to FORMAT */
     if (outformat_s) {
-        for (u = 0; u < mods->count; u++) {
-            if (u) {
-                fputs("\n", out);
+        if (outtarget_s) {
+            lys_node_print_file(out, ctx, NULL, outformat_s, outtarget_s, outline_length_s, outoptions_s);
+        } else {
+            for (u = 0; u < mods->count; u++) {
+                if (u) {
+                    fputs("\n", out);
+                }
+                lys_print_file(out, (struct lys_module *)mods->objs[u], outformat_s, outline_length_s, outoptions_s);
             }
-            lys_print_file(out, (struct lys_module *)mods->objs[u], outformat_s, outline_length_s, outoptions_s);
         }
     } else if (data) {
 


### PR DESCRIPTION
Print compiled YANG as (instead of) info format. There is also a possibility to print information about a single node or a subtree. What I'm not sure about is format of the schema path - the initial implementation requires full schema module names to be used as prefixes. As an alternative, it would be passible to use import prefixes refering to a specific schema module.