### PR TITLE
tests/fuzz: New AFL target: function lyd_parse_path()

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(fuzz_targets yangfuzz xmlfuzz)
+set(fuzz_targets yangfuzz xmlfuzz jsonfuzz lybfuzz xml_lyd_parse_path_fuzz)
 
 foreach(target_name IN LISTS fuzz_targets)
     add_executable(${target_name} ${target_name}.c)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(fuzz_targets yangfuzz xmlfuzz jsonfuzz lybfuzz xml_lyd_parse_path_fuzz)
+set(fuzz_targets yangfuzz xmlfuzz jsonfuzz lybfuzz xml_lyd_parse_path_fuzz yinfuzz)
 
 foreach(target_name IN LISTS fuzz_targets)
     add_executable(${target_name} ${target_name}.c)

--- a/tests/fuzz/jsonfuzz.c
+++ b/tests/fuzz/jsonfuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lyd_parse_path(ctx, argv[1], LYD_JSON, LYD_OPT_DATA);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}

--- a/tests/fuzz/lybfuzz.c
+++ b/tests/fuzz/lybfuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lyd_parse_path(ctx, argv[1], LYD_LYB, LYD_OPT_DATA);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}

--- a/tests/fuzz/xml_lyd_parse_path_fuzz.c
+++ b/tests/fuzz/xml_lyd_parse_path_fuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lyd_parse_path(ctx, argv[1], LYD_XML, LYD_OPT_DATA);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}

--- a/tests/fuzz/yinfuzz.c
+++ b/tests/fuzz/yinfuzz.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int main(int argc, char **argv) {
+    struct ly_ctx *ctx = NULL;
+
+    if (argc != 2) {
+        fprintf(stderr, "invalid usage\n");
+        exit(EXIT_FAILURE);
+    }
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        fprintf(stderr, "failed to create context.\n");
+        return 1;
+    }
+
+    while (__AFL_LOOP(100)) {
+        lys_parse_path(ctx, argv[1], LYS_IN_YIN);
+
+        ly_ctx_clean(ctx, NULL);
+    }
+
+    ly_ctx_destroy(ctx, NULL);
+}


### PR DESCRIPTION
For each of the three supported formats: JSON, XML, LYB.
The JSON version crashes very quickly, xml after some time too.