### PR TITLE
fixed issue printing xml where namespace was printed multiple times on anydata

### DIFF
--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -55,8 +55,8 @@ modlist_add(struct mlist **mlist, const struct lys_module *mod)
         LY_CHECK_ERR_RETURN(!iter, LOGMEM(mod->ctx), EXIT_FAILURE);
         iter->next = *mlist;
         iter->module = (struct lys_module *)mod;
-	iter->printed = 0;
-	*mlist = iter;
+        iter->printed = 0;
+        *mlist = iter;
     }
 
     return EXIT_SUCCESS;
@@ -153,7 +153,7 @@ print:
 
         if (!miter->printed) {
             ly_print(out, " xmlns:%s=\"%s\"", miter->module->prefix, miter->module->ns);
-	    miter->printed = 1;
+            miter->printed = 1;
         }
         miter = miter->next;
     }
@@ -510,8 +510,8 @@ xml_print_list(struct lyout *out, int level, const struct lyd_node *node, int is
         }
 
         if (toplevel) {
-	    xml_print_ns(out, node, &mlist, options);
-	    free_mlist(&mlist);
+            xml_print_ns(out, node, &mlist, options);
+            free_mlist(&mlist);
         }
         if (xml_print_attrs(out, node, options)) {
             return EXIT_FAILURE;
@@ -582,12 +582,12 @@ xml_print_anydata(struct lyout *out, int level, const struct lyd_node *node, int
         if (any->value_type == LYD_ANYDATA_DATATREE) {
             /* print namespaces in the anydata data tree */
             LY_TREE_FOR(any->value.tree, iter) {
-		xml_print_ns(out, iter, &mlist, options);
+                xml_print_ns(out, iter, &mlist, options);
             }
         }
         /* close opening tag ... */
         ly_print(out, ">");
-	free_mlist(&mlist);
+        free_mlist(&mlist);
         /* ... and print anydata content */
         switch (any->value_type) {
         case LYD_ANYDATA_CONSTSTRING:

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -43,7 +43,7 @@ static int
 modlist_add(struct mlist **mlist, const struct lys_module *mod)
 {
     struct mlist *iter;
-    
+
     for (iter = *mlist; iter; iter = iter->next) {
         if (mod == iter->module) {
             break;
@@ -582,7 +582,7 @@ xml_print_anydata(struct lyout *out, int level, const struct lyd_node *node, int
         if (any->value_type == LYD_ANYDATA_DATATREE) {
             /* print namespaces in the anydata data tree */
             LY_TREE_FOR(any->value.tree, iter) {
-  	        xml_print_ns(out, iter, &mlist, options);
+		xml_print_ns(out, iter, &mlist, options);
             }
         }
         /* close opening tag ... */

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -43,6 +43,7 @@ static int
 modlist_add(struct mlist **mlist, const struct lys_module *mod)
 {
     struct mlist *iter;
+    
     for (iter = *mlist; iter; iter = iter->next) {
         if (mod == iter->module) {
             break;
@@ -63,12 +64,12 @@ modlist_add(struct mlist **mlist, const struct lys_module *mod)
 
 static void
 free_mlist(struct mlist **mlist) {
-  struct mlist *miter;
-  while(*mlist) {
-    miter = *mlist;
-    *mlist = miter->next;
-    free(miter);
-  }
+    struct mlist *miter;
+    while (*mlist) {
+        miter = *mlist;
+        *mlist = miter->next;
+        free(miter);
+    }
 }
 
 static void
@@ -151,11 +152,10 @@ print:
     while (miter) {
 
         if (!miter->printed) {
-          ly_print(out, " xmlns:%s=\"%s\"", miter->module->prefix, miter->module->ns);
-	  miter->printed = 1;
+            ly_print(out, " xmlns:%s=\"%s\"", miter->module->prefix, miter->module->ns);
+	    miter->printed = 1;
         }
         miter = miter->next;
-        // free(miter);
     }
 }
 
@@ -316,8 +316,8 @@ xml_print_leaf(struct lyout *out, int level, const struct lyd_node *node, int to
     }
 
     if (toplevel) {
-      xml_print_ns(out, node, &mlist, options);
-      free_mlist(&mlist);
+        xml_print_ns(out, node, &mlist, options);
+        free_mlist(&mlist);
     }
 
     if (xml_print_attrs(out, node, options)) {
@@ -464,8 +464,8 @@ xml_print_container(struct lyout *out, int level, const struct lyd_node *node, i
     }
 
     if (toplevel) {
-      xml_print_ns(out, node, &mlist, options);
-      free_mlist(&mlist);
+        xml_print_ns(out, node, &mlist, options);
+        free_mlist(&mlist);
     }
 
     if (xml_print_attrs(out, node, options)) {
@@ -510,8 +510,8 @@ xml_print_list(struct lyout *out, int level, const struct lyd_node *node, int is
         }
 
         if (toplevel) {
-	  xml_print_ns(out, node, &mlist, options);
-	  free_mlist(&mlist);
+	    xml_print_ns(out, node, &mlist, options);
+	    free_mlist(&mlist);
         }
         if (xml_print_attrs(out, node, options)) {
             return EXIT_FAILURE;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_MACOSX_RPATH TRUE)
 get_filename_component(TESTS_DIR "${CMAKE_SOURCE_DIR}/tests" REALPATH)
 
 set(api_tests test_libyang test_tree_schema test_xml test_dict test_tree_data test_tree_data_dup test_tree_data_merge test_xpath test_xpath_1.1 test_diff)
-set(data_tests test_data_initialization test_leafref_remove test_instid_remove test_keys test_autodel test_when test_when_1.1 test_must_1.1 test_defaults test_emptycont test_unique test_mandatory test_json test_parse_print test_values test_metadata test_yangtypes_xpath test_yang_data test_unknown_element test_user_types)
+set(data_tests test_data_initialization test_leafref_remove test_instid_remove test_keys test_autodel test_when test_when_1.1 test_must_1.1 test_defaults test_emptycont test_unique test_mandatory test_json test_parse_print test_values test_metadata test_yangtypes_xpath test_yang_data test_yang_data_ns test_unknown_element test_user_types)
 set(schema_yin_tests test_print_transform)
 set(schema_tests test_ietf test_augment test_deviation test_refine test_typedef test_import test_include test_feature test_conformance test_leaflist test_status test_printer test_invalid)
 if(CMAKE_BUILD_TYPE MATCHES debug)

--- a/tests/data/test_yang_data_ns.c
+++ b/tests/data/test_yang_data_ns.c
@@ -1,0 +1,307 @@
+/**
+ * @file test_yang_data_ns.c
+ * @author Peter Schoenmaker <pds@ntt.net>
+ * @brief Cmocka tests for YANG data namespace.
+ *
+ * Copyright (c) 2018 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <cmocka.h>
+
+#include "tests/config.h"
+#include "libyang.h"
+
+struct state {
+    struct ly_ctx *ctx;
+    const struct lys_module *mod1, *mod2;
+    struct lyd_node *dt;
+    char * str1, *str2;
+};
+
+static int
+setup_f(void **state)
+{
+    struct state *st;
+    const char *yang1 = "module yang-data-config-ns1 {\n"
+                       "  prefix dcn1;\n"
+                       "  namespace \"urn:cesnet:yang-data-config-ns1\";\n"
+                       "  container con1 {\n"
+                       "    leaf leaf1 {\n"
+                       "        type string;\n"
+                       "    }\n"
+                       "  }\n"
+                       "}";
+
+    const char *yang2 = "module yang-data-config-ns2 {\n"
+                       "  prefix dcn2;\n"
+                       "  namespace \"urn:cesnet:yang-data-config-ns2\";\n"
+                       "  container con2 {\n"
+                       "    leaf leaf2 {\n"
+                       "        type string;\n"
+                       "    }\n"
+                       "  }\n"
+                       "}";
+
+    (*state) = st = calloc(1, sizeof *st);
+    if (!st) {
+        fprintf(stderr, "Memory allocation error");
+        return -1;
+    }
+
+    /* libyang context */
+    st->ctx = ly_ctx_new(TESTS_DIR"/schema/yang/ietf/", 0);
+    if (!st->ctx) {
+        fprintf(stderr, "Failed to create context.\n");
+        return -1;
+    }
+
+    st->mod1 = lys_parse_mem(st->ctx, yang1, LYS_IN_YANG);
+    if (!st->mod1){
+        fprintf(stderr, "Failed to load module 1.\n");
+        return -1;
+    }
+    st->mod2 = lys_parse_mem(st->ctx, yang2, LYS_IN_YANG);
+    if (!st->mod2){
+        fprintf(stderr, "Failed to load module 2.\n");
+        return -1;
+    }
+    return 0;
+}
+
+static int
+teardown_f(void **state)
+{
+    struct state *st = (*state);
+
+    lyd_free_withsiblings(st->dt);
+    ly_ctx_destroy(st->ctx, NULL);
+    free(st->str1);
+    free(st->str2);
+    free(st);
+    (*state) = NULL;
+
+    return 0;
+}
+
+static void
+test_anydata_ns(void **state)
+{
+  struct state *st = (*state);
+  struct lys_module *mod;
+  struct lyd_attr *attr;
+  struct lyd_node *config, *node1, *node2, *nodet;
+  char *s;
+  FILE *f;
+  const char *opentag = "<config xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">";
+
+  mod = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
+  assert_ptr_not_equal(mod, NULL);
+
+  node1 = lyd_new(NULL, st->mod1, "con1");
+  assert_ptr_not_equal(node1, NULL);
+    
+  attr = lyd_insert_attr(node1, mod, "operation", "create");
+  assert_ptr_not_equal(attr, NULL);
+  
+  nodet = lyd_new_leaf(node1, st->mod1, "leaf1", "test1234");
+  assert_ptr_not_equal(nodet, NULL);
+
+  node2 = lyd_new(NULL, st->mod2, "con2");
+  assert_ptr_not_equal(node2, NULL);
+  
+  attr = lyd_insert_attr(node2, mod, "operation", "merge");
+  assert_ptr_not_equal(attr, NULL);
+
+  nodet = lyd_new_leaf(node2, st->mod2, "leaf2", "leaf2-test1234");
+  assert_ptr_not_equal(nodet, NULL);
+  
+  assert_return_code(lyd_insert_sibling(&node1, node2), 0);
+
+  config = lyd_new_anydata(NULL, mod, "config", node1, LYD_ANYDATA_DATATREE);
+  assert_ptr_not_equal(config, NULL);
+  st->dt = config;
+
+  lyd_print_mem(&s, st->dt, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+  assert_return_code(strncmp(s, opentag, strlen(opentag)), 0);
+  
+  fprintf(stderr, "stringlen is %d, sizeof is %d\nfdafsa%s\n", strlen(opentag), sizeof(opentag), s);
+  f = fopen("/tmp/test-out-xml", "w");
+  lyd_print_file(f, st->dt, LYD_XML,  LYP_WITHSIBLINGS | LYP_FORMAT | LYP_NETCONF );
+
+}
+
+static void
+test_print_xml_ns(void **state)
+{
+  struct state *st = (*state);
+
+  
+  assert_return_code(1, 0);
+  assert_ptr_not_equal(123, 123);
+}
+/*
+static void
+test_new_path(void **state)
+{
+    struct state *st = (*state);
+
+    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#node/test1/first", "test", 0 ,0);
+    assert_ptr_equal(st->dt, NULL);
+    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#node/test1/first", "50", 0 ,0);
+    assert_ptr_not_equal(st->dt, NULL);
+    assert_ptr_not_equal(lyd_new_path(st->dt, st->ctx, "/yang-data:#node/test1/second", "test-second", 0 ,0), NULL);
+    assert_ptr_equal(lyd_new_path(st->dt, st->ctx, "/yang-data:test1/third", "true", 0 ,0), NULL);
+}
+
+static void
+test_new_yangdata(void **state)
+{
+    struct state *st = (*state);
+
+    st->dt = lyd_new_yangdata(st->mod, "node", "test");
+    assert_ptr_not_equal(st->dt, NULL);
+    lyd_new_leaf(st->dt, st->mod, "num", "25");
+    assert_ptr_not_equal(st->dt->child, NULL);
+    st->str1 = lyd_path(st->dt->child);
+    assert_string_equal(st->str1, "/yang-data:#node/test/num");
+}
+
+static void
+test_mem_yangdata(void **state)
+{
+    struct state *st = (*state);
+    char *str;
+
+    char *xml_file = "<errors xmlns=\"urn:cesnet:yang-data\">\n"
+                     "  <error>\n"
+                     "    <error-type>protocol</error-type>\n"
+                     "    <error-tag>Bad packet</error-tag>\n"
+                     "  </error>\n"
+                     "</errors>\n"
+                     "<node xmlns=\"urn:cesnet:yang-data\">\n"
+                     "  <test>\n"
+                     "    <num>50</num>\n"
+                     "  </test>\n"
+                     "</node>\n";
+    char *json_file1 = "{\n"
+                       "   \"yang-data:errors\" : {\n"
+                       "     \"error\" : [\n"
+                       "       {\n"
+                       "         \"error-type\" : \"protocol\",\n"
+                       "         \"error-tag\" : \"Bad packet\"\n"
+                       "       }\n"
+                       "     ]\n"
+                       "   }\n"
+                       "   \"yang-data:node\" : {\n"
+                       "     \"test\" : {\n"
+                       "       \"num\" : 50\n"
+                       "     }\n"
+                       "   }\n"
+                       "}\n";
+    char *json_file2 = "{\n"
+                       "   \"yang-data:errors\" : {\n"
+                       "     \"error\" : [\n"
+                       "       {\n"
+                       "         \"error-type\" : \"protocol\",\n"
+                       "         \"error-tag\" : \"Bad packet\"\n"
+                       "       }\n"
+                       "     ]\n"
+                       "   }\n"
+                       "}\n";
+    st->dt = lyd_parse_mem(st->ctx, json_file1, LYD_JSON, LYD_OPT_DATA_TEMPLATE, "data");
+    assert_ptr_equal(st->dt, NULL);
+    st->dt = lyd_parse_mem(st->ctx, json_file2, LYD_JSON, LYD_OPT_DATA_TEMPLATE, "data");
+    assert_ptr_not_equal(st->dt, NULL);
+
+    lyd_print_mem(&str, st->dt, LYD_LYB, 0);
+    lyd_free(st->dt);
+    st->dt = lyd_parse_mem(st->ctx, str, LYD_LYB, LYD_OPT_DATA_TEMPLATE, "data");
+    free(str);
+    assert_ptr_not_equal(st->dt, NULL);
+    lyd_free(st->dt);
+
+    st->dt = lyd_parse_mem(st->ctx, xml_file, LYD_XML, LYD_OPT_DATA_TEMPLATE | LYD_OPT_STRICT, "data");
+    assert_ptr_equal(st->dt, NULL);
+    st->dt = lyd_parse_mem(st->ctx, xml_file, LYD_XML, LYD_OPT_DATA_TEMPLATE, "data");
+    assert_ptr_not_equal(st->dt, NULL);
+}
+
+static void
+test_validate_yangdata(void **state)
+{
+    struct state *st = (*state);
+
+    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#data/errors/error[1]/error-type", "transport", 0 ,0);
+    assert_return_code(lyd_validate(&st->dt, LYD_OPT_DATA_TEMPLATE, NULL), EXIT_FAILURE);
+    assert_ptr_not_equal(lyd_new_leaf(st->dt->child, st->mod, "error-tag", "Error"), NULL);
+    assert_return_code(lyd_validate(&st->dt, LYD_OPT_DATA_TEMPLATE, NULL), EXIT_SUCCESS);
+}
+
+static void
+test_path_yangdata(void **state)
+{
+    struct state *st = (*state);
+    struct ly_set *set;
+    const struct lys_node *node;
+    char *str;
+
+    st->dt = lyd_new_path(st->dt, st->ctx, "/yang-data:#node/test1/second", "test-second", 0 ,0);
+    set = lyd_find_path(st->dt,"/yang-data:#node/test1/second");
+    assert_ptr_not_equal(set, NULL);
+    assert_int_equal(set->number, 1);
+
+    st->str1 = lys_data_path(st->dt->child->schema);
+    st->str2 = lyd_path(st->dt->child);
+    assert_string_equal(st->str1, st->str2);
+    assert_string_equal(st->str1, "/yang-data:#node/test1/second");
+
+    str = st->str2;
+    free(st->str1);
+    st->str1 = lys_path(st->dt->child->schema, LYS_PATH_FIRST_PREFIX);
+    st->str2 = ly_path_data2schema(st->ctx,str);
+    free(str);
+    assert_string_equal(st->str1, st->str2);
+    assert_string_equal(st->str1, "/yang-data:#node/select/test1/test1/second");
+
+    ly_set_free(set);
+    set = lys_find_path(st->mod, NULL, st->str1);
+    assert_ptr_not_equal(set, NULL);
+    assert_int_equal(set->number, 1);
+
+    ly_set_free(set);
+    free(st->str1);
+    st->str1 = lys_path(st->dt->child->schema, 0);
+    set = ly_ctx_find_path(st->ctx, st->str1);
+    assert_ptr_not_equal(set, NULL);
+    assert_int_equal(set->number, 1);
+    ly_set_free(set);
+
+    free(st->str2);
+    st->str2 = lyd_path(st->dt->child);
+    node = ly_ctx_get_node(st->ctx, NULL, st->str2, 0);
+    assert_ptr_not_equal(node, NULL);
+}
+*/
+int main(void)
+{
+    const struct CMUnitTest tests[] = {
+	cmocka_unit_test_setup_teardown(test_anydata_ns, setup_f, teardown_f),
+	//	cmocka_unit_test_setup_teardown(test_print_xml_ns, setup_f, teardown_f),
+	//        cmocka_unit_test_setup_teardown(test_new_yangdata, setup_f, teardown_f),
+        //cmocka_unit_test_setup_teardown(test_path_yangdata, setup_f, teardown_f),
+	//    cmocka_unit_test_setup_teardown(test_validate_yangdata, setup_f, teardown_f),
+        //cmocka_unit_test_setup_teardown(test_mem_yangdata, setup_f, teardown_f),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/data/test_yang_data_ns.c
+++ b/tests/data/test_yang_data_ns.c
@@ -24,7 +24,7 @@
 
 struct state {
     struct ly_ctx *ctx;
-  const struct lys_module *mod1, *mod2, *mod_nc;
+    const struct lys_module *mod1, *mod2, *mod_nc;
     struct lyd_node *dt, *node1, *node2, *nodet;
 };
 
@@ -33,24 +33,24 @@ setup_f(void **state)
 {
     struct state *st;
     const char *yang1 = "module yang-data-config-ns1 {\n"
-                       "  prefix dcn1;\n"
-                       "  namespace \"urn:cesnet:yang-data-config-ns1\";\n"
-                       "  container con1 {\n"
-                       "    leaf leaf1 {\n"
-                       "        type string;\n"
-                       "    }\n"
-                       "  }\n"
-                       "}";
+	"  prefix dcn1;\n"
+	"  namespace \"urn:cesnet:yang-data-config-ns1\";\n"
+	"  container con1 {\n"
+	"    leaf leaf1 {\n"
+	"        type string;\n"
+	"    }\n"
+	"  }\n"
+	"}";
 
     const char *yang2 = "module yang-data-config-ns2 {\n"
-                       "  prefix dcn2;\n"
-                       "  namespace \"urn:cesnet:yang-data-config-ns2\";\n"
-                       "  container con2 {\n"
-                       "    leaf leaf2 {\n"
-                       "        type string;\n"
-                       "    }\n"
-                       "  }\n"
-                       "}";
+	"  prefix dcn2;\n"
+	"  namespace \"urn:cesnet:yang-data-config-ns2\";\n"
+	"  container con2 {\n"
+	"    leaf leaf2 {\n"
+	"        type string;\n"
+	"    }\n"
+	"  }\n"
+	"}";
 
     (*state) = st = calloc(1, sizeof *st);
     if (!st) {
@@ -94,41 +94,41 @@ teardown_f(void **state)
 static void
 test_anydata_ns(void **state)
 {
-  struct state *st = (*state);
-  struct lyd_attr *attr;
+    struct state *st = (*state);
+    struct lyd_attr *attr;
 
-  char *s;
-  const char *opentag = "<config xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">";
+    char *s;
+    const char *opentag = "<config xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">";
 
-  if(!(st->mod_nc = ly_ctx_get_module(st->ctx, "ietf-netconf", NULL, 0))) {
-      st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
-  }
-  assert_ptr_not_equal(st->mod_nc, NULL);
+    if(!(st->mod_nc = ly_ctx_get_module(st->ctx, "ietf-netconf", NULL, 0))) {
+	st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
+    }
+    assert_ptr_not_equal(st->mod_nc, NULL);
 
-  st->node1 = lyd_new(NULL, st->mod1, "con1");
-  assert_ptr_not_equal(st->node1, NULL);
+    st->node1 = lyd_new(NULL, st->mod1, "con1");
+    assert_ptr_not_equal(st->node1, NULL);
     
-  attr = lyd_insert_attr(st->node1, st->mod_nc, "operation", "create");
-  assert_ptr_not_equal(attr, NULL);
+    attr = lyd_insert_attr(st->node1, st->mod_nc, "operation", "create");
+    assert_ptr_not_equal(attr, NULL);
   
-  st->nodet = lyd_new_leaf(st->node1, st->mod1, "leaf1", "test1234");
-  assert_ptr_not_equal(st->nodet, NULL);
+    st->nodet = lyd_new_leaf(st->node1, st->mod1, "leaf1", "test1234");
+    assert_ptr_not_equal(st->nodet, NULL);
 
-  st->node2 = lyd_new(NULL, st->mod2, "con2");
-  assert_ptr_not_equal(st->node2, NULL);  
-  attr = lyd_insert_attr(st->node2, st->mod_nc, "operation", "merge");
-  assert_ptr_not_equal(attr, NULL);
+    st->node2 = lyd_new(NULL, st->mod2, "con2");
+    assert_ptr_not_equal(st->node2, NULL);  
+    attr = lyd_insert_attr(st->node2, st->mod_nc, "operation", "merge");
+    assert_ptr_not_equal(attr, NULL);
 
-  st->nodet = lyd_new_leaf(st->node2, st->mod2, "leaf2", "leaf2-test1234");
-  assert_ptr_not_equal(st->nodet, NULL);
+    st->nodet = lyd_new_leaf(st->node2, st->mod2, "leaf2", "leaf2-test1234");
+    assert_ptr_not_equal(st->nodet, NULL);
   
-  assert_return_code(lyd_insert_sibling(&(st->node1), st->node2), 0);
+    assert_return_code(lyd_insert_sibling(&(st->node1), st->node2), 0);
 
-  st->dt = lyd_new_anydata(NULL, st->mod_nc, "config", st->node1, LYD_ANYDATA_DATATREE);
-  assert_ptr_not_equal(st->dt, NULL);
+    st->dt = lyd_new_anydata(NULL, st->mod_nc, "config", st->node1, LYD_ANYDATA_DATATREE);
+    assert_ptr_not_equal(st->dt, NULL);
 
-  lyd_print_mem(&s, st->dt, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
-  assert_return_code(strncmp(s, opentag, strlen(opentag)), 0);
+    lyd_print_mem(&s, st->dt, LYD_XML, LYP_WITHSIBLINGS | LYP_FORMAT);
+    assert_return_code(strncmp(s, opentag, strlen(opentag)), 0);
   
 }
 

--- a/tests/data/test_yang_data_ns.c
+++ b/tests/data/test_yang_data_ns.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <setjmp.h>
 #include <stdarg.h>
+#include <string.h>
 #include <cmocka.h>
 
 #include "tests/config.h"
@@ -83,9 +84,6 @@ teardown_f(void **state)
     struct state *st = (*state);
 
     lyd_free_withsiblings(st->dt);
-    lyd_free_withsiblings(st->node1);
-    lyd_free_withsiblings(st->node2);
-    lyd_free_withsiblings(st->nodet);
     ly_ctx_destroy(st->ctx, NULL);
     free(st);
     (*state) = NULL;
@@ -102,7 +100,9 @@ test_anydata_ns(void **state)
   char *s;
   const char *opentag = "<config xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">";
 
-  st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
+  if(!(st->mod_nc = ly_ctx_get_module(st->ctx, "ietf-netconf", NULL, 0))) {
+      st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
+  }
   assert_ptr_not_equal(st->mod_nc, NULL);
 
   st->node1 = lyd_new(NULL, st->mod1, "con1");
@@ -132,167 +132,10 @@ test_anydata_ns(void **state)
   
 }
 
-static void
-test_print_xml_ns(void **state)
-{
-  struct state *st = (*state);
-
-  
-  assert_return_code(1, 0);
-  assert_ptr_not_equal(123, 123);
-}
-/*
-static void
-test_new_path(void **state)
-{
-    struct state *st = (*state);
-
-    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#node/test1/first", "test", 0 ,0);
-    assert_ptr_equal(st->dt, NULL);
-    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#node/test1/first", "50", 0 ,0);
-    assert_ptr_not_equal(st->dt, NULL);
-    assert_ptr_not_equal(lyd_new_path(st->dt, st->ctx, "/yang-data:#node/test1/second", "test-second", 0 ,0), NULL);
-    assert_ptr_equal(lyd_new_path(st->dt, st->ctx, "/yang-data:test1/third", "true", 0 ,0), NULL);
-}
-
-static void
-test_new_yangdata(void **state)
-{
-    struct state *st = (*state);
-
-    st->dt = lyd_new_yangdata(st->mod, "node", "test");
-    assert_ptr_not_equal(st->dt, NULL);
-    lyd_new_leaf(st->dt, st->mod, "num", "25");
-    assert_ptr_not_equal(st->dt->child, NULL);
-    st->str1 = lyd_path(st->dt->child);
-    assert_string_equal(st->str1, "/yang-data:#node/test/num");
-}
-
-static void
-test_mem_yangdata(void **state)
-{
-    struct state *st = (*state);
-    char *str;
-
-    char *xml_file = "<errors xmlns=\"urn:cesnet:yang-data\">\n"
-                     "  <error>\n"
-                     "    <error-type>protocol</error-type>\n"
-                     "    <error-tag>Bad packet</error-tag>\n"
-                     "  </error>\n"
-                     "</errors>\n"
-                     "<node xmlns=\"urn:cesnet:yang-data\">\n"
-                     "  <test>\n"
-                     "    <num>50</num>\n"
-                     "  </test>\n"
-                     "</node>\n";
-    char *json_file1 = "{\n"
-                       "   \"yang-data:errors\" : {\n"
-                       "     \"error\" : [\n"
-                       "       {\n"
-                       "         \"error-type\" : \"protocol\",\n"
-                       "         \"error-tag\" : \"Bad packet\"\n"
-                       "       }\n"
-                       "     ]\n"
-                       "   }\n"
-                       "   \"yang-data:node\" : {\n"
-                       "     \"test\" : {\n"
-                       "       \"num\" : 50\n"
-                       "     }\n"
-                       "   }\n"
-                       "}\n";
-    char *json_file2 = "{\n"
-                       "   \"yang-data:errors\" : {\n"
-                       "     \"error\" : [\n"
-                       "       {\n"
-                       "         \"error-type\" : \"protocol\",\n"
-                       "         \"error-tag\" : \"Bad packet\"\n"
-                       "       }\n"
-                       "     ]\n"
-                       "   }\n"
-                       "}\n";
-    st->dt = lyd_parse_mem(st->ctx, json_file1, LYD_JSON, LYD_OPT_DATA_TEMPLATE, "data");
-    assert_ptr_equal(st->dt, NULL);
-    st->dt = lyd_parse_mem(st->ctx, json_file2, LYD_JSON, LYD_OPT_DATA_TEMPLATE, "data");
-    assert_ptr_not_equal(st->dt, NULL);
-
-    lyd_print_mem(&str, st->dt, LYD_LYB, 0);
-    lyd_free(st->dt);
-    st->dt = lyd_parse_mem(st->ctx, str, LYD_LYB, LYD_OPT_DATA_TEMPLATE, "data");
-    free(str);
-    assert_ptr_not_equal(st->dt, NULL);
-    lyd_free(st->dt);
-
-    st->dt = lyd_parse_mem(st->ctx, xml_file, LYD_XML, LYD_OPT_DATA_TEMPLATE | LYD_OPT_STRICT, "data");
-    assert_ptr_equal(st->dt, NULL);
-    st->dt = lyd_parse_mem(st->ctx, xml_file, LYD_XML, LYD_OPT_DATA_TEMPLATE, "data");
-    assert_ptr_not_equal(st->dt, NULL);
-}
-
-static void
-test_validate_yangdata(void **state)
-{
-    struct state *st = (*state);
-
-    st->dt = lyd_new_path(NULL, st->ctx, "/yang-data:#data/errors/error[1]/error-type", "transport", 0 ,0);
-    assert_return_code(lyd_validate(&st->dt, LYD_OPT_DATA_TEMPLATE, NULL), EXIT_FAILURE);
-    assert_ptr_not_equal(lyd_new_leaf(st->dt->child, st->mod, "error-tag", "Error"), NULL);
-    assert_return_code(lyd_validate(&st->dt, LYD_OPT_DATA_TEMPLATE, NULL), EXIT_SUCCESS);
-}
-
-static void
-test_path_yangdata(void **state)
-{
-    struct state *st = (*state);
-    struct ly_set *set;
-    const struct lys_node *node;
-    char *str;
-
-    st->dt = lyd_new_path(st->dt, st->ctx, "/yang-data:#node/test1/second", "test-second", 0 ,0);
-    set = lyd_find_path(st->dt,"/yang-data:#node/test1/second");
-    assert_ptr_not_equal(set, NULL);
-    assert_int_equal(set->number, 1);
-
-    st->str1 = lys_data_path(st->dt->child->schema);
-    st->str2 = lyd_path(st->dt->child);
-    assert_string_equal(st->str1, st->str2);
-    assert_string_equal(st->str1, "/yang-data:#node/test1/second");
-
-    str = st->str2;
-    free(st->str1);
-    st->str1 = lys_path(st->dt->child->schema, LYS_PATH_FIRST_PREFIX);
-    st->str2 = ly_path_data2schema(st->ctx,str);
-    free(str);
-    assert_string_equal(st->str1, st->str2);
-    assert_string_equal(st->str1, "/yang-data:#node/select/test1/test1/second");
-
-    ly_set_free(set);
-    set = lys_find_path(st->mod, NULL, st->str1);
-    assert_ptr_not_equal(set, NULL);
-    assert_int_equal(set->number, 1);
-
-    ly_set_free(set);
-    free(st->str1);
-    st->str1 = lys_path(st->dt->child->schema, 0);
-    set = ly_ctx_find_path(st->ctx, st->str1);
-    assert_ptr_not_equal(set, NULL);
-    assert_int_equal(set->number, 1);
-    ly_set_free(set);
-
-    free(st->str2);
-    st->str2 = lyd_path(st->dt->child);
-    node = ly_ctx_get_node(st->ctx, NULL, st->str2, 0);
-    assert_ptr_not_equal(node, NULL);
-}
-*/
 int main(void)
 {
     const struct CMUnitTest tests[] = {
 	cmocka_unit_test_setup_teardown(test_anydata_ns, setup_f, teardown_f),
-	//	cmocka_unit_test_setup_teardown(test_print_xml_ns, setup_f, teardown_f),
-	//        cmocka_unit_test_setup_teardown(test_new_yangdata, setup_f, teardown_f),
-        //cmocka_unit_test_setup_teardown(test_path_yangdata, setup_f, teardown_f),
-	//    cmocka_unit_test_setup_teardown(test_validate_yangdata, setup_f, teardown_f),
-        //cmocka_unit_test_setup_teardown(test_mem_yangdata, setup_f, teardown_f),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/data/test_yang_data_ns.c
+++ b/tests/data/test_yang_data_ns.c
@@ -33,24 +33,24 @@ setup_f(void **state)
 {
     struct state *st;
     const char *yang1 = "module yang-data-config-ns1 {\n"
-	"  prefix dcn1;\n"
-	"  namespace \"urn:cesnet:yang-data-config-ns1\";\n"
-	"  container con1 {\n"
-	"    leaf leaf1 {\n"
-	"        type string;\n"
-	"    }\n"
-	"  }\n"
-	"}";
+        "  prefix dcn1;\n"
+        "  namespace \"urn:cesnet:yang-data-config-ns1\";\n"
+        "  container con1 {\n"
+        "    leaf leaf1 {\n"
+        "        type string;\n"
+        "    }\n"
+        "  }\n"
+        "}";
 
     const char *yang2 = "module yang-data-config-ns2 {\n"
-	"  prefix dcn2;\n"
-	"  namespace \"urn:cesnet:yang-data-config-ns2\";\n"
-	"  container con2 {\n"
-	"    leaf leaf2 {\n"
-	"        type string;\n"
-	"    }\n"
-	"  }\n"
-	"}";
+        "  prefix dcn2;\n"
+        "  namespace \"urn:cesnet:yang-data-config-ns2\";\n"
+        "  container con2 {\n"
+        "    leaf leaf2 {\n"
+        "        type string;\n"
+        "    }\n"
+        "  }\n"
+        "}";
 
     (*state) = st = calloc(1, sizeof *st);
     if (!st) {
@@ -101,7 +101,7 @@ test_anydata_ns(void **state)
     const char *opentag = "<config xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">";
 
     if(!(st->mod_nc = ly_ctx_get_module(st->ctx, "ietf-netconf", NULL, 0))) {
-	st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
+        st->mod_nc = ly_ctx_load_module(st->ctx, "ietf-netconf", NULL);
     }
     assert_ptr_not_equal(st->mod_nc, NULL);
 
@@ -115,7 +115,7 @@ test_anydata_ns(void **state)
     assert_ptr_not_equal(st->nodet, NULL);
 
     st->node2 = lyd_new(NULL, st->mod2, "con2");
-    assert_ptr_not_equal(st->node2, NULL);  
+    assert_ptr_not_equal(st->node2, NULL);
     attr = lyd_insert_attr(st->node2, st->mod_nc, "operation", "merge");
     assert_ptr_not_equal(attr, NULL);
 
@@ -135,7 +135,7 @@ test_anydata_ns(void **state)
 int main(void)
 {
     const struct CMUnitTest tests[] = {
-	cmocka_unit_test_setup_teardown(test_anydata_ns, setup_f, teardown_f),
+        cmocka_unit_test_setup_teardown(test_anydata_ns, setup_f, teardown_f),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/data/test_yang_data_ns.c
+++ b/tests/data/test_yang_data_ns.c
@@ -24,7 +24,7 @@
 struct state {
     struct ly_ctx *ctx;
   const struct lys_module *mod1, *mod2, *mod_nc;
-    struct lyd_node *dt, *config, *node1, *node2, *nodet;;
+    struct lyd_node *dt, *node1, *node2, *nodet;
 };
 
 static int
@@ -83,6 +83,9 @@ teardown_f(void **state)
     struct state *st = (*state);
 
     lyd_free_withsiblings(st->dt);
+    lyd_free_withsiblings(st->node1);
+    lyd_free_withsiblings(st->node2);
+    lyd_free_withsiblings(st->nodet);
     ly_ctx_destroy(st->ctx, NULL);
     free(st);
     (*state) = NULL;


### PR DESCRIPTION
when output xml and the data structure is anydata, with multiple namespaces, in addition to using a single namespace, the printer would output the same xmlns multiple times.

-- created test to verify fix
-- valgrind passes all tests