### PR TITLE
libyang2: YANG parser BUGFIX double quoted string parsing whitespace underflow

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -358,8 +358,8 @@ read_qstring(struct lys_parser_ctx *ctx, const char **data, enum yang_arg arg, c
                 } else {
                     /* check and store character */
                     LY_CHECK_RET(buf_store_char(ctx, data, arg, word_p, word_len, word_b, buf_len, need_buf, &prefix));
+                    trailing_ws++;
                 }
-                trailing_ws++;
                 break;
             case '\t':
                 if (current_indent < block_indent) {
@@ -377,8 +377,8 @@ read_qstring(struct lys_parser_ctx *ctx, const char **data, enum yang_arg arg, c
                     LY_CHECK_RET(buf_store_char(ctx, data, arg, word_p, word_len, word_b, buf_len, need_buf, &prefix));
                     /* additional characters for indentation - only 1 was count in buf_store_char */
                     ctx->indent += 7;
+                    trailing_ws++;
                 }
-                trailing_ws++;
                 break;
             case '\n':
                 if (block_indent) {


### PR DESCRIPTION
Hello,

while fuzzing the libyang2 YANG parser, the fuzzer found an unsigned overflow in the read_qstring function, which would later cause the parser to crash. The following file caused the bug to appear:

```
module m {
	prefix p;
	namespace "

	list l {
		must "";
	}
}
```

The issue arises when a newline in a double quoted string is followed by a line containing only indentation (the lines containing namespace and the following line in the file), which is less than the previous block's indentation, followed by another newline. The example file contains two spaces, but the same crash appears for two tabs.

The overflow would happen at src/parser_yang.c:389, because word_len would be 1, due to the first newline character, and trailing whitespace was 2, which would case UB, and therefore heap corruption when the 2nd newline was stored into the word buffer, as size_t max is way out of bounds of the word_b buffer.

word_len was only one, because whitespace characters are only stored if current_indent is larger than block_indent (that is the previous block's indent, as far as I understand).

The commit in this PR fixes the crash by only incrementing trailing_ws when a tab or whitespace is actually stored into the word buffer. The change passes all tests, and after a quick look, I don't think a new test is necessary to test this, as the behaviour should be tested with tests introduced in PR #910 and other relevant commits/PRs.

However, while reading the YANG, RFC, I'm not entirely sure why should trailing_ws be incremented when current_indent is larger than block_indent, since I understood this section: 
```If a double-quoted string contains a line break followed by space or
   tab characters that are used to indent the text according to the
   layout in the YANG file, this leading whitespace is stripped from the
   string, up to and including the column of the starting double quote
   character, or to the first non-whitespace character, whichever occurs
   first.  Any tab character in a succeeding line that must be examined
   for stripping is first converted into 8 space characters.
```
to mean that whitespaces shouldn't be stripped after current_indent passes block_indent.

I've tried to fix the bug by removing trailing_ws entirely, as the trailing whitespace wouldn't be stored at all that way, and the whitespace after block_indent would, which did fix the bug, but broke the src_parser_yang test.

I assume that this fix might be somewhat wrong as well, although it passes the tests and fixes the crash, so feedback is welcome.

Regards,
Juraj