### PR TITLE
libyang2: yang parser BUGFIX null dereference in moveto_resolve_model

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -5232,14 +5232,12 @@ moveto_resolve_model(const char **qname, uint16_t *qname_len, struct lyxp_set *s
             LOGINT_RET(set->ctx);
         }
 
-        if (!mod->implemented) {
-            /* non-implemented module is not valid */
-            mod = NULL;
-        }
-        if (!mod) {
+        /* Check for errors and non-implemented modules, as they are not valid */
+        if (!mod || !mod->implemented) {
             LOGVAL(set->ctx, LY_VLOG_LYD, set->ctx_node, LY_VCODE_XP_INMOD, pref_len, *qname);
             return LY_EVALID;
         }
+
         *qname += pref_len + 1;
         *qname_len -= pref_len + 1;
     } else if (((*qname)[0] == '*') && (*qname_len == 1)) {


### PR DESCRIPTION
Hello,

this should fix a null dereference found while fuzzing libyang2. 

The following file caused the crash:
```
module d{
	namespace "";
	prefix d;
	leaf f {
		type string;
		must ":e";
		default "";
	}
}
```

The issue was in moveto_resolve_model in src/xpath.c, a null mod was returned from lys_module_find_prefix, which then caused a null dereference when !mod->implemented was checked.

This commit fixes the issue and doesn't break any tests on my machine.

Regards,
Juraj