### PR TITLE
fix the bug about rpc and notification with the same name.

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -660,6 +660,8 @@ lys_check_id(struct lys_node *node, struct lys_node *parent, struct lys_module *
     case LYS_LIST:
     case LYS_CONTAINER:
     case LYS_CHOICE:
+    case LYS_RPC:
+    case LYS_NOTIF:
     case LYS_ANYDATA:
         /* 6.2.1, rule 7 */
         if (parent) {
@@ -700,7 +702,7 @@ lys_check_id(struct lys_node *node, struct lys_node *parent, struct lys_module *
                 continue;
             }
 
-            if (iter->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_LIST | LYS_CONTAINER | LYS_CHOICE | LYS_ANYDATA)) {
+            if (iter->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_LIST | LYS_CONTAINER | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ANYDATA)) {
                 if (iter->module == node->module && ly_strequal(iter->name, node->name, 1)) {
                     LOGVAL(module->ctx, LYE_DUPID, LY_VLOG_LYS, node, strnodetype(node->nodetype), node->name);
                     return EXIT_FAILURE;

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -662,6 +662,7 @@ lys_check_id(struct lys_node *node, struct lys_node *parent, struct lys_module *
     case LYS_CHOICE:
     case LYS_RPC:
     case LYS_NOTIF:
+    case LYS_ACTION:
     case LYS_ANYDATA:
         /* 6.2.1, rule 7 */
         if (parent) {
@@ -702,7 +703,7 @@ lys_check_id(struct lys_node *node, struct lys_node *parent, struct lys_module *
                 continue;
             }
 
-            if (iter->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_LIST | LYS_CONTAINER | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ANYDATA)) {
+            if (iter->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_LIST | LYS_CONTAINER | LYS_CHOICE | LYS_RPC | LYS_NOTIF | LYS_ACTION | LYS_ANYDATA)) {
                 if (iter->module == node->module && ly_strequal(iter->name, node->name, 1)) {
                     LOGVAL(module->ctx, LYE_DUPID, LY_VLOG_LYS, node, strnodetype(node->nodetype), node->name);
                     return EXIT_FAILURE;


### PR DESCRIPTION
Hi,
As description in [RFC7950, Chapter 6.2.1](https://tools.ietf.org/html/rfc7950#section-6.2)
```
   o  All leafs, leaf-lists, lists, containers, choices, rpcs, actions,
      notifications, anydatas, and anyxmls defined (directly or through
      a "uses" statement) within a parent node or at the top level of
      the module or its submodules share the same identifier namespace.
      This namespace is scoped to the parent node or module, unless the
      parent node is a case node.  In that case, the namespace is scoped
      to the closest ancestor node that is not a case or choice node.
```
I use the following yang file to test and find a bug.
`mod1.yang:`
```
module mod1 {
  namespace "urn:mod1";
  prefix m1;

  rpc aaa {
    input {
      leaf le1 {
        type string;
      }
    }
  }
  
  notification aaa {
    leaf le2 {
      type string;
    }
  }
}
```
`the expected result is that:`
```
~/libyang/build$ ./yanglint -f yang mod1.yang
err : Duplicated notification identifier "aaa". (/mod1:aaa)
err : Module "mod1" parsing failed.
```
But the actual result is no error.