### PR TITLE
tree printer BUGFIX specific node(leaf/leaf-list/anydata/anyxml) printing's assertion(max_name_len) failed

### DIFF
--- a/src/printer_tree.c
+++ b/src/printer_tree.c
@@ -783,6 +783,7 @@ tree_print_subtree(struct lyout *out, const struct lys_node *node, tp_opts *opts
 {
     unsigned int depth, i, j;
     int level = 0;
+    uint16_t max_child_len;
     const struct lys_node *parent;
 
     /* learn the depth of the node */
@@ -823,7 +824,8 @@ tree_print_subtree(struct lyout *out, const struct lys_node *node, tp_opts *opts
     }
 
     /* print the node and its descendants */
-    tree_print_snode(out, level, 0, node, LYS_ANY, NULL, 2, opts);
+    max_child_len = tree_get_max_name_len(node, NULL, LYS_LEAF|LYS_LEAFLIST|LYS_ANYDATA, opts);
+    tree_print_snode(out, level, max_child_len, node, LYS_ANY, NULL, 2, opts);
 }
 
 static int

--- a/tests/schema/test_printer.c
+++ b/tests/schema/test_printer.c
@@ -162,6 +162,13 @@ test_tree_rfc_subtree(void **state)
     lys_print_mem(&str, moda, LYS_OUT_TREE, "/tree-a:notif1", 0, LYS_OUTOPT_TREE_RFC);
     assert_string_equal(str, temp3);
     free(str);
+    
+    const char temp4[] = "module: tree-a\n"
+    "  +--rw cont\n"
+    "     +--rw leaf3?   uint8\n";
+    lys_print_mem(&str, moda, LYS_OUT_TREE, "/tree-a:cont/leaf3", 0, LYS_OUTOPT_TREE_RFC);
+    assert_string_equal(str, temp4);
+    free(str);
 }
 
 static void


### PR DESCRIPTION
Hi,
I find a segmentation fault when printing subtree with the existed Yang Model (tree-a.yang), the error occurs tightly when the target node is one of `leaf/leaf-list/anydata/anyxml nodes`. The tree-a.yang's path is `libyang-master/tests/schema/yang/files`.

`tree-a.yang:`
```
module tree-a {
    namespace "urn:tree-a";
    prefix ta;

    grouping group1 {
        leaf leaf1 {
            type string;
        }
    }

    grouping group2 {
        leaf leaf2 {
            type string;
        }
    }

    container cont {
        leaf leaf3 {
            type uint8;
        }
    }

    rpc rpc1;
    rpc rpc2;

    notification notif1;
    notification notif2;
}

```
`the error message is like that:`
```
test~:/data/libyang-master/tests/schema/yang/files #yanglint -f tree-rfc tree-a.yang -P /tree-a:cont/leaf3

module: tree-a
  +--rw cont
yanglint: /data/jenkins/workspace/libyang/libyang-master20191026/libyang-master/src/printer_tree.c:604: tree_print_snode: Assertion 'max_name_len' failed.Aborted(core dumped)
```
this `PR` fix the bug, and I also provide some testcases to test it.
`the result is that:`
```
module: tree-a
  +--rw cont
     +--rw leaf3?    uint8
```