### PR TITLE
libyang2: compiled schema BUGFIX when validating empty leafref path

### DIFF
--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -2674,6 +2674,12 @@ lys_compile_leafref_validate(struct lysc_ctx *ctx, struct lysc_node *startnode, 
 
     iter = 0;
     id = leafref->path;
+
+    if (!*id) {
+        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Empty leafref path.");
+        return LY_EVALID;
+    }
+
     while(*id && (ret = lys_path_token(&id, &prefix, &prefix_len, &name, &name_len, &parent_times, &has_predicate)) == LY_SUCCESS) {
         if (!iter) { /* first iteration */
             /* precess ".." in relative paths */


### PR DESCRIPTION
Hello,

the following file causes a null pointer dereference in src/tree_schema_compile.c:2736, because the leafref path is NULL. The issue is that the while loop validating the path runs only as long as *id is a non string terminating character. If id is an empty path the loop never runs, and later on node->nodetype is checked, even though node was never set, and is NULL.

Here is a file that causes the crash:
```
module p{
	namespace "";
	prefix p;

	leaf mgmt-interface {
		type leafref {
			path "";
		}
	}
}
```

This commit adds a check for empty leafref paths which fixes the issue and doesn't break any tests.

Regards,
Juraj