### PR TITLE
Change Value::dec64 to also return fraction digits

### DIFF
--- a/swig/cpp/src/Tree_Data.hpp
+++ b/swig/cpp/src/Tree_Data.hpp
@@ -37,6 +37,12 @@ namespace libyang {
  * Class wrappers for data structures and functions to manipulate and access instance data tree.
  */
 
+struct Decimal64
+{
+    int64_t value;
+    uint8_t digits;
+};
+
 /**
  * @brief class for wrapping [lyd_val](@ref lyd_val).
  * @class Value
@@ -54,7 +60,7 @@ public:
     /** get bln variable from [lyd_val](@ref lyd_val)*/
     int8_t bln() {return LY_TYPE_BOOL == value_type ? value.bln : throw "wrong type";};
     /** get dec64 variable from [lyd_val](@ref lyd_val)*/
-    int64_t dec64() {return LY_TYPE_DEC64 == value_type ? value.dec64 : throw "wrong type";};
+    Decimal64 dec64() {return LY_TYPE_DEC64 == value_type ? Decimal64{ value.dec64, type->info.dec64.dig } : throw "wrong type";};
     /** get enm variable from [lyd_val](@ref lyd_val)*/
     S_Type_Enum enm() {return LY_TYPE_ENUM == value_type ? std::make_shared<Type_Enum>(value.enm, deleter) : throw "wrong type";};
     /** get ident variable from [lyd_val](@ref lyd_val)*/


### PR DESCRIPTION
Right now, if you only have `libyang::Value` and call `dec64()` on it, you only get the value, but not the fraction digits, the value is useless by itself. This patch changes the return value to a struct that has both the value and the fraction digits.

I'm not sure if a simple approach like this is a good idea, tell me what you think.

cc @jktjkt 