### PR TITLE
libyang2: tree schema BUGFIX check for NULL extension definition before free

### DIFF
--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -486,7 +486,9 @@ lysc_ext_instance_free(struct ly_ctx *ctx, struct lysc_ext_instance *ext)
     if (ext->def && ext->def->plugin && ext->def->plugin->free) {
         ext->def->plugin->free(ctx, ext);
     }
-    lysc_extension_free(ctx, &ext->def);
+    if (ext->def) {
+        lysc_extension_free(ctx, &ext->def);
+    }
     FREE_STRING(ctx, ext->argument);
     FREE_ARRAY(ctx, ext->exts, lysc_ext_instance_free);
 }


### PR DESCRIPTION
Hello,

this PR fixes a NULL dereference in tree_schema_free.c

The following YANG file causes the crash:
```
module a {
	yang-version 1.1;
  	namespace "urn:all";
  	prefix all_mod;

  	grouping group1 {
    	leaf leaf1 {
       		type int64 {
        		range "1000 .. 50000" {
          			error:message
            		"Spec";
        		}
      		}
    	}
    }
}
```

The issue appeared due to no NULL check for ext->def when calling lysc_extension_free from lysc_ext_instance_free. The only other place where lysc_extension_free is called from is lysp_ext_free, and a NULL check is done there, so the issue can't appear there.

Regards,
Juraj