### PR TITLE
json parser BUGFIX null dereference in json_parse_data

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -876,6 +876,10 @@ json_parse_data(struct ly_ctx *ctx, const char *data, const struct lys_node *sch
     len++;
 
     str = lyjson_parse_text(ctx, &data[len], &r);
+    if (!str) {
+        goto error;
+    }
+
     if (!r) {
         goto error;
     } else if (data[len + r] != '"') {


### PR DESCRIPTION
Hello,

the libyang JSON data parser can segfault in the **lyjson_parse_data** function after attempting to use the **str** pointer when the call to **lyjson_parse_text** returns a null pointer.

This PR implements a simple check after the call to **lyjson_parse_text**, to see if the function returned a null pointer, and if so, jumps to the error goto label.

Attached is an example file which causes the null pointer dereference in **lyjson_parse_data**.
[null-dereference.txt](https://github.com/CESNET/libyang/files/4364024/null-dereference.txt)

Regards,
Luka