### PR TITLE
json parser BUGFIX wrong argument to LOGVAL

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -798,7 +798,7 @@ json_skip_unknown(struct ly_ctx *ctx, struct lyd_node *parent, const char *data,
             } else if (data[(*len) - 1] != '\\') {
                 qstr = 1;
             } else {
-                LOGVAL(ctx, LYE_INVAL, LY_VLOG_LYD, parent, "JSON data (missing quotation mark for a string data) ");
+                LOGVAL(ctx, LYE_XML_INVAL, LY_VLOG_LYD, parent, "JSON data (missing quotation mark for a string data) ");
                 return -1;
             }
             break;


### PR DESCRIPTION
Hello,

This PR fixes an invalid **LY_ECODE** error code argument in a call to **ly_vlog** from **json_skip_unknown** which results in a segmenation fault, as the variable argument list's length doesn't match the constructed format string in a later call to **vasprintf**.

It seems the **LYE_INVAL** error code format string takes two string "**%s**" format specifiers, while only one argument is being forwarded in the call to **LOGVAL** (**ly_vlog** define) in the **json_skip_unknown** function, resulting in a segmentation fault when it attempts to dereference an invalid string address pulled from the stack for the second format specifier. This seems to be because the wrong error code is being used, as the **LY_ECODE** argument should probably be **LYE_XML_INVAL**, rather than **LYE_INVAL**, which only takes one "**%s**" format specifier and logs the error message correctly.

Attached is an example file which causes the segmentation fault.
[log-error.txt](https://github.com/CESNET/libyang/files/4364090/log-error.txt)


Regards,
Luka