### PR TITLE
libyang2: data tree BUGFIX invalid tree unlink call for non top opaque data nodes

### DIFF
--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -244,8 +244,7 @@ lyd_free_(struct lyd_node *node, int top)
     }
 
     LY_LIST_FOR_SAFE(node, next, iter) {
-        /* in case of the top-level nodes (node->parent is NULL), no unlinking needed */
-        lyd_free_subtree(iter, iter->parent ? 1 : 0);
+        lyd_free_subtree(iter, !iter->parent ? 1 : 0);
     }
 }
 


### PR DESCRIPTION
Hello,

this PR includes a commit that fixes out of bounds reads and a null dereference which causes a segmentation fault.

The original file that causes the crash is here:

```
<a xmlns="ns">
<b>x</b>
<c xml:id="D">1</c>
</a>
```

The issue appeared while fuzzing with LibFuzzer, by calling lyd_parse_mem like this:
```
lyd_parse_mem(ctx, data, LYD_XML, LYD_VALOPT_DATA_ONLY | LYD_OPT_OPAQ);
```

I will push the new fuzzer harness which I used later, when I finish cleaning up some things in it.

The issue seems to appear due to an invalid ternary statement in tree_data_free.c:247. Looking at the other usages of lyd_free_subtree, and the name of the variable, it seems that top should be set to 1 only for top data nodes, while that was not the case here. I've also removed the comment as it seems to be wrong too, and unlinking is actually done for top level nodes only as far as I can tell. 

In this particular case, lyd_unlink_tree would be called for the non top node, <b>x</b>, which would later cause issues, as the node was an opaque data node, but was wrongly interpreted as lyd_node_inner.
The code working with the hash table in lyd_node_inner would then try to clean up the hash table which would cause various memory issues and crash in the end.

The commit doesn't break any tests, and this seems to be an appropriate fix to me. If this is not the right place for the fix, or if there are any other issues please let me know.

Regards,
Juraj
