### PR TITLE
C++: Allow constructing Submodule from Module

### DIFF
--- a/swig/cpp/src/Tree_Schema.cpp
+++ b/swig/cpp/src/Tree_Schema.cpp
@@ -39,6 +39,14 @@ Submodule::Submodule(struct lys_submodule *submodule, S_Deleter deleter):
     submodule(submodule),
     deleter(deleter)
 {};
+Submodule::Submodule(S_Module module):
+    submodule((lys_submodule*)module->module),
+    deleter(module->deleter)
+{
+    if (module->type() != 1) {
+        throw std::invalid_argument("Attempted to cast a YANG module into a YANG submodule");
+    }
+}
 std::vector<S_Schema_Node> Module::data_instantiables(int options) {
     std::vector<S_Schema_Node> s_vector;
     struct lys_node *iter = NULL;

--- a/swig/cpp/src/Tree_Schema.hpp
+++ b/swig/cpp/src/Tree_Schema.hpp
@@ -111,6 +111,7 @@ public:
 
     friend Context;
     friend Data_Node;
+    friend Submodule;
 
 private:
     struct lys_module *module;
@@ -126,6 +127,8 @@ class Submodule
 public:
     /** wrapper for struct [lys_submodule](@ref lys_submodule), for internal use only */
     Submodule(struct lys_submodule *submodule, S_Deleter deleter);
+    /** creates a Submodule from `module` if it is a submodule */
+    Submodule(S_Module module);
     ~Submodule();
     /** get ctx variable from [lys_submodule](@ref lys_submodule)*/
     S_Context ctx() LY_NEW(submodule, ctx, Context);


### PR DESCRIPTION
I couldn't find a way to get info about a submodule (like the `belongsTo` variable of `lys_submodule`), so this patch adds a way to convert `libyang::Module` to `libyang::Submodule` to get info about a submodule.

The constructor follows the constructors of the `libyang::Schema_Node_*` family, taking in an `S_Module` and just assigning the private variables. I'm not sure if the deleter should just be assigned like this, but I don't get any memory errors.