### PR TITLE
Fix compile on older systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif()
 
-set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu11")
+set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG   "-g -O0")

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -5235,8 +5235,9 @@ lys_data_path_pattern(const struct lys_node *node, const char *placeholder)
         if (node->nodetype == LYS_LIST) {
             /* add specific key values (placeholders) for list */
             const struct lys_node_list *list;
+            uint8_t j;
             list = (const struct lys_node_list *)node;
-            for (uint8_t j = 0; j < list->keys_size; j++) {
+            for (j = 0; j < list->keys_size; j++) {
                 k += sprintf(keys + k, "[%s=%s]", list->keys[j]->name, placeholder);
             }
         }


### PR DESCRIPTION
fixes compiling libyang on older Systems such as Debian 8 and CentOS 6

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>
