### PR TITLE
build BUGFIX fix detection of vasprintf() on FreeBSD >= 11

### DIFF
--- a/CMakeModules/UseCompat.cmake
+++ b/CMakeModules/UseCompat.cmake
@@ -7,6 +7,7 @@ macro(USE_COMPAT)
     # compatibility checks
     set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200809L)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS -D__BSD_VISIBLE=1)
     check_symbol_exists(vdprintf "stdio.h;stdarg.h" HAVE_VDPRINTF)
     check_symbol_exists(asprintf "stdio.h" HAVE_ASPRINTF)
     check_symbol_exists(vasprintf "stdio.h" HAVE_VASPRINTF)


### PR DESCRIPTION
When vasprintf() isn't detected, the fallback implementation
from compat/compat.c doesn't compile on FreeBSD (>= 11) because
of a strange problem with va_copy() not being available. Define
__BSD_VISIBLE to fix the detection of vasprintf(), which in turn
fixes the build errors on FreeBSD >= 11.

Signed-off-by: Renato Westphal <renato@opensourcerouting.org>