### PR TITLE
libyang CHANGE headers includes cleanup using include-what-you-use tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,13 +398,13 @@ add_executable(yanglint ${lintsrc})
 target_link_libraries(yanglint yang)
 install(TARGETS yanglint DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_SOURCE_DIR}/tools/lint/yanglint.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
-target_include_directories(yanglint BEFORE PRIVATE ${PROJECT_BINARY_DIR}/tools)
+target_include_directories(yanglint BEFORE PRIVATE ${PROJECT_BINARY_DIR})
 
 # yangre
 add_executable(yangre ${resrc})
 target_link_libraries(yangre yang)
 install(TARGETS yangre DESTINATION ${CMAKE_INSTALL_BINDIR})
-target_include_directories(yangre BEFORE PRIVATE ${PROJECT_BINARY_DIR}/tools)
+target_include_directories(yangre BEFORE PRIVATE ${PROJECT_BINARY_DIR})
 
 if(ENABLE_VALGRIND_TESTS)
     set(ENABLE_BUILD_TESTS ON)

--- a/src/common.c
+++ b/src/common.c
@@ -12,19 +12,21 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
+#define _GNU_SOURCE
+
 #include "common.h"
 
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "plugins_exts.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
 

--- a/src/common.h
+++ b/src/common.h
@@ -15,8 +15,6 @@
 #ifndef LY_COMMON_H_
 #define LY_COMMON_H_
 
-#define _GNU_SOURCE
-
 #include <pthread.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -29,8 +27,10 @@
 #include "log.h"
 #include "set.h"
 #include "tree.h"
+#include "tree_data.h"
 
 struct ly_ctx;
+struct lys_module;
 
 #if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
 # define THREAD_LOCAL _Thread_local

--- a/src/compat.c
+++ b/src/compat.c
@@ -15,7 +15,8 @@
 #include "common.h"
 
 #include <string.h>
-#include <unistd.h>
+
+#include "config.h"
 
 #ifndef HAVE_STRNSTR
 char *

--- a/src/context.c
+++ b/src/context.c
@@ -11,23 +11,25 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _GNU_SOUCRE /* asprintf */
+#define _GNU_SOURCE /* asprintf */
 
-#include "common.h"
+#include "context.h"
 
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "context.h"
+#include "common.h"
 #include "hash_table.h"
 #include "set.h"
 #include "tree.h"
+#include "tree_data.h"
 #include "tree_schema_internal.h"
 #include "plugins_types.h"
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#include "hash_table.h"
 
 #include <string.h>
 #include <stdint.h>
@@ -20,7 +20,8 @@
 #include <pthread.h>
 #include <assert.h>
 
-#include "hash_table.h"
+#include "common.h"
+#include "dict.h"
 
 static int
 lydict_val_eq(void *val1_p, void *val2_p, int UNUSED(mod), void *cb_data)

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -16,12 +16,11 @@
 #ifndef LY_HASH_TABLE_H_
 #define LY_HASH_TABLE_H_
 
-#include "common.h"
-
 #include <pthread.h>
 #include <stddef.h>
 #include <stdint.h>
 
+#include "config.h"
 #include "log.h"
 
 /**

--- a/src/log.c
+++ b/src/log.c
@@ -12,7 +12,9 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
+
+#include "log.h"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -23,8 +25,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "log.h"
+#include "common.h"
 #include "plugins_exts.h"
+#include "tree_data.h"
+#include "tree_schema.h"
 
 volatile uint8_t ly_log_level = LY_LLWRN;
 volatile uint8_t ly_log_opts = LY_LOLOG | LY_LOSTORE_LAST;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -12,22 +12,14 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
 
-#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "common.h"
+#include "config.h"
 #include "context.h"
-#include "dict.h"
-#include "log.h"
-#include "plugins_types.h"
-#include "set.h"
-#include "tree_data.h"
-#include "tree_data_internal.h"
-#include "tree_schema.h"
-#include "xml.h"
-#include "validation.h"
 
 /**
  * @brief JSON-parser's implementation of ly_type_resolve_prefix() callback to provide mapping between prefixes used

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -12,12 +12,17 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
+#include "common.h"
+#include "dict.h"
+#include "log.h"
+#include "tree.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
 

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -12,23 +12,20 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 
+#include "common.h"
 #include "context.h"
-#include "dict.h"
 #include "log.h"
-#include "plugins_types.h"
 #include "set.h"
-#include "tree_data.h"
+#include "tree.h"
 #include "tree_data_internal.h"
 #include "tree_schema.h"
-#include "xml.h"
 #include "validation.h"
+#include "xml.h"
 
 #define LYD_INTOPT_RPC      0x01    /**< RPC/action invocation is being parsed */
 #define LYD_INTOPT_NOTIF    0x02    /**< notification is being parsed */

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -12,8 +12,6 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
@@ -22,10 +20,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common.h"
 #include "context.h"
 #include "dict.h"
 #include "log.h"
-#include "plugins_exts.h"
 #include "set.h"
 #include "tree.h"
 #include "tree_schema.h"

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -11,25 +11,25 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
+#include "parser_yin.h"
 
 #include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <string.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <ctype.h>
-#include <stdarg.h>
 
+#include "common.h"
 #include "context.h"
 #include "dict.h"
-#include "xml.h"
+#include "set.h"
 #include "tree.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
-#include "parser_yin.h"
+#include "xml.h"
 
 /**
  * @brief check if given string is URI of yin namespace.

--- a/src/parser_yin.h
+++ b/src/parser_yin.h
@@ -15,11 +15,13 @@
 #ifndef LY_PARSER_YIN_H_
 #define LY_PARSER_YIN_H_
 
+#include <stdint.h>
 #include <stdio.h>
-#include <stdlib.h>
 
 #include "log.h"
-#include "xml.h"
+#include "tree.h"
+#include "tree_schema.h"
+#include "tree_schema_internal.h"
 
 /* list of yin attribute strings */
 extern const char *const yin_attr_list[];

--- a/src/plugins_exts.c
+++ b/src/plugins_exts.c
@@ -11,12 +11,14 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
 
 #include "plugins_exts.h"
 
-#include "plugins_exts_nacm.c"
+#include <string.h>
+
+#include "common.h"
 #include "plugins_exts_metadata.c"
+#include "plugins_exts_nacm.c"
 
 /**
  * @brief list of all extension plugins implemented internally

--- a/src/plugins_exts.h
+++ b/src/plugins_exts.h
@@ -15,8 +15,12 @@
 #ifndef LY_PLUGINS_EXTS_H_
 #define LY_PLUGINS_EXTS_H_
 
-#include "set.h"
+#include "log.h"
 #include "tree_schema.h"
+#include "tree_schema_internal.h"
+
+struct ly_ctx;
+struct lyd_node;
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,44 +56,6 @@ extern "C" {
  *
  * @{
  */
-
-/**
- * @defgroup scflags Schema compile flags
- * @ingroup schematree
- *
- * @{
- */
-#define LYSC_OPT_RPC_INPUT  LYS_CONFIG_W       /**< Internal option when compiling schema tree of RPC/action input */
-#define LYSC_OPT_RPC_OUTPUT LYS_CONFIG_R       /**< Internal option when compiling schema tree of RPC/action output */
-#define LYSC_OPT_RPC_MASK   LYS_CONFIG_MASK    /**< mask for the internal RPC options */
-#define LYSC_OPT_FREE_SP    0x04               /**< Free the input printable schema */
-#define LYSC_OPT_INTERNAL   0x08               /**< Internal compilation caused by dependency */
-#define LYSC_OPT_NOTIFICATION 0x10             /**< Internal option when compiling schema tree of Notification */
-
-#define LYSC_OPT_GROUPING   0x20               /** Compiling (validation) of a non-instantiated grouping.
-                                                   In this case not all the restrictions are checked since they can be valid only
-                                                   in the real placement of the grouping. TODO - what specifically is not done */
-/** @} scflags */
-
-/**
- * @brief internal context for compilation
- */
-struct lysc_ctx {
-    struct ly_ctx *ctx;
-    struct lys_module *mod;
-    struct lys_module *mod_def; /**< context module for the definitions of the nodes being currently
-                                     processed - groupings are supposed to be evaluated in place where
-                                     defined, but its content instances are supposed to be placed into
-                                     the target module (mod) */
-    struct ly_set groupings;    /**< stack for groupings circular check */
-    struct ly_set unres;        /**< to validate leafref's target and xpath of when/must */
-    struct ly_set dflts;        /**< set of incomplete default values */
-    struct ly_set tpdf_chain;
-    uint16_t path_len;
-    int options;                /**< various @ref scflags. */
-#define LYSC_CTX_BUFSIZE 4078
-    char path[LYSC_CTX_BUFSIZE];
-};
 
 /**
  * @brief Possible cardinalities of the YANG statements.

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -11,24 +11,27 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
+
+#define _GNU_SOURCE
+
+#include "plugins_types.h"
 
 #include <assert.h>
 #include <ctype.h>
-#include <errno.h>
 #include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "plugins_types.h"
+#include "common.h"
+#include "config.h"
 #include "dict.h"
+#include "set.h"
 #include "tree.h"
+#include "tree_data_internal.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
-#include "tree_data_internal.h"
 #include "xml.h"
-#include "xpath.h"
 
 /**
  * @brief Generic comparison callback checking the canonical value.

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -20,8 +20,13 @@
 
 #include "log.h"
 #include "tree.h"
-#include "tree_schema.h"
 #include "tree_data.h"
+
+struct ly_ctx;
+struct lysc_ident;
+struct lysc_pattern;
+struct lysc_range;
+struct lysc_type;
 
 /**
  * @internal

--- a/src/printer.c
+++ b/src/printer.c
@@ -12,20 +12,26 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
 
+#include "printer.h"
+
+#include <assert.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
 #include <unistd.h>
-#include <assert.h>
 
+#include "common.h"
+#include "config.h"
 #include "log.h"
-#include "printer_internal.h"
 #include "plugins_types.h"
+#include "printer_data.h"
+#include "printer_internal.h"
+#include "tree.h"
+#include "tree_schema.h"
 
 /**
  * @brief informational structure shared by printers

--- a/src/printer.h
+++ b/src/printer.h
@@ -15,7 +15,10 @@
 #ifndef LY_PRINTER_H_
 #define LY_PRINTER_H_
 
+#include <stdio.h>
 #include <unistd.h>
+
+#include "log.h"
 
 /**
  * @brief Printer output structure specifying where the data are printed.

--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -12,17 +12,14 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#include "printer_data.h"
 
-#include <errno.h>
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
+#include "common.h"
 #include "log.h"
 #include "printer_internal.h"
-#include "printer_data.h"
-#include "tree_schema.h"
 #include "tree_data.h"
 
 /**

--- a/src/printer_data.h
+++ b/src/printer_data.h
@@ -15,11 +15,11 @@
 #ifndef LY_PRINTER_DATA_H_
 #define LY_PRINTER_DATA_H_
 
-#include <stdio.h>
 #include <unistd.h>
 
 #include "tree_data.h"
-#include "printer.h"
+
+struct ly_out;
 
 /**
  * @defgroup dataprinterflags Data printer flags

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -14,16 +14,7 @@
  */
 
 #include "common.h"
-
-#include <stdlib.h>
-#include <string.h>
-
-#include "log.h"
-#include "plugins_types.h"
-#include "printer_data.h"
-#include "printer_internal.h"
-#include "tree.h"
-#include "tree_data.h"
+#include "config.h"
 #include "tree_schema.h"
 
 /**

--- a/src/printer_schema.c
+++ b/src/printer_schema.c
@@ -12,16 +12,14 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
-#include <errno.h>
 #include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
+#include "common.h"
+#include "config.h"
 #include "log.h"
-#include "printer.h"
 #include "printer_internal.h"
+#include "printer_schema.h"
 #include "tree_schema.h"
 
 API ssize_t

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -15,11 +15,11 @@
 #ifndef LY_PRINTER_SCHEMA_H_
 #define LY_PRINTER_SCHEMA_H_
 
-#include <stdio.h>
 #include <unistd.h>
 
-#include "printer.h"
 #include "tree_schema.h"
+
+struct ly_out;
 
 /**
  * @addtogroup schematree

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -13,18 +13,21 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
+#include <assert.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
+#include "common.h"
+#include "context.h"
+#include "dict.h"
 #include "log.h"
 #include "plugins_types.h"
+#include "printer.h"
 #include "printer_data.h"
 #include "printer_internal.h"
+#include "set.h"
 #include "tree.h"
-#include "tree_data.h"
 #include "tree_schema.h"
 #include "xml.h"
 

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
 
 #include <inttypes.h>
 #include <stdint.h>
@@ -20,13 +20,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common.h"
 #include "log.h"
-#include "plugins_exts.h"
+#include "plugins_types.h"
+#include "printer.h"
 #include "printer_internal.h"
+#include "printer_schema.h"
 #include "tree.h"
+#include "tree_data.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
-#include "plugins_types.h"
 #include "xpath.h"
 
 /**

--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -12,22 +12,19 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
 
-#include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
+#include "common.h"
 #include "log.h"
-#include "plugins_exts.h"
+#include "printer.h"
 #include "printer_internal.h"
 #include "tree.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
-#include "plugins_types.h"
-#include "xpath.h"
 #include "xml.h"
 
 /**

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -11,9 +11,10 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _POSIX_C_SOURCE 200809L /* strndup */
 
-#include "common.h"
+#define _GNU_SOURCE
+
+#include "tree_data.h"
 
 #include <assert.h>
 #include <ctype.h>
@@ -21,20 +22,28 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 
-#include "log.h"
-#include "tree.h"
-#include "tree_data.h"
-#include "tree_data_internal.h"
-#include "tree_schema_internal.h"
+#include "common.h"
+#include "config.h"
+#include "context.h"
+#include "dict.h"
 #include "hash_table.h"
-#include "tree_schema.h"
-#include "xpath.h"
-#include "xml.h"
+#include "log.h"
+#include "plugins_exts.h"
 #include "plugins_exts_metadata.h"
 #include "plugins_exts_internal.h"
+#include "plugins_types.h"
+#include "set.h"
+#include "tree.h"
+#include "tree_data_internal.h"
+#include "tree_schema.h"
+#include "tree_schema_internal.h"
+#include "xml.h"
+#include "xpath.h"
 
 struct ly_keys {
     char *str;

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -19,11 +19,13 @@
 #include <stdint.h>
 
 #include "log.h"
-#include "set.h"
-#include "tree.h"
-#include "tree_schema.h"
 
 struct ly_ctx;
+struct ly_set;
+struct lyd_node;
+struct lyd_node_opaq;
+struct lys_module;
+struct lysc_node;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -12,15 +12,13 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
 
 #include <assert.h>
 #include <stdlib.h>
 
+#include "common.h"
 #include "hash_table.h"
-#include "log.h"
 #include "tree.h"
-#include "tree_data.h"
 #include "tree_schema.h"
 #include "tree_data_internal.h"
 #include "plugins_types.h"

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -11,12 +11,19 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "common.h"
-
+#include "config.h"
 #include "hash_table.h"
-#include "tree_data.h"
+#include "log.h"
 #include "plugins_types.h"
-
+#include "tree.h"
+#include "tree_data.h"
+#include "tree_schema.h"
 
 static void
 lyd_hash_keyless_list_dfs(struct lyd_node *child, uint32_t *hash)

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -11,14 +11,15 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
 
 #include <assert.h>
+#include <stdint.h>
 #include <stdlib.h>
 
+#include "common.h"
+#include "context.h"
 #include "log.h"
-#include "dict.h"
-#include "plugins_types.h"
+#include "tree.h"
 #include "tree_data.h"
 #include "tree_schema.h"
 

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -12,6 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
+#define _GNU_SOURCE
+
 #include "common.h"
 
 #include <assert.h>
@@ -31,6 +33,7 @@
 #include "log.h"
 #include "set.h"
 #include "xpath.h"
+#include "plugins_exts.h"
 #include "tree.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -18,14 +18,16 @@
 #define PCRE2_CODE_UNIT_WIDTH 8
 
 #include <pcre2.h>
+
 #include <stdint.h>
 #include <stdio.h>
 
-#include "tree_data.h"
 #include "log.h"
 #include "tree.h"
+#include "tree_data.h"
 
 struct ly_ctx;
+struct ly_set;
 
 #ifdef __cplusplus
 extern "C" {
@@ -1112,6 +1114,24 @@ struct lysp_submodule {
  * @param[in] module Printable YANG schema tree structure to free.
  */
 void lysp_module_free(struct lysp_module *module);
+
+/**
+ * @defgroup scflags Schema compile flags
+ * @ingroup schematree
+ *
+ * @{
+ */
+#define LYSC_OPT_RPC_INPUT  LYS_CONFIG_W       /**< Internal option when compiling schema tree of RPC/action input */
+#define LYSC_OPT_RPC_OUTPUT LYS_CONFIG_R       /**< Internal option when compiling schema tree of RPC/action output */
+#define LYSC_OPT_RPC_MASK   LYS_CONFIG_MASK    /**< mask for the internal RPC options */
+#define LYSC_OPT_FREE_SP    0x04               /**< Free the input printable schema */
+#define LYSC_OPT_INTERNAL   0x08               /**< Internal compilation caused by dependency */
+#define LYSC_OPT_NOTIFICATION 0x10             /**< Internal option when compiling schema tree of Notification */
+
+#define LYSC_OPT_GROUPING   0x20               /** Compiling (validation) of a non-instantiated grouping.
+                                                   In this case not all the restrictions are checked since they can be valid only
+                                                   in the real placement of the grouping. TODO - what specifically is not done */
+/** @} scflags */
 
 /**
  * @brief Compiled YANG extension-stmt

--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
 
 #include <assert.h>
 #include <ctype.h>
@@ -22,13 +22,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "common.h"
+#include "context.h"
 #include "dict.h"
 #include "log.h"
 #include "plugins_exts.h"
-#include "set.h"
 #include "plugins_types.h"
 #include "plugins_exts_internal.h"
+#include "set.h"
 #include "tree.h"
+#include "tree_data.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
 #include "xpath.h"

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -12,15 +12,17 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
 #include <stdlib.h>
 
-#include "dict.h"
+#include "common.h"
+#include "config.h"
+#include "plugins_exts.h"
+#include "plugins_types.h"
 #include "tree.h"
+#include "tree_data.h"
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
-#include "plugins_types.h"
+#include "xml.h"
 #include "xpath.h"
 
 void lysp_grp_free(struct ly_ctx *ctx, struct lysp_grp *grp);

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -11,7 +11,8 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
+
+#define _GNU_SOURCE
 
 #include <assert.h>
 #include <ctype.h>
@@ -21,9 +22,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 #include <time.h>
+#include <unistd.h>
 
+#include "common.h"
+#include "config.h"
 #include "context.h"
 #include "dict.h"
 #include "hash_table.h"

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -17,7 +17,7 @@
 
 #include <stdint.h>
 
-#include "plugins_exts.h"
+#include "common.h"
 #include "set.h"
 #include "tree_schema.h"
 #include "xml.h"
@@ -160,6 +160,26 @@ struct lysc_incomplete_dflt {
     struct lyd_value *dflt;
     struct lys_module *dflt_mod;
     struct lysc_node *context_node;
+};
+
+/**
+ * @brief internal context for compilation
+ */
+struct lysc_ctx {
+    struct ly_ctx *ctx;
+    struct lys_module *mod;
+    struct lys_module *mod_def; /**< context module for the definitions of the nodes being currently
+                                     processed - groupings are supposed to be evaluated in place where
+                                     defined, but its content instances are supposed to be placed into
+                                     the target module (mod) */
+    struct ly_set groupings;    /**< stack for groupings circular check */
+    struct ly_set unres;        /**< to validate leafref's target and xpath of when/must */
+    struct ly_set dflts;        /**< set of incomplete default values */
+    struct ly_set tpdf_chain;
+    uint16_t path_len;
+    int options;                /**< various @ref scflags. */
+#define LYSC_CTX_BUFSIZE 4078
+    char path[LYSC_CTX_BUFSIZE];
 };
 
 /**

--- a/src/validation.c
+++ b/src/validation.c
@@ -12,16 +12,23 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
-
 #include <assert.h>
-#include <string.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
-#include "xpath.h"
+#include "common.h"
+#include "config.h"
+#include "hash_table.h"
+#include "log.h"
+#include "plugins_types.h"
+#include "set.h"
+#include "tree.h"
 #include "tree_data_internal.h"
+#include "tree_schema.h"
 #include "tree_schema_internal.h"
+#include "xpath.h"
 
 static struct lyd_node *
 lys_getnext_data(const struct lyd_node *last, const struct lyd_node *sibling, const struct lysc_node **slast,

--- a/src/xml.c
+++ b/src/xml.c
@@ -13,17 +13,21 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "common.h"
+#define _GNU_SOURCE
+
+#include "xml.h"
 
 #include <assert.h>
 #include <ctype.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "xml.h"
-#include "printer_internal.h"
+#include "common.h"
+#include "dict.h"
+#include "printer.h"
+#include "tree.h"
+#include "tree_data.h"
 
 /* Move input p by s characters, if EOF log with lyxml_ctx c */
 #define move_input(c,s) c->input += s; LY_CHECK_ERR_RET(!c->input[0], LOGVAL(c->ctx, LY_VLOG_LINE, &c->line, LY_VCODE_EOF), LY_EVALID)

--- a/src/xml.h
+++ b/src/xml.h
@@ -20,8 +20,8 @@
 
 #include "log.h"
 #include "set.h"
-#include "tree_schema.h"
 
+struct ly_ctx;
 struct ly_out;
 struct ly_prefix;
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -16,24 +16,29 @@
 /* needed by libmath functions isfinite(), isinf(), isnan(), signbit(), ... */
 #define _ISOC99_SOURCE
 
-#include "common.h"
+#include "xpath.h"
 
-#include <math.h>
+#include <assert.h>
 #include <ctype.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <errno.h>
-#include <assert.h>
 
-#include "xpath.h"
+#include "common.h"
+#include "context.h"
 #include "dict.h"
-#include "xml.h"
-#include "printer_data.h"
-#include "tree_schema_internal.h"
-#include "tree_data_internal.h"
+#include "hash_table.h"
 #include "plugins_types.h"
+#include "printer.h"
+#include "printer_data.h"
+#include "tree.h"
+#include "tree_data_internal.h"
+#include "tree_schema_internal.h"
+#include "xml.h"
 
 static LY_ERR reparse_or_expr(const struct ly_ctx *ctx, struct lyxp_expr *exp, uint16_t *exp_idx);
 static LY_ERR eval_expr_select(struct lyxp_expr *exp, uint16_t *exp_idx, enum lyxp_expr_type etype, struct lyxp_set *set, int options);

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -17,10 +17,12 @@
 
 #include <stdint.h>
 
+#include "config.h"
 #include "log.h"
+#include "tree_data.h"
+#include "tree_schema.h"
 
 struct ly_ctx;
-struct lysc_node;
 
 /*
  * XPath evaluator fully compliant with http://www.w3.org/TR/1999/REC-xpath-19991116/

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -24,6 +24,7 @@
 
 #include "../../src/context.h"
 #include "../../src/tree_data_internal.h"
+#include "../../src/printer.h"
 #include "../../src/printer_data.h"
 
 #define BUFSIZE 1024

--- a/tests/utests/data/test_printer_xml.c
+++ b/tests/utests/data/test_printer_xml.c
@@ -23,6 +23,7 @@
 #include "tests/config.h"
 
 #include "../../src/context.h"
+#include "../../src/printer.h"
 #include "../../src/printer_data.h"
 
 #define BUFSIZE 1024

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -24,6 +24,7 @@
 
 #include "../../src/context.h"
 #include "../../src/tree_data_internal.h"
+#include "../../src/printer.h"
 #include "../../src/printer_data.h"
 
 #define BUFSIZE 1024

--- a/tests/utests/schema/test_printer_yang.c
+++ b/tests/utests/schema/test_printer_yang.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "../../src/context.h"
+#include "../../src/printer.h"
 #include "../../src/printer_schema.h"
 
 #define BUFSIZE 1024

--- a/tests/utests/schema/test_printer_yin.c
+++ b/tests/utests/schema/test_printer_yin.c
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "../../src/context.h"
+#include "../../src/printer.h"
 #include "../../src/printer_schema.h"
 
 #define BUFSIZE 1024

--- a/tests/utests/test_hash_table.c
+++ b/tests/utests/test_hash_table.c
@@ -12,6 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
+#define _GNU_SOURCE
+
 #include "common.h"
 
 #include "tests/config.h"

--- a/tests/utests/test_set.c
+++ b/tests/utests/test_set.c
@@ -11,14 +11,16 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#include "common.h"
+
+#define _GNU_SOURCE
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <setjmp.h>
-#include <cmocka.h>
-
 #include <string.h>
+
+#include <cmocka.h>
 
 #include "../../src/set.h"
 

--- a/tests/utests/test_xpath.c
+++ b/tests/utests/test_xpath.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #include "../../src/context.h"
+#include "../../src/set.h"
 #include "../../src/tree_data.h"
 #include "../../src/tree_schema.h"
 

--- a/tests/utests/test_yanglib.c
+++ b/tests/utests/test_yanglib.c
@@ -12,17 +12,20 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "tests/config.h"
-
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdlib.h>
 #include <setjmp.h>
-#include <cmocka.h>
-
-#include <stdio.h>
 #include <string.h>
 
+#include <cmocka.h>
+
+#include "tests/config.h"
+
 #include "../../src/context.h"
+#include "../../src/log.h"
+#include "../../src/set.h"
+#include "../../src/tree_data.h"
 #include "../../src/tree_schema.h"
 
 #define BUFSIZE 1024

--- a/tools/config.h.in
+++ b/tools/config.h.in
@@ -15,9 +15,6 @@
 #ifndef YANGLINT_CONFIG_H_
 #define YANGLINT_CONFIG_H_
 
-#define _DEFAULT_SOURCE
-#define _GNU_SOURCE
-
 #define PROJECT_VERSION "@LIBYANG_VERSION@" /**< libyang project version string */
 
 #endif /* YANGLINT_CONFIG_H_ */

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -12,20 +12,19 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
-
-#include <string.h>
-#include <stdio.h>
-#include <errno.h>
-#include <ctype.h>
-#include <assert.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <getopt.h>
-#include <libgen.h>
+#define _GNU_SOURCE
 
 #include "commands.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
 #include "libyang.h"
 
 COMMAND commands[];

--- a/tools/lint/commands.h
+++ b/tools/lint/commands.h
@@ -21,8 +21,6 @@
 #  define UNUSED(x) UNUSED_ ## x
 #endif
 
-#include <stdlib.h>
-
 #include "libyang.h"
 
 #define PROMPT "> "

--- a/tools/lint/completion.c
+++ b/tools/lint/completion.c
@@ -12,18 +12,18 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
+#define _GNU_SOURCE
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <sys/types.h>
-#include <dirent.h>
 #include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-#include "commands.h"
-#include "./linenoise/linenoise.h"
 #include "libyang.h"
+
+#include "commands.h"
+#include "linenoise/linenoise.h"
 
 extern struct ly_ctx *ctx;
 

--- a/tools/lint/configuration.c
+++ b/tools/lint/configuration.c
@@ -12,19 +12,17 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
-
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <pwd.h>
-
 #include "configuration.h"
-#include "./linenoise/linenoise.h"
+
+#include <errno.h>
+#include <pwd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "linenoise/linenoise.h"
 
 /* Yanglint home (appended to ~/) */
 #define YL_DIR ".yanglint"

--- a/tools/lint/linenoise/linenoise.c
+++ b/tools/lint/linenoise/linenoise.c
@@ -107,20 +107,19 @@
 
 #define _GNU_SOURCE
 
-#include <termios.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <stdlib.h>
+#include "linenoise.h"
+
 #include <ctype.h>
 #include <dirent.h>
-#include <sys/types.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <termios.h>
 #include <unistd.h>
-#include "linenoise.h"
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096

--- a/tools/lint/linenoise/linenoise.h
+++ b/tools/lint/linenoise/linenoise.h
@@ -39,6 +39,8 @@
 #ifndef __LINENOISE_H
 #define __LINENOISE_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tools/lint/main.c
+++ b/tools/lint/main.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
+#define _GNU_SOURCE
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,11 +20,15 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "commands.h"
-#include "configuration.h"
-#include "completion.h"
-#include "./linenoise/linenoise.h"
 #include "libyang.h"
+
+#include "tools/config.h"
+
+#include "commands.h"
+#include "completion.h"
+#include "configuration.h"
+#include "linenoise/linenoise.h"
+
 
 int done;
 struct ly_ctx *ctx = NULL;

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
+#define _GNU_SOURCE
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -25,8 +25,12 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "commands.h"
 #include "libyang.h"
+
+#include "tools/config.h"
+
+#include "commands.h"
+
 
 volatile uint8_t verbose = 0;
 

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -12,7 +12,7 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#include "config.h"
+#define _GNU_SOURCE
 
 #include <errno.h>
 #include <fcntl.h>
@@ -24,8 +24,9 @@
 #include <getopt.h>
 #include <unistd.h>
 
-#include "context.h"
-#include "plugins_types.h"
+#include "libyang.h"
+
+#include "tools/config.h"
 
 void
 help(void)


### PR DESCRIPTION
Tests were not really involved into the cleanup since they are subject to redesign anyway.