### PR TITLE
Fix travis deployment commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ before_install:
   - cmake .. && make -j2 && sudo make install
   - cd ../..
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y valgrind libpcre3-dev python3-dev swig python3-cffi python3-setuptools twine; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CC" = "gcc" -a "$TRAVIS_ARCH" = "amd64" ]; then pip install --user codecov; export CFLAGS="-coverage"; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y valgrind libpcre3-dev python3-dev swig python3-cffi python3-setuptools python3-pip; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$CC" = "gcc" -a "$TRAVIS_ARCH" = "amd64" ]; then pip3 install --user codecov==2.0.22 twine==3.1.1; export CFLAGS="-coverage"; fi
 
 script:
   - mkdir build && cd build


### PR DESCRIPTION
This fixes two problems seen during deployment of build artifacts:

The first one is:

```
~# codecov
...
Error running `gcov -pb /home/travis/build/CESNET/libyang/build/CMakeFiles/compat.dir/compat/compat.c.gcno`: [Errno 2] No such file or directory
Error: 'NoneType' object has no attribute 'replace'
```

Which is a bug introduced in a recent version of codecov. Use a fixed version that we know works.

And the second one:

```
~# twine upload --skip-existing build/python/dist/*
Uploading distributions to https://upload.pypi.org/legacy/
TypeError: expected string or bytes-like object
```

Which seems related to specific a metadata 2.1 field in setup.py:

https://github.com/CESNET/libyang/blob/7de0d225cdd61a19b5709015e910269212fc2381/python/setup.py#L133

The version of twine provided by ubuntu 18.04 is too old for this. Install a recent version of twine with pip to fix the problem.

Use pip3 for both codecov and twine as pip (python 2) may have problems with recent versions of python packages.