### PR TITLE
weaken the validation of trusted query operation

### DIFF
--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -437,10 +437,17 @@ printvalue:
         goto printvalue;
 
     case LY_TYPE_EMPTY:
-    case LY_TYPE_UNKNOWN:
         /* treat <edit-config> node without value as empty */
         ly_print(out, "/>");
         break;
+
+    case LY_TYPE_UNKNOWN:
+        if (leaf->value_str[0] == '\0') {
+            ly_print(out, "/>");
+            break;
+        }
+        datatype = ((struct lys_node_leaf *)leaf->schema)->type.base;
+        goto printvalue;
 
     default:
         /* error */


### PR DESCRIPTION
Target Parsing option combination[lyd_parse_mem, lyd_parse_xml...]: LYD_OPT_GET|LYD_OPT_TRUSTED or LYD_OPT_GETCONFIG|LYD_OPT_TRUSTED

Related issue:
https://github.com/CESNET/libyang/issues/1114