### PR TITLE
fuzzing REFACTOR fuzz harneses

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-set(fuzz_targets lys_parse_mem buf_add_char yang_parse_module)
+set(fuzz_targets lys_parse_mem lyd_parse_mem buf_add_char yang_parse_module)
 
 if(FUZZER STREQUAL "AFL")
 	foreach(target_name IN LISTS fuzz_targets)

--- a/tests/fuzz/lyd_parse_mem.c
+++ b/tests/fuzz/lyd_parse_mem.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "libyang.h"
+
+int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
+{
+	struct ly_ctx *ctx = NULL;
+	static bool log = false;
+	const char *schema_a = "module defs {namespace urn:tests:defs;prefix d;yang-version 1.1;"
+		            "identity crypto-alg; identity interface-type; identity ethernet {base interface-type;} identity fast-ethernet {base ethernet;}}";
+    const char *schema_b = "module types {namespace urn:tests:types;prefix t;yang-version 1.1; import defs {prefix defs;}"
+            "feature f; identity gigabit-ethernet { base defs:ethernet;}"
+            "container cont {leaf leaftarget {type empty;}"
+                            "list listtarget {key id; max-elements 5;leaf id {type uint8;} leaf value {type string;}}"
+                            "leaf-list leaflisttarget {type uint8; max-elements 5;}}"
+            "list list {key id; leaf id {type string;} leaf value {type string;} leaf-list targets {type string;}}"
+            "list list2 {key \"id value\"; leaf id {type string;} leaf value {type string;}}"
+            "list list_inst {key id; leaf id {type instance-identifier {require-instance true;}} leaf value {type string;}}"
+            "list list_ident {key id; leaf id {type identityref {base defs:interface-type;}} leaf value {type string;}}"
+            "leaf-list leaflisttarget {type string;}"
+            "leaf binary {type binary {length 5 {error-message \"This base64 value must be of length 5.\";}}}"
+            "leaf binary-norestr {type binary;}"
+            "leaf int8 {type int8 {range 10..20;}}"
+            "leaf uint8 {type uint8 {range 150..200;}}"
+            "leaf int16 {type int16 {range -20..-10;}}"
+            "leaf uint16 {type uint16 {range 150..200;}}"
+            "leaf int32 {type int32;}"
+            "leaf uint32 {type uint32;}"
+            "leaf int64 {type int64;}"
+            "leaf uint64 {type uint64;}"
+            "leaf bits {type bits {bit zero; bit one {if-feature f;} bit two;}}"
+            "leaf enums {type enumeration {enum white; enum yellow {if-feature f;}}}"
+            "leaf dec64 {type decimal64 {fraction-digits 1; range 1.5..10;}}"
+            "leaf dec64-norestr {type decimal64 {fraction-digits 18;}}"
+            "leaf str {type string {length 8..10; pattern '[a-z ]*';}}"
+            "leaf str-norestr {type string;}"
+            "leaf str-utf8 {type string{length 2..5; pattern '€*';}}"
+            "leaf bool {type boolean;}"
+            "leaf empty {type empty;}"
+            "leaf ident {type identityref {base defs:interface-type;}}"
+ 	    "leaf inst {type instance-identifier {require-instance true;}}"
+            "leaf inst-noreq {type instance-identifier {require-instance false;}}"
+            "leaf lref {type leafref {path /leaflisttarget; require-instance true;}}"
+            "leaf lref2 {type leafref {path \"../list[id = current()/../str-norestr]/targets\"; require-instance true;}}"
+            "leaf un1 {type union {"
+            "type leafref {path /int8; require-instance true;}"
+            "type union { type identityref {base defs:interface-type;} type instance-identifier {require-instance true;} }"
+            "type string {length 1..20;}}}}";
+    	char *data = NULL;
+
+	LY_ERR err;
+
+	if (!log) {
+		ly_log_options(0);
+		log = true;
+	}
+
+	err = ly_ctx_new(NULL, 0, &ctx);
+	if (err != LY_SUCCESS) {
+		fprintf(stderr, "Failed to create context\n");
+		exit(EXIT_FAILURE);
+	}
+
+	lys_parse_mem(ctx, schema_a, LYS_IN_YANG);
+	lys_parse_mem(ctx, schema_b, LYS_IN_YANG);
+
+	data = malloc(len + 1);
+	if (data == NULL) {
+		return 0;
+	}
+	memcpy(data, buf, len);
+	data[len] = 0;
+
+	lyd_parse_mem(ctx, data, LYD_XML, LYD_VALOPT_DATA_ONLY);
+	ly_ctx_destroy(ctx, NULL);
+
+	free(data);
+
+	return 0;
+}

--- a/tests/fuzz/lys_parse_mem.c
+++ b/tests/fuzz/lys_parse_mem.c
@@ -8,6 +8,7 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 {
 	struct ly_ctx *ctx = NULL;
 	static bool log = false;
+	char *data = NULL;
 	LY_ERR err;
 
 	if (!log) {
@@ -21,7 +22,16 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 		exit(EXIT_FAILURE);
 	}
 
-	lys_parse_mem(ctx, buf, LYS_IN_YANG);
+	data = malloc(len + 1);
+	if (data == NULL) {
+		return 0;
+	}
+
+	memcpy(data, buf, len);
+	data[len] = 0;
+
+	lys_parse_mem(ctx, data, LYS_IN_YANG);
 	ly_ctx_destroy(ctx, NULL);
+	free(data);
 	return 0;
 }

--- a/tests/fuzz/main.c
+++ b/tests/fuzz/main.c
@@ -24,4 +24,18 @@ int main(void) {
 	return 0;
 }
 
+#else
+int main(void) {
+	int ret;
+	uint8_t buf[64 * 1024];
+
+	ret = fread(buf, 1, sizeof(buf), stdin);
+	if (ret < 0) {
+		return 0;
+	}
+
+	LLVMFuzzerTestOneInput(buf, ret);
+
+	return 0;
+}
 #endif /* __AFL_COMPILER */

--- a/tests/fuzz/yang_parse_module.c
+++ b/tests/fuzz/yang_parse_module.c
@@ -5,10 +5,12 @@
 #include "../../src/common.h"
 #include "../../src/tree_schema_internal.h"
 
+LY_ERR yang_parse_module(struct lys_yang_parser_ctx **context, const char *data, struct lys_module *mod);
+
 int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 {
 	struct lys_module *mod = NULL;
-	struct lys_parser_ctx *context = NULL;
+	struct lys_yang_parser_ctx *context = NULL;
 	uint8_t *data = NULL;
 	struct ly_ctx *ctx = NULL;
 	static bool log = false; 
@@ -30,8 +32,8 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 		fprintf(stderr, "Out of memory\n");
 		return 0;
 	}
-	data[len] = 0;
 	memcpy(data, buf, len);
+	data[len] = 0;
 
 	mod = calloc(1, sizeof *mod);
 	if (mod == NULL) {


### PR DESCRIPTION
Hello,

this PR is a cleanup of the fuzzing harnesses.
It fixes minor issues with implicit function declarations in the fuzzing harnesses and terminates fuzzer
string inputs with string termination characters to stop false positive crashes that appear due to unterminated strings.

Additionally I've added an ifdef to enable use of the harnesses without any fuzzing, which should make testing of the crashes easier, in tests/fuzz/main.c. When built with ```make -DENABLE_BUILD_TESTS=ON -DENABLE_FUZZ_TARGETS=ON ..``` the fuzz harnesses will accept input from stdin and forward it to the function that is being tested.

This also adds a harness that I've used for XML fuzzing in tests/fuzz/lyd_parse_mem.c. Once the libyang2 JSON parser is implemented it should be usable with the JSON parser by changing the arguments passed to lyd_parse_mem. I've reused a YANG model from one of the unit tests that test the xml parser, although so far from my experiences it doesn't seem to matter what YANG model is used as I've reproduced multiple crashes with different models.

Regards,
Juraj