### PR TITLE
libyang2: xml BUGFIX heap oob crash issues in lyxml_parse_value

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -376,6 +376,8 @@ lyxml_pututf8(char *dst, uint32_t value, size_t *bytes_written)
         dst[3] = 0x80 | (value & 0x3f);
 
         (*bytes_written) = 4;
+    } else {
+	    return LY_EINVAL;
     }
     return LY_SUCCESS;
 }
@@ -430,7 +432,7 @@ lyxml_parse_value(struct lyxml_ctx *xmlctx, char endchar, char **value, size_t *
             /* allocate enough for the offset and next character,
              * we will need 4 bytes at most since we support only the predefined
              * (one-char) entities and character references */
-            if (len + offset + 4 >= size) {
+            while (len + offset + 4 >= size) {
                 buf = ly_realloc(buf, size + BUFSIZE_STEP);
                 LY_CHECK_ERR_RET(!buf, LOGMEM(ctx), LY_EMEM);
                 size += BUFSIZE_STEP;


### PR DESCRIPTION
Hello,

this fixes an out of bounds write that appeared due to buf being increased in size
only once, even if len + offset + 4 was larger than size by a number
larger than BUFSIZE_STEP. This fix incrementally increases the buffer size, as long as it
is smaller than len + offset + 4.

It also fixes the uninitialized use of the u variable used to store a UTF-8 character in the same
function to stop valgrind complaints about uninitialized reads.

The XML files I've used to reproduce the issue are attached below. I've tested them by passing them to the lyd_parse_mem fuzz harness available in #1126 by compiling without any fuzzers and passing the file directly to lyd_parse_mem.

The first file, crash.xml reproduces the out of bounds write, while crash2.xml has the uninitialized variable issue with the invalid write.

If any changes are required please let me know,
[crashes_xml.zip](https://github.com/CESNET/libyang/files/4848065/crashes_xml.zip)

Thanks,
Juraj