### PR TITLE
fix a coredump for api 'lyd_parse_xml' when action has no namespace

### DIFF
--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -673,7 +673,8 @@ lyd_parse_xml(struct ly_ctx *ctx, struct lyxml_elem **root, int options, ...)
     }
 
     if ((options & LYD_OPT_RPC)
-            && !strcmp(xmlstart->name, "action") && !strcmp(xmlstart->ns->value, LY_NSYANG)) {
+            && !strcmp(xmlstart->name, "action")
+            && xmlstart->ns && !strcmp(xmlstart->ns->value, LY_NSYANG)) {
         /* it's an action, not a simple RPC */
         xmlstart = xmlstart->child;
         if (options & LYD_OPT_DESTRUCT) {


### PR DESCRIPTION
Hi,Michal,
 there is a coredump in api `lyd_parse_xml`  when  `action` has no namespace in XML data, and I try to  fix it,  please review it , thanks.

my  sample yang module, XML data  and test it with yanglint (the latest version 1.8.7)   are as follows:
`the yang module,mod.yang :`
```
module mod {
    prefix abc;
    namespace "urn:cesnet:mod";

    yang-version 1.1;

    container action {
        action act {
            input {
                leaf l {
                    type string;
                }
            }

            output {
                leaf l2 {
                    type string;
                }
            }
        }
    }
}

```
`the XML data,data.xml:`
```
<action>
  <act>
    <l>test</l>
  </act>
</action>
```

`using yanglint with the  command (yanglint -t rpc -f xml mod.yang data.xml) , the result appears a coredump  `
```
root@oss-0007:/home/sample_test# yanglint -v
yanglint SO 1.8.7
root@oss-0007:/home/sample_test# yanglint -t rpc -f xml mod.yang data.xml
Segmentation fault (core dumped)
root@oss-0007:/home/sample_test#

```