### PR TITLE
Add ABI laboratory tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,12 @@ branches:
     - master
     - devel
 
+addons:
+  apt:
+    update: true
+
 before_install:
+  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo apt-get -y install abi-dumper abi-compliance-checker pkg-config; fi
   - git clone git://git.cryptomilk.org/projects/cmocka.git
   - cd cmocka && mkdir build && cd build
   - cmake .. && make -j2 && sudo make install
@@ -54,6 +59,7 @@ script:
   - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_ARCH" = "arm64" ]; then cmake -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_VALGRIND_TESTS=OFF ..; fi
   - make -j2 && ctest --output-on-failure
   - cd -
+  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then ./tools/abi-check.sh; fi
 
 deploy:
   - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ addons:
     update: true
 
 before_install:
-  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo apt-get -y install abi-dumper abi-compliance-checker pkg-config; fi
+  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo apt-get -y install abi-dumper abi-compliance-checker pkg-config w3m; fi
   - git clone git://git.cryptomilk.org/projects/cmocka.git
   - cd cmocka && mkdir build && cd build
   - cmake .. && make -j2 && sudo make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: c
+env:
+  global:
+  - CMOCKA_VERSION: 1.1.5
+
+cache:
+  directories:
+  - cmocka
 
 matrix:
   include:
@@ -60,10 +67,12 @@ addons:
     update: true
 
 before_install:
-  - git clone git://git.cryptomilk.org/projects/cmocka.git
-  - cd cmocka && mkdir build && cd build
-  - cmake .. && make -j2 && sudo make install
-  - cd ../..
+  - OLD_CMOCKA_VERSION=$(sed -n 's/project(cmocka VERSION \([0-9.]*\) LANGUAGES C)/\1/p' cmocka/CMakeLists.txt)
+  - if [ -f "cmocka/CMakeLists.txt" ] && [ "$OLD_CMOCKA_VERSION" != "$CMOCKA_VERSION" ]; then echo "Purging the cmocka-$OLD_CMOCKA_VERSION from cache"; rm -rf cmocka; fi
+  - if [ ! -d "cmocka" ] || [ ! -f "cmocka/CMakeLists.txt" ]; then echo "Downloading cmocka-$CMOCKA_VERSION"; rm -rf cmocka && curl -SLO https://cmocka.org/files/1.1/cmocka-$CMOCKA_VERSION.tar.xz && tar -xJf cmocka-$CMOCKA_VERSION.tar.xz && mv "cmocka-$CMOCKA_VERSION" cmocka; fi
+  - if [ ! -d "cmocka/build" ] || [ ! -f "cmocka/build/Makefile" ]; then mkdir -p cmocka/build && (cd cmocka/build && cmake ..); fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ ! -f "cmocka/build/src/libcmocka.dylib" ]; then (cd cmocka/build && make -j2); fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -f "cmocka/build/src/libcmocka.so" ]; then (cd cmocka/build && make -j2); fi
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then pip3 install --user codecov==2.0.22; export CFLAGS="-coverage"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ before_install:
   - if [ ! -d "cmocka/build" ] || [ ! -f "cmocka/build/Makefile" ]; then mkdir -p cmocka/build && (cd cmocka/build && cmake ..); fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ ! -f "cmocka/build/src/libcmocka.dylib" ]; then (cd cmocka/build && make -j2); fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -f "cmocka/build/src/libcmocka.so" ]; then (cd cmocka/build && make -j2); fi
+  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo snap install universal-ctags; fi
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then pip3 install --user codecov==2.0.22; export CFLAGS="-coverage"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,16 +40,30 @@ branches:
 
 addons:
   apt:
+    packages:
+    - abi-dumper
+    - abi-compliance-checker
+    - pkg-config
+    - w3m
+    - curl
+    - valgrind
+    - libpcre3-dev
+    - python3-dev
+    - python3-cffi
+    - python3-setuptools
+    - python3-pip
+    - swig
+    update: true
+  homebrew:
+    packages:
+    - curl
     update: true
 
 before_install:
-  - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo apt-get -y install abi-dumper abi-compliance-checker pkg-config w3m; fi
   - git clone git://git.cryptomilk.org/projects/cmocka.git
   - cd cmocka && mkdir build && cd build
   - cmake .. && make -j2 && sudo make install
   - cd ../..
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update -qq; sudo apt-get install -y valgrind libpcre3-dev python3-dev swig; fi
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then pip3 install --user codecov==2.0.22; export CFLAGS="-coverage"; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,8 @@ before_install:
 script:
   - mkdir build && cd build
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then cmake -DENABLE_VALGRIND_TESTS=OFF ..; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_ARCH" = "amd64" ]; then cmake -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_STATIC=${ENABLE_STATIC:-OFF} ..; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$TRAVIS_ARCH" = "arm64" ]; then cmake -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_VALGRIND_TESTS=OFF ..; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_ARCH" = "amd64" ]; then cmake -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_STATIC=${ENABLE_STATIC:-OFF} ..; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ "$TRAVIS_ARCH" = "arm64" ]; then cmake -DGEN_LANGUAGE_BINDINGS=ON -DENABLE_VALGRIND_TESTS=OFF ..; fi
   - make -j2 && ctest --output-on-failure
   - cd -
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then ./tools/abi-check.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ env:
   - CMOCKA_VERSION: 1.1.5
 
 cache:
+  pip: true
   directories:
-  - cmocka
+    - cmocka
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: c
-env:
-  global:
-  - CMOCKA_VERSION: 1.1.5
 
 cache:
   pip: true
@@ -55,6 +52,7 @@ addons:
     - w3m
     - curl
     - valgrind
+    - libcmocka-dev
     - libpcre3-dev
     - python3-dev
     - python3-cffi
@@ -65,15 +63,10 @@ addons:
   homebrew:
     packages:
     - curl
+    - cmocka
     update: true
 
 before_install:
-  - OLD_CMOCKA_VERSION=$(sed -n 's/project(cmocka VERSION \([0-9.]*\) LANGUAGES C)/\1/p' cmocka/CMakeLists.txt)
-  - if [ -f "cmocka/CMakeLists.txt" ] && [ "$OLD_CMOCKA_VERSION" != "$CMOCKA_VERSION" ]; then echo "Purging the cmocka-$OLD_CMOCKA_VERSION from cache"; rm -rf cmocka; fi
-  - if [ ! -d "cmocka" ] || [ ! -f "cmocka/CMakeLists.txt" ]; then echo "Downloading cmocka-$CMOCKA_VERSION"; rm -rf cmocka && curl -SLO https://cmocka.org/files/1.1/cmocka-$CMOCKA_VERSION.tar.xz && tar -xJf cmocka-$CMOCKA_VERSION.tar.xz && mv "cmocka-$CMOCKA_VERSION" cmocka; fi
-  - if [ ! -d "cmocka/build" ] || [ ! -f "cmocka/build/Makefile" ]; then mkdir -p cmocka/build && (cd cmocka/build && cmake ..); fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ] && [ ! -f "cmocka/build/src/libcmocka.dylib" ]; then (cd cmocka/build && make -j2); fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ] && [ ! -f "cmocka/build/src/libcmocka.so" ]; then (cd cmocka/build && make -j2); fi
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then sudo snap install universal-ctags; fi
   - if [ "$DEPLOY_BUILD" = "TRUE" ]; then pip3 install --user codecov==2.0.22; export CFLAGS="-coverage"; fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
 set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_C_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
-set(CMAKE_C_FLAGS_DEBUG   "-g -O0")
+set(CMAKE_C_FLAGS_DEBUG   "-g -Og")
 
 # options
 if((CMAKE_BUILD_TYPE STREQUAL debug) OR (CMAKE_BUILD_TYPE STREQUAL Package))

--- a/libyang.dump
+++ b/libyang.dump
@@ -1,0 +1,6263 @@
+$VAR1 = {
+          'ABI_DUMPER_VERSION' => '1.1',
+          'ABI_DUMP_VERSION' => '3.5',
+          'Arch' => 'x86_64',
+          'GccVersion' => '7.4.0',
+          'Headers' => {
+                         'libyang.h' => 1
+                       },
+          'Language' => 'C',
+          'LibraryName' => 'libyang.so.1.8.4',
+          'LibraryVersion' => '1.0.176',
+          'NameSpaces' => {},
+          'Needed' => {
+                        'ld-linux-x86-64.so.2' => 1,
+                        'libc.so.6' => 1,
+                        'libdl.so.2' => 1,
+                        'libpcre.so.3' => 1,
+                        'libpthread.so.0' => 1
+                      },
+          'PublicABI' => '1',
+          'Sources' => {
+                         'common.c' => 1,
+                         'context.c' => 1,
+                         'log.c' => 1,
+                         'tree_data.c' => 1
+                       },
+          'SymbolInfo' => {
+                            '13906' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'data_path',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '238',
+                                         'ShortName' => 'ly_path_data2schema',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '1194'
+                                       },
+                            '22614' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'xml_path',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'xml',
+                                                               'type' => '8484'
+                                                             }
+                                                    },
+                                         'Return' => '238',
+                                         'ShortName' => 'ly_path_xml2json',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '603'
+                                       },
+                            '28091' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '2170',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'eitem',
+                                                               'type' => '10126'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_err_clean',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '133'
+                                       },
+                            '28593' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '2153',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '10126',
+                                         'ShortName' => 'ly_err_first',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '106'
+                                       },
+                            '28724' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '361',
+                                         'ShortName' => 'ly_errapptag',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '91'
+                                       },
+                            '28875' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '2119',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '361',
+                                         'ShortName' => 'ly_errpath',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '76'
+                                       },
+                            '29047' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '361',
+                                         'ShortName' => 'ly_errmsg',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '61'
+                                       },
+                            '29219' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '2092',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '9997',
+                                         'ShortName' => 'ly_vecode',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '46'
+                                       },
+                            '29370' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '2076',
+                                         'Return' => '29469',
+                                         'ShortName' => 'ly_errno_glob_address',
+                                         'Source' => 'common.c',
+                                         'SourceLine' => '38'
+                                       },
+                            '29749' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1416',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'name',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'revision',
+                                                               'type' => '361'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'implemented',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_get_module',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '721'
+                                       },
+                            '30019' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1547',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'ns',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'revision',
+                                                               'type' => '361'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'implemented',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_get_module_by_ns',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '713'
+                                       },
+                            '41476' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'path',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '7473',
+                                         'ShortName' => 'ly_ctx_find_path',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1986'
+                                       },
+                            '41765' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1593',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'start',
+                                                               'type' => '13900'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'nodeid',
+                                                               'type' => '361'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'output',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '13900',
+                                         'ShortName' => 'ly_ctx_get_node',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1964'
+                                       },
+                            '42079' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1384',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '8941',
+                                         'ShortName' => 'ly_ctx_info',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1761'
+                                       },
+                            '44185' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '1548',
+                                         'ShortName' => 'ly_ctx_get_module_set_id',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1753'
+                                       },
+                            '45367' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'idx',
+                                                               'type' => '19896'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_get_disabled_module_iter',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1623'
+                                       },
+                            '45585' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1393',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'idx',
+                                                               'type' => '19896'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_get_module_iter',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1604'
+                                       },
+                            '45797' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'private_destructor',
+                                                               'type' => '46017'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_clean',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1580'
+                                       },
+                            '46044' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'module',
+                                                               'type' => '9338'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'private_destructor',
+                                                               'type' => '46017'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_ctx_remove_module',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1451'
+                                       },
+                            '48466' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'name',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'revision',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_load_module',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '1093'
+                                       },
+                            '51043' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'user_data',
+                                                               'type' => '6990'
+                                                             }
+                                                    },
+                                         'Return' => '9285',
+                                         'ShortName' => 'ly_ctx_get_module_data_clb',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '823'
+                                       },
+                            '51255' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'clb',
+                                                               'type' => '9285'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'user_data',
+                                                               'type' => '231'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_module_data_clb',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '809'
+                                       },
+                            '51458' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'user_data',
+                                                               'type' => '6990'
+                                                             }
+                                                    },
+                                         'Return' => '9188',
+                                         'ShortName' => 'ly_ctx_get_module_imp_clb',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '793'
+                                       },
+                            '51670' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'clb',
+                                                               'type' => '9188'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'user_data',
+                                                               'type' => '231'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_module_imp_clb',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '779'
+                                       },
+                            '51873' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'module',
+                                                               'type' => '9338'
+                                                             }
+                                                    },
+                                         'Return' => '9338',
+                                         'ShortName' => 'ly_ctx_get_module_older',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '735'
+                                       },
+                            '53189' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'module',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'revision',
+                                                               'type' => '361'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'submodule',
+                                                               'type' => '361'
+                                                             },
+                                                      '4' => {
+                                                               'name' => 'sub_revision',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '53655',
+                                         'ShortName' => 'ly_ctx_get_submodule',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '593'
+                                       },
+                            '53661' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'main_module',
+                                                               'type' => '9338'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'submodule',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '53655',
+                                         'ShortName' => 'ly_ctx_get_submodule2',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '564'
+                                       },
+                            '53927' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'private_destructor',
+                                                               'type' => '46017'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_destroy',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '525'
+                                       },
+                            '54279' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'index',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '499'
+                                       },
+                            '54451' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '17433'
+                                                             }
+                                                    },
+                                         'Return' => '54626',
+                                         'ShortName' => 'ly_ctx_get_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '487'
+                                       },
+                            '54632' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'search_dir',
+                                                               'type' => '361'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_ctx_set_searchdir',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '431'
+                                       },
+                            '55390' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_ctx_get_options',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '423'
+                                       },
+                            '55506' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_trusted',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '415'
+                                       },
+                            '55647' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_trusted',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '407'
+                                       },
+                            '55788' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_allimplemented',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '399'
+                                       },
+                            '55950' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_allimplemented',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '391'
+                                       },
+                            '56091' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_prefer_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '383'
+                                       },
+                            '56254' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_prefer_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '375'
+                                       },
+                            '56417' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_disable_searchdir_cwd',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '367'
+                                       },
+                            '56579' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_disable_searchdir_cwd',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '359'
+                                       },
+                            '56741' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_unset_disable_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '351'
+                                       },
+                            '56882' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_ctx_set_disable_searchdirs',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '343'
+                                       },
+                            '57164' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'search_dir',
+                                                               'type' => '361'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'data',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'format',
+                                                               'type' => '37910'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'options',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '3714',
+                                         'ShortName' => 'ly_ctx_new_ylmem',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '315'
+                                       },
+                            '57370' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'search_dir',
+                                                               'type' => '361'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'path',
+                                                               'type' => '361'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'format',
+                                                               'type' => '37910'
+                                                             },
+                                                      '3' => {
+                                                               'name' => 'options',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '3714',
+                                         'ShortName' => 'ly_ctx_new_ylpath',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '307'
+                                       },
+                            '58773' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'search_dir',
+                                                               'type' => '361'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'options',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '3714',
+                                         'ShortName' => 'ly_ctx_new',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '84'
+                                       },
+                            '59650' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1232',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'ctx',
+                                                               'type' => '3714'
+                                                             }
+                                                    },
+                                         'Return' => '69',
+                                         'ShortName' => 'ly_ctx_internal_modules_count',
+                                         'Source' => 'context.c',
+                                         'SourceLine' => '73'
+                                       },
+                            '60110' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1725',
+                                         'Return' => '7473',
+                                         'ShortName' => 'ly_set_new',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '6971'
+                                       },
+                            '60122' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1748',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'set',
+                                                               'type' => '7473'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'node',
+                                                               'type' => '231'
+                                                             },
+                                                      '2' => {
+                                                               'name' => 'options',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_set_add',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '7040'
+                                       },
+                            '60134' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1809',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'set',
+                                                               'type' => '7473'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_set_free',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '6983'
+                                       },
+                            '60146' => {
+                                         'Header' => 'libyang.h',
+                                         'Line' => '1770',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'set',
+                                                               'type' => '709540'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'node',
+                                                               'type' => '231'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_set_contains',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '6996'
+                                       },
+                            '60192' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'set',
+                                                               'type' => '7473'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'index',
+                                                               'type' => '69'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_set_rm_index',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '7122'
+                                       },
+                            '60548' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'set',
+                                                               'type' => '7473'
+                                                             }
+                                                    },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_set_clean',
+                                         'Source' => 'tree_data.c',
+                                         'SourceLine' => '7172'
+                                       },
+                            '707862' => {
+                                          'Header' => 'libyang.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'set',
+                                                                'type' => '7473'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'node',
+                                                                'type' => '231'
+                                                              }
+                                                     },
+                                          'Return' => '157',
+                                          'ShortName' => 'ly_set_rm',
+                                          'Source' => 'tree_data.c',
+                                          'SourceLine' => '7145'
+                                        },
+                            '708362' => {
+                                          'Header' => 'libyang.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'trg',
+                                                                'type' => '7473'
+                                                              },
+                                                       '1' => {
+                                                                'name' => 'src',
+                                                                'type' => '7473'
+                                                              },
+                                                       '2' => {
+                                                                'name' => 'options',
+                                                                'type' => '157'
+                                                              }
+                                                     },
+                                          'Return' => '157',
+                                          'ShortName' => 'ly_set_merge',
+                                          'Source' => 'tree_data.c',
+                                          'SourceLine' => '7075'
+                                        },
+                            '709143' => {
+                                          'Header' => 'libyang.h',
+                                          'Param' => {
+                                                       '0' => {
+                                                                'name' => 'set',
+                                                                'type' => '709540'
+                                                              }
+                                                     },
+                                          'Return' => '7473',
+                                          'ShortName' => 'ly_set_dup',
+                                          'Source' => 'tree_data.c',
+                                          'SourceLine' => '7018'
+                                        },
+                            '74941' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'eitem',
+                                                               'type' => '10126'
+                                                             }
+                                                    },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_err_print',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '934'
+                                       },
+                            '82935' => {
+                                         'Header' => 'libyang.h',
+                                         'Return' => '73467',
+                                         'ShortName' => 'ly_get_log_clb',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '72'
+                                       },
+                            '82964' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'clb',
+                                                               'type' => '73467'
+                                                             },
+                                                      '1' => {
+                                                               'name' => 'path',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi',
+                                                    '1' => 'rsi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_set_log_clb',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '65'
+                                       },
+                            '83020' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'dbg_groups',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '1',
+                                         'ShortName' => 'ly_verb_dbg',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '55'
+                                       },
+                            '83063' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'opts',
+                                                               'type' => '157'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '157',
+                                         'ShortName' => 'ly_log_options',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '46'
+                                       },
+                            '83123' => {
+                                         'Header' => 'libyang.h',
+                                         'Param' => {
+                                                      '0' => {
+                                                               'name' => 'level',
+                                                               'type' => '9433'
+                                                             }
+                                                    },
+                                         'Reg' => {
+                                                    '0' => 'rdi'
+                                                  },
+                                         'Return' => '9433',
+                                         'ShortName' => 'ly_verb',
+                                         'Source' => 'log.c',
+                                         'SourceLine' => '37'
+                                       }
+                          },
+          'SymbolVersion' => {},
+          'Symbols' => {
+                         'libyang.so.1.8.4' => {
+                                                 '__gcov_error_file' => -8,
+                                                 '__gcov_master' => -16,
+                                                 '__gcov_sort_n_vals' => 1,
+                                                 '__gcov_var' => -4136,
+                                                 '_fini' => 1,
+                                                 '_init' => 1,
+                                                 'ly_clean_plugins' => 1,
+                                                 'ly_ctx_clean' => 1,
+                                                 'ly_ctx_destroy' => 1,
+                                                 'ly_ctx_find_path' => 1,
+                                                 'ly_ctx_get_disabled_module_iter' => 1,
+                                                 'ly_ctx_get_module' => 1,
+                                                 'ly_ctx_get_module_by_ns' => 1,
+                                                 'ly_ctx_get_module_data_clb' => 1,
+                                                 'ly_ctx_get_module_imp_clb' => 1,
+                                                 'ly_ctx_get_module_iter' => 1,
+                                                 'ly_ctx_get_module_older' => 1,
+                                                 'ly_ctx_get_module_set_id' => 1,
+                                                 'ly_ctx_get_node' => 1,
+                                                 'ly_ctx_get_options' => 1,
+                                                 'ly_ctx_get_searchdirs' => 1,
+                                                 'ly_ctx_get_submodule' => 1,
+                                                 'ly_ctx_get_submodule2' => 1,
+                                                 'ly_ctx_info' => 1,
+                                                 'ly_ctx_internal_modules_count' => 1,
+                                                 'ly_ctx_load_module' => 1,
+                                                 'ly_ctx_new' => 1,
+                                                 'ly_ctx_new_ylmem' => 1,
+                                                 'ly_ctx_new_ylpath' => 1,
+                                                 'ly_ctx_remove_module' => 1,
+                                                 'ly_ctx_set_allimplemented' => 1,
+                                                 'ly_ctx_set_disable_searchdir_cwd' => 1,
+                                                 'ly_ctx_set_disable_searchdirs' => 1,
+                                                 'ly_ctx_set_module_data_clb' => 1,
+                                                 'ly_ctx_set_module_imp_clb' => 1,
+                                                 'ly_ctx_set_prefer_searchdirs' => 1,
+                                                 'ly_ctx_set_searchdir' => 1,
+                                                 'ly_ctx_set_trusted' => 1,
+                                                 'ly_ctx_unset_allimplemented' => 1,
+                                                 'ly_ctx_unset_disable_searchdir_cwd' => 1,
+                                                 'ly_ctx_unset_disable_searchdirs' => 1,
+                                                 'ly_ctx_unset_prefer_searchdirs' => 1,
+                                                 'ly_ctx_unset_searchdirs' => 1,
+                                                 'ly_ctx_unset_trusted' => 1,
+                                                 'ly_err_clean' => 1,
+                                                 'ly_err_first' => 1,
+                                                 'ly_err_print' => 1,
+                                                 'ly_errapptag' => 1,
+                                                 'ly_errmsg' => 1,
+                                                 'ly_errno_glob_address' => 1,
+                                                 'ly_errpath' => 1,
+                                                 'ly_get_loaded_plugins' => 1,
+                                                 'ly_get_log_clb' => 1,
+                                                 'ly_load_plugins' => 1,
+                                                 'ly_log_options' => 1,
+                                                 'ly_path_data2schema' => 1,
+                                                 'ly_path_xml2json' => 1,
+                                                 'ly_register_exts' => 1,
+                                                 'ly_register_types' => 1,
+                                                 'ly_set_add' => 1,
+                                                 'ly_set_clean' => 1,
+                                                 'ly_set_contains' => 1,
+                                                 'ly_set_dup' => 1,
+                                                 'ly_set_free' => 1,
+                                                 'ly_set_log_clb' => 1,
+                                                 'ly_set_merge' => 1,
+                                                 'ly_set_new' => 1,
+                                                 'ly_set_rm' => 1,
+                                                 'ly_set_rm_index' => 1,
+                                                 'ly_vecode' => 1,
+                                                 'ly_verb' => 1,
+                                                 'ly_verb_dbg' => 1,
+                                                 'lyd_change_leaf' => 1,
+                                                 'lyd_dec64_to_double' => 1,
+                                                 'lyd_diff' => 1,
+                                                 'lyd_dup' => 1,
+                                                 'lyd_dup_to_ctx' => 1,
+                                                 'lyd_dup_withsiblings' => 1,
+                                                 'lyd_find_instance' => 1,
+                                                 'lyd_find_path' => 1,
+                                                 'lyd_find_sibling' => 1,
+                                                 'lyd_find_sibling_set' => 1,
+                                                 'lyd_find_sibling_val' => 1,
+                                                 'lyd_first_sibling' => 1,
+                                                 'lyd_free' => 1,
+                                                 'lyd_free_attr' => 1,
+                                                 'lyd_free_diff' => 1,
+                                                 'lyd_free_val_diff' => 1,
+                                                 'lyd_free_withsiblings' => 1,
+                                                 'lyd_insert' => 1,
+                                                 'lyd_insert_after' => 1,
+                                                 'lyd_insert_attr' => 1,
+                                                 'lyd_insert_before' => 1,
+                                                 'lyd_insert_sibling' => 1,
+                                                 'lyd_leaf_type' => 1,
+                                                 'lyd_list_pos' => 1,
+                                                 'lyd_lyb_data_length' => 1,
+                                                 'lyd_merge' => 1,
+                                                 'lyd_merge_to_ctx' => 1,
+                                                 'lyd_new' => 1,
+                                                 'lyd_new_anydata' => 1,
+                                                 'lyd_new_leaf' => 1,
+                                                 'lyd_new_output' => 1,
+                                                 'lyd_new_output_anydata' => 1,
+                                                 'lyd_new_output_leaf' => 1,
+                                                 'lyd_new_path' => 1,
+                                                 'lyd_new_yangdata' => 1,
+                                                 'lyd_node_module' => 1,
+                                                 'lyd_node_should_print' => 1,
+                                                 'lyd_parse_fd' => 1,
+                                                 'lyd_parse_mem' => 1,
+                                                 'lyd_parse_path' => 1,
+                                                 'lyd_parse_xml' => 1,
+                                                 'lyd_path' => 1,
+                                                 'lyd_print_clb' => 1,
+                                                 'lyd_print_fd' => 1,
+                                                 'lyd_print_file' => 1,
+                                                 'lyd_print_mem' => 1,
+                                                 'lyd_print_path' => 1,
+                                                 'lyd_schema_sort' => 1,
+                                                 'lyd_unlink' => 1,
+                                                 'lyd_validate' => 1,
+                                                 'lyd_validate_modules' => 1,
+                                                 'lyd_validate_value' => 1,
+                                                 'lyd_value_type' => 1,
+                                                 'lyd_wd_default' => 1,
+                                                 'lydict_insert' => 1,
+                                                 'lydict_insert_zc' => 1,
+                                                 'lydict_remove' => 1,
+                                                 'lyext_log' => 1,
+                                                 'lyext_vlog' => 1,
+                                                 'lys_data_path' => 1,
+                                                 'lys_data_path_pattern' => 1,
+                                                 'lys_ext_complex_get_substmt' => 1,
+                                                 'lys_ext_instance_presence' => 1,
+                                                 'lys_ext_instance_substmt' => 1,
+                                                 'lys_features_disable' => 1,
+                                                 'lys_features_enable' => 1,
+                                                 'lys_features_list' => 1,
+                                                 'lys_features_state' => 1,
+                                                 'lys_find_path' => 1,
+                                                 'lys_getnext' => 1,
+                                                 'lys_getnext_union_type' => 1,
+                                                 'lys_iffeature_free' => 1,
+                                                 'lys_iffeature_value' => 1,
+                                                 'lys_implemented_module' => 1,
+                                                 'lys_is_disabled' => 1,
+                                                 'lys_is_key' => 1,
+                                                 'lys_main_module' => 1,
+                                                 'lys_node_module' => 1,
+                                                 'lys_node_xpath_atomize' => 1,
+                                                 'lys_parent' => 1,
+                                                 'lys_parse_fd' => 1,
+                                                 'lys_parse_mem' => 1,
+                                                 'lys_parse_path' => 1,
+                                                 'lys_path' => 1,
+                                                 'lys_print_clb' => 1,
+                                                 'lys_print_fd' => 1,
+                                                 'lys_print_file' => 1,
+                                                 'lys_print_mem' => 1,
+                                                 'lys_print_path' => 1,
+                                                 'lys_search_localfile' => 1,
+                                                 'lys_set_disabled' => 1,
+                                                 'lys_set_enabled' => 1,
+                                                 'lys_set_implemented' => 1,
+                                                 'lys_set_private' => 1,
+                                                 'lys_xpath_atomize' => 1,
+                                                 'lyxml_dup' => 1,
+                                                 'lyxml_free' => 1,
+                                                 'lyxml_free_withsiblings' => 1,
+                                                 'lyxml_get_attr' => 1,
+                                                 'lyxml_get_ns' => 1,
+                                                 'lyxml_parse_mem' => 1,
+                                                 'lyxml_parse_path' => 1,
+                                                 'lyxml_print_clb' => 1,
+                                                 'lyxml_print_fd' => 1,
+                                                 'lyxml_print_file' => 1,
+                                                 'lyxml_print_mem' => 1,
+                                                 'lyxml_unlink' => 1
+                                               }
+                       },
+          'Target' => 'unix',
+          'TypeInfo' => {
+                          '1' => {
+                                   'Name' => 'void',
+                                   'Type' => 'Intrinsic'
+                                 },
+                          '10009' => {
+                                       'Header' => 'libyang.h',
+                                       'Line' => '2136',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'level',
+                                                            'offset' => '0',
+                                                            'type' => '9433'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'no',
+                                                            'offset' => '4',
+                                                            'type' => '9502'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'vecode',
+                                                            'offset' => '8',
+                                                            'type' => '9997'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'msg',
+                                                            'offset' => '16',
+                                                            'type' => '238'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'path',
+                                                            'offset' => '24',
+                                                            'type' => '238'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'apptag',
+                                                            'offset' => '32',
+                                                            'type' => '238'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'next',
+                                                            'offset' => '40',
+                                                            'type' => '10126'
+                                                          },
+                                                   '7' => {
+                                                            'name' => 'prev',
+                                                            'offset' => '48',
+                                                            'type' => '10126'
+                                                          }
+                                                 },
+                                       'Name' => 'struct ly_err_item',
+                                       'Size' => '56',
+                                       'Type' => 'Struct'
+                                     },
+                          '10126' => {
+                                       'BaseType' => '10009',
+                                       'Name' => 'struct ly_err_item*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '10132' => {
+                                       'BaseType' => '10143',
+                                       'Header' => 'hash_table.h',
+                                       'Line' => '44',
+                                       'Name' => 'values_equal_cb',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10143' => {
+                                       'Name' => 'int(*)(void*, void*, int, void*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '231'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '231'
+                                                           },
+                                                    '2' => {
+                                                             'type' => '157'
+                                                           },
+                                                    '3' => {
+                                                             'type' => '231'
+                                                           }
+                                                  },
+                                       'Return' => '157',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '10179' => {
+                                       'BaseType' => '45',
+                                       'Name' => 'unsigned char*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '10185' => {
+                                       'Header' => 'hash_table.h',
+                                       'Line' => '95',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'hash_tab',
+                                                            'offset' => '0',
+                                                            'type' => '9176'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'lock',
+                                                            'offset' => '8',
+                                                            'type' => '743'
+                                                          }
+                                                 },
+                                       'Name' => 'struct dict_table',
+                                       'PrivateABI' => 1,
+                                       'Size' => '48',
+                                       'Type' => 'Struct'
+                                     },
+                          '10350' => {
+                                       'Header' => 'extensions.h',
+                                       'Line' => '67',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'LYEXT_PAR_MODULE',
+                                                            'value' => '0'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'LYEXT_PAR_NODE',
+                                                            'value' => '1'
+                                                          },
+                                                   '10' => {
+                                                             'name' => 'LYEXT_PAR_EXT',
+                                                             'value' => '10'
+                                                           },
+                                                   '11' => {
+                                                             'name' => 'LYEXT_PAR_EXTINST',
+                                                             'value' => '11'
+                                                           },
+                                                   '12' => {
+                                                             'name' => 'LYEXT_PAR_REFINE',
+                                                             'value' => '12'
+                                                           },
+                                                   '13' => {
+                                                             'name' => 'LYEXT_PAR_DEVIATION',
+                                                             'value' => '13'
+                                                           },
+                                                   '14' => {
+                                                             'name' => 'LYEXT_PAR_DEVIATE',
+                                                             'value' => '14'
+                                                           },
+                                                   '15' => {
+                                                             'name' => 'LYEXT_PAR_IMPORT',
+                                                             'value' => '15'
+                                                           },
+                                                   '16' => {
+                                                             'name' => 'LYEXT_PAR_INCLUDE',
+                                                             'value' => '16'
+                                                           },
+                                                   '17' => {
+                                                             'name' => 'LYEXT_PAR_REVISION',
+                                                             'value' => '17'
+                                                           },
+                                                   '18' => {
+                                                             'name' => 'LYEXT_PAR_IFFEATURE',
+                                                             'value' => '18'
+                                                           },
+                                                   '2' => {
+                                                            'name' => 'LYEXT_PAR_TPDF',
+                                                            'value' => '2'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'LYEXT_PAR_TYPE',
+                                                            'value' => '3'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'LYEXT_PAR_TYPE_BIT',
+                                                            'value' => '4'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'LYEXT_PAR_TYPE_ENUM',
+                                                            'value' => '5'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'LYEXT_PAR_FEATURE',
+                                                            'value' => '6'
+                                                          },
+                                                   '7' => {
+                                                            'name' => 'LYEXT_PAR_RESTR',
+                                                            'value' => '7'
+                                                          },
+                                                   '8' => {
+                                                            'name' => 'LYEXT_PAR_WHEN',
+                                                            'value' => '8'
+                                                          },
+                                                   '9' => {
+                                                            'name' => 'LYEXT_PAR_IDENT',
+                                                            'value' => '9'
+                                                          }
+                                                 },
+                                       'Name' => 'enum LYEXT_PAR',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Enum'
+                                     },
+                          '10573' => {
+                                       'Header' => 'extensions.h',
+                                       'Line' => '127',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'LYEXT_SUBSTMT_ALL',
+                                                            'value' => '-1'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'LYEXT_SUBSTMT_SELF',
+                                                            'value' => '0'
+                                                          },
+                                                   '10' => {
+                                                             'name' => 'LYEXT_SUBSTMT_KEY',
+                                                             'value' => '9'
+                                                           },
+                                                   '11' => {
+                                                             'name' => 'LYEXT_SUBSTMT_NAMESPACE',
+                                                             'value' => '10'
+                                                           },
+                                                   '12' => {
+                                                             'name' => 'LYEXT_SUBSTMT_ORGANIZATION',
+                                                             'value' => '11'
+                                                           },
+                                                   '13' => {
+                                                             'name' => 'LYEXT_SUBSTMT_PATH',
+                                                             'value' => '12'
+                                                           },
+                                                   '14' => {
+                                                             'name' => 'LYEXT_SUBSTMT_PREFIX',
+                                                             'value' => '13'
+                                                           },
+                                                   '15' => {
+                                                             'name' => 'LYEXT_SUBSTMT_PRESENCE',
+                                                             'value' => '14'
+                                                           },
+                                                   '16' => {
+                                                             'name' => 'LYEXT_SUBSTMT_REFERENCE',
+                                                             'value' => '15'
+                                                           },
+                                                   '17' => {
+                                                             'name' => 'LYEXT_SUBSTMT_REVISIONDATE',
+                                                             'value' => '16'
+                                                           },
+                                                   '18' => {
+                                                             'name' => 'LYEXT_SUBSTMT_UNITS',
+                                                             'value' => '17'
+                                                           },
+                                                   '19' => {
+                                                             'name' => 'LYEXT_SUBSTMT_VALUE',
+                                                             'value' => '18'
+                                                           },
+                                                   '2' => {
+                                                            'name' => 'LYEXT_SUBSTMT_ARGUMENT',
+                                                            'value' => '1'
+                                                          },
+                                                   '20' => {
+                                                             'name' => 'LYEXT_SUBSTMT_VERSION',
+                                                             'value' => '19'
+                                                           },
+                                                   '21' => {
+                                                             'name' => 'LYEXT_SUBSTMT_MODIFIER',
+                                                             'value' => '20'
+                                                           },
+                                                   '22' => {
+                                                             'name' => 'LYEXT_SUBSTMT_REQINSTANCE',
+                                                             'value' => '21'
+                                                           },
+                                                   '23' => {
+                                                             'name' => 'LYEXT_SUBSTMT_YINELEM',
+                                                             'value' => '22'
+                                                           },
+                                                   '24' => {
+                                                             'name' => 'LYEXT_SUBSTMT_CONFIG',
+                                                             'value' => '23'
+                                                           },
+                                                   '25' => {
+                                                             'name' => 'LYEXT_SUBSTMT_MANDATORY',
+                                                             'value' => '24'
+                                                           },
+                                                   '26' => {
+                                                             'name' => 'LYEXT_SUBSTMT_ORDEREDBY',
+                                                             'value' => '25'
+                                                           },
+                                                   '27' => {
+                                                             'name' => 'LYEXT_SUBSTMT_STATUS',
+                                                             'value' => '26'
+                                                           },
+                                                   '28' => {
+                                                             'name' => 'LYEXT_SUBSTMT_DIGITS',
+                                                             'value' => '27'
+                                                           },
+                                                   '29' => {
+                                                             'name' => 'LYEXT_SUBSTMT_MAX',
+                                                             'value' => '28'
+                                                           },
+                                                   '3' => {
+                                                            'name' => 'LYEXT_SUBSTMT_BASE',
+                                                            'value' => '2'
+                                                          },
+                                                   '30' => {
+                                                             'name' => 'LYEXT_SUBSTMT_MIN',
+                                                             'value' => '29'
+                                                           },
+                                                   '31' => {
+                                                             'name' => 'LYEXT_SUBSTMT_POSITION',
+                                                             'value' => '30'
+                                                           },
+                                                   '32' => {
+                                                             'name' => 'LYEXT_SUBSTMT_UNIQUE',
+                                                             'value' => '31'
+                                                           },
+                                                   '4' => {
+                                                            'name' => 'LYEXT_SUBSTMT_BELONGSTO',
+                                                            'value' => '3'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'LYEXT_SUBSTMT_CONTACT',
+                                                            'value' => '4'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'LYEXT_SUBSTMT_DEFAULT',
+                                                            'value' => '5'
+                                                          },
+                                                   '7' => {
+                                                            'name' => 'LYEXT_SUBSTMT_DESCRIPTION',
+                                                            'value' => '6'
+                                                          },
+                                                   '8' => {
+                                                            'name' => 'LYEXT_SUBSTMT_ERRTAG',
+                                                            'value' => '7'
+                                                          },
+                                                   '9' => {
+                                                            'name' => 'LYEXT_SUBSTMT_ERRMSG',
+                                                            'value' => '8'
+                                                          }
+                                                 },
+                                       'Name' => 'enum LYEXT_SUBSTMT',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Enum'
+                                     },
+                          '10584' => {
+                                       'BaseType' => '10595',
+                                       'Header' => 'extensions.h',
+                                       'Line' => '142',
+                                       'Name' => 'lyext_check_position_clb',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10595' => {
+                                       'Name' => 'int(*)(void const*, LYEXT_PAR, LYEXT_SUBSTMT)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '1446'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '10350'
+                                                           },
+                                                    '2' => {
+                                                             'type' => '10573'
+                                                           }
+                                                  },
+                                       'Return' => '157',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '106' => {
+                                     'BaseType' => '45',
+                                     'Header' => 'types.h',
+                                     'Line' => '37',
+                                     'Name' => '__uint8_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '1',
+                                     'Type' => 'Typedef'
+                                   },
+                          '10626' => {
+                                       'BaseType' => '10637',
+                                       'Header' => 'extensions.h',
+                                       'Line' => '152',
+                                       'Name' => 'lyext_check_result_clb',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10637' => {
+                                       'Name' => 'int(*)(struct lys_ext_instance*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '2730'
+                                                           }
+                                                  },
+                                       'Return' => '157',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '10658' => {
+                                       'BaseType' => '10669',
+                                       'Header' => 'extensions.h',
+                                       'Line' => '165',
+                                       'Name' => 'lyext_check_inherit_clb',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10669' => {
+                                       'Name' => 'int(*)(struct lys_ext_instance*, struct lys_node*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '2730'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '5163'
+                                                           }
+                                                  },
+                                       'Return' => '157',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '10695' => {
+                                       'BaseType' => '10706',
+                                       'Header' => 'extensions.h',
+                                       'Line' => '176',
+                                       'Name' => 'lyext_valid_data_clb',
+                                       'PrivateABI' => 1,
+                                       'Size' => '8',
+                                       'Type' => 'Typedef'
+                                     },
+                          '10706' => {
+                                       'Name' => 'int(*)(struct lys_ext_instance*, struct lyd_node*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '2730'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '8941'
+                                                           }
+                                                  },
+                                       'Return' => '157',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '10732' => {
+                                       'BaseType' => '3269',
+                                       'Name' => 'struct lys_module**',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '117' => {
+                                     'BaseType' => '128',
+                                     'Header' => 'types.h',
+                                     'Line' => '38',
+                                     'Name' => '__int16_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '2',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1230' => {
+                                      'BaseType' => '249',
+                                      'Name' => 'char[1]',
+                                      'Size' => '1',
+                                      'Type' => 'Array'
+                                    },
+                          '12757' => {
+                                       'Header' => 'context.h',
+                                       'Line' => '25',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'search_paths',
+                                                            'offset' => '0',
+                                                            'type' => '1470'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'size',
+                                                            'offset' => '8',
+                                                            'type' => '157'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'used',
+                                                            'offset' => '12',
+                                                            'type' => '157'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'list',
+                                                            'offset' => '16',
+                                                            'type' => '10732'
+                                                          },
+                                                   '4' => {
+                                                            'name' => 'parsing_sub_modules',
+                                                            'offset' => '24',
+                                                            'type' => '10732'
+                                                          },
+                                                   '5' => {
+                                                            'name' => 'parsed_submodules',
+                                                            'offset' => '32',
+                                                            'type' => '10732'
+                                                          },
+                                                   '6' => {
+                                                            'name' => 'parsing_sub_modules_count',
+                                                            'offset' => '40',
+                                                            'type' => '1532'
+                                                          },
+                                                   '7' => {
+                                                            'name' => 'parsed_submodules_count',
+                                                            'offset' => '41',
+                                                            'type' => '1532'
+                                                          },
+                                                   '8' => {
+                                                            'name' => 'module_set_id',
+                                                            'offset' => '42',
+                                                            'type' => '1548'
+                                                          },
+                                                   '9' => {
+                                                            'name' => 'flags',
+                                                            'offset' => '44',
+                                                            'type' => '157'
+                                                          }
+                                                 },
+                                       'Name' => 'struct ly_modules_list',
+                                       'PrivateABI' => 1,
+                                       'Size' => '48',
+                                       'Type' => 'Struct'
+                                     },
+                          '128' => {
+                                     'Name' => 'short',
+                                     'Size' => '2',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '135' => {
+                                     'BaseType' => '57',
+                                     'Header' => 'types.h',
+                                     'Line' => '39',
+                                     'Name' => '__uint16_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '2',
+                                     'Type' => 'Typedef'
+                                   },
+                          '13900' => {
+                                       'BaseType' => '5158',
+                                       'Name' => 'struct lys_node const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1402' => {
+                                      'BaseType' => '88',
+                                      'Header' => 'stdint-intn.h',
+                                      'Line' => '24',
+                                      'Name' => 'int8_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1413' => {
+                                      'BaseType' => '117',
+                                      'Header' => 'stdint-intn.h',
+                                      'Line' => '25',
+                                      'Name' => 'int16_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1424' => {
+                                      'BaseType' => '146',
+                                      'Header' => 'stdint-intn.h',
+                                      'Line' => '26',
+                                      'Name' => 'int32_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1435' => {
+                                      'BaseType' => '180',
+                                      'Header' => 'stdint-intn.h',
+                                      'Line' => '27',
+                                      'Name' => 'int64_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1446' => {
+                                      'BaseType' => '1457',
+                                      'Name' => 'void const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1457' => {
+                                      'BaseType' => '1',
+                                      'Name' => 'void const',
+                                      'Type' => 'Const'
+                                    },
+                          '146' => {
+                                     'BaseType' => '157',
+                                     'Header' => 'types.h',
+                                     'Line' => '40',
+                                     'Name' => '__int32_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '4',
+                                     'Type' => 'Typedef'
+                                   },
+                          '1470' => {
+                                      'BaseType' => '238',
+                                      'Name' => 'char**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '1532' => {
+                                      'BaseType' => '106',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '24',
+                                      'Name' => 'uint8_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1548' => {
+                                      'BaseType' => '135',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '25',
+                                      'Name' => 'uint16_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '2',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1559' => {
+                                      'BaseType' => '169',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '26',
+                                      'Name' => 'uint32_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '157' => {
+                                     'Name' => 'int',
+                                     'Size' => '4',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '1570' => {
+                                      'BaseType' => '198',
+                                      'Header' => 'stdint-uintn.h',
+                                      'Line' => '27',
+                                      'Name' => 'uint64_t',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '1613' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '191',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LYS_IN_UNKNOWN',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LYS_IN_YANG',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LYS_IN_YIN',
+                                                           'value' => '2'
+                                                         }
+                                                },
+                                      'Name' => 'enum LYS_INFORMAT',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '1624' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '229',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LYS_UNKNOWN',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LYS_CONTAINER',
+                                                           'value' => '1'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'LYS_INPUT',
+                                                            'value' => '512'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'LYS_OUTPUT',
+                                                            'value' => '1024'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'LYS_GROUPING',
+                                                            'value' => '2048'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'LYS_USES',
+                                                            'value' => '4096'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'LYS_AUGMENT',
+                                                            'value' => '8192'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'LYS_ACTION',
+                                                            'value' => '16384'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'LYS_ANYDATA',
+                                                            'value' => '32800'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'LYS_EXT',
+                                                            'value' => '65536'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'LYS_CHOICE',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'LYS_LEAF',
+                                                           'value' => '4'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'LYS_LEAFLIST',
+                                                           'value' => '8'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'LYS_LIST',
+                                                           'value' => '16'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'LYS_ANYXML',
+                                                           'value' => '32'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'LYS_CASE',
+                                                           'value' => '64'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'LYS_NOTIF',
+                                                           'value' => '128'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'LYS_RPC',
+                                                           'value' => '256'
+                                                         }
+                                                },
+                                      'Name' => 'enum lys_nodetype',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '169' => {
+                                     'BaseType' => '69',
+                                     'Header' => 'types.h',
+                                     'Line' => '41',
+                                     'Name' => '__uint32_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '4',
+                                     'Type' => 'Typedef'
+                                   },
+                          '17433' => {
+                                       'BaseType' => '3709',
+                                       'Name' => 'struct ly_ctx const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '1761' => {
+                                      'BaseType' => '1624',
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '248',
+                                      'Name' => 'LYS_NODE',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '180' => {
+                                     'BaseType' => '191',
+                                     'Header' => 'types.h',
+                                     'Line' => '43',
+                                     'Name' => '__int64_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '191' => {
+                                     'Name' => 'long',
+                                     'Size' => '8',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '198' => {
+                                     'BaseType' => '81',
+                                     'Header' => 'types.h',
+                                     'Line' => '44',
+                                     'Name' => '__uint64_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '19896' => {
+                                       'BaseType' => '1559',
+                                       'Name' => 'uint32_t*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '2207' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '367',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_STMT_NODE',
+                                                           'value' => '-1'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_STMT_UNKNOWN',
+                                                           'value' => '0'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'LY_STMT_KEY',
+                                                            'value' => '9'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'LY_STMT_NAMESPACE',
+                                                            'value' => '10'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'LY_STMT_ORGANIZATION',
+                                                            'value' => '11'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'LY_STMT_PATH',
+                                                            'value' => '12'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'LY_STMT_PREFIX',
+                                                            'value' => '13'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'LY_STMT_PRESENCE',
+                                                            'value' => '14'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'LY_STMT_REFERENCE',
+                                                            'value' => '15'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'LY_STMT_REVISIONDATE',
+                                                            'value' => '16'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'LY_STMT_UNITS',
+                                                            'value' => '17'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'LY_STMT_VALUE',
+                                                            'value' => '18'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'LY_STMT_ARGUMENT',
+                                                           'value' => '1'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'LY_STMT_VERSION',
+                                                            'value' => '19'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'LY_STMT_MODIFIER',
+                                                            'value' => '20'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'LY_STMT_REQINSTANCE',
+                                                            'value' => '21'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'LY_STMT_YINELEM',
+                                                            'value' => '22'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'LY_STMT_CONFIG',
+                                                            'value' => '23'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'LY_STMT_MANDATORY',
+                                                            'value' => '24'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'LY_STMT_ORDEREDBY',
+                                                            'value' => '25'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'LY_STMT_STATUS',
+                                                            'value' => '26'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'LY_STMT_DIGITS',
+                                                            'value' => '27'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'LY_STMT_MAX',
+                                                            'value' => '28'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'LY_STMT_BASE',
+                                                           'value' => '2'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'LY_STMT_MIN',
+                                                            'value' => '29'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'LY_STMT_POSITION',
+                                                            'value' => '30'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'LY_STMT_UNIQUE',
+                                                            'value' => '31'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'LY_STMT_MODULE',
+                                                            'value' => '32'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'LY_STMT_ACTION',
+                                                            'value' => '33'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'LY_STMT_ANYDATA',
+                                                            'value' => '34'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'LY_STMT_ANYXML',
+                                                            'value' => '35'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'LY_STMT_CASE',
+                                                            'value' => '36'
+                                                          },
+                                                  '38' => {
+                                                            'name' => 'LY_STMT_CHOICE',
+                                                            'value' => '37'
+                                                          },
+                                                  '39' => {
+                                                            'name' => 'LY_STMT_CONTAINER',
+                                                            'value' => '38'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'LY_STMT_BELONGSTO',
+                                                           'value' => '3'
+                                                         },
+                                                  '40' => {
+                                                            'name' => 'LY_STMT_GROUPING',
+                                                            'value' => '39'
+                                                          },
+                                                  '41' => {
+                                                            'name' => 'LY_STMT_INPUT',
+                                                            'value' => '40'
+                                                          },
+                                                  '42' => {
+                                                            'name' => 'LY_STMT_LEAF',
+                                                            'value' => '41'
+                                                          },
+                                                  '43' => {
+                                                            'name' => 'LY_STMT_LEAFLIST',
+                                                            'value' => '42'
+                                                          },
+                                                  '44' => {
+                                                            'name' => 'LY_STMT_LIST',
+                                                            'value' => '43'
+                                                          },
+                                                  '45' => {
+                                                            'name' => 'LY_STMT_NOTIFICATION',
+                                                            'value' => '44'
+                                                          },
+                                                  '46' => {
+                                                            'name' => 'LY_STMT_OUTPUT',
+                                                            'value' => '45'
+                                                          },
+                                                  '47' => {
+                                                            'name' => 'LY_STMT_USES',
+                                                            'value' => '46'
+                                                          },
+                                                  '48' => {
+                                                            'name' => 'LY_STMT_TYPEDEF',
+                                                            'value' => '47'
+                                                          },
+                                                  '49' => {
+                                                            'name' => 'LY_STMT_TYPE',
+                                                            'value' => '48'
+                                                          },
+                                                  '5' => {
+                                                           'name' => 'LY_STMT_CONTACT',
+                                                           'value' => '4'
+                                                         },
+                                                  '50' => {
+                                                            'name' => 'LY_STMT_IFFEATURE',
+                                                            'value' => '49'
+                                                          },
+                                                  '51' => {
+                                                            'name' => 'LY_STMT_LENGTH',
+                                                            'value' => '50'
+                                                          },
+                                                  '52' => {
+                                                            'name' => 'LY_STMT_MUST',
+                                                            'value' => '51'
+                                                          },
+                                                  '53' => {
+                                                            'name' => 'LY_STMT_PATTERN',
+                                                            'value' => '52'
+                                                          },
+                                                  '54' => {
+                                                            'name' => 'LY_STMT_RANGE',
+                                                            'value' => '53'
+                                                          },
+                                                  '55' => {
+                                                            'name' => 'LY_STMT_WHEN',
+                                                            'value' => '54'
+                                                          },
+                                                  '56' => {
+                                                            'name' => 'LY_STMT_REVISION',
+                                                            'value' => '55'
+                                                          },
+                                                  '57' => {
+                                                            'name' => 'LY_STMT_SUBMODULE',
+                                                            'value' => '56'
+                                                          },
+                                                  '58' => {
+                                                            'name' => 'LY_STMT_RPC',
+                                                            'value' => '57'
+                                                          },
+                                                  '59' => {
+                                                            'name' => 'LY_STMT_BIT',
+                                                            'value' => '58'
+                                                          },
+                                                  '6' => {
+                                                           'name' => 'LY_STMT_DEFAULT',
+                                                           'value' => '5'
+                                                         },
+                                                  '60' => {
+                                                            'name' => 'LY_STMT_ENUM',
+                                                            'value' => '59'
+                                                          },
+                                                  '61' => {
+                                                            'name' => 'LY_STMT_REFINE',
+                                                            'value' => '60'
+                                                          },
+                                                  '62' => {
+                                                            'name' => 'LY_STMT_AUGMENT',
+                                                            'value' => '61'
+                                                          },
+                                                  '63' => {
+                                                            'name' => 'LY_STMT_DEVIATE',
+                                                            'value' => '62'
+                                                          },
+                                                  '64' => {
+                                                            'name' => 'LY_STMT_DEVIATION',
+                                                            'value' => '63'
+                                                          },
+                                                  '65' => {
+                                                            'name' => 'LY_STMT_EXTENSION',
+                                                            'value' => '64'
+                                                          },
+                                                  '66' => {
+                                                            'name' => 'LY_STMT_FEATURE',
+                                                            'value' => '65'
+                                                          },
+                                                  '67' => {
+                                                            'name' => 'LY_STMT_IDENTITY',
+                                                            'value' => '66'
+                                                          },
+                                                  '68' => {
+                                                            'name' => 'LY_STMT_IMPORT',
+                                                            'value' => '67'
+                                                          },
+                                                  '69' => {
+                                                            'name' => 'LY_STMT_INCLUDE',
+                                                            'value' => '68'
+                                                          },
+                                                  '7' => {
+                                                           'name' => 'LY_STMT_DESCRIPTION',
+                                                           'value' => '6'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'LY_STMT_ERRTAG',
+                                                           'value' => '7'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'LY_STMT_ERRMSG',
+                                                           'value' => '8'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_STMT',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '2258' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '379',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_STMT_CARD_OPT',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_STMT_CARD_MAND',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LY_STMT_CARD_SOME',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'LY_STMT_CARD_ANY',
+                                                           'value' => '3'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_STMT_CARD',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '2303' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '394',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LYEXT_ERR',
+                                                           'value' => '-1'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LYEXT_FLAG',
+                                                           'value' => '0'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LYEXT_COMPLEX',
+                                                           'value' => '1'
+                                                         }
+                                                },
+                                      'Name' => 'enum LYEXT_TYPE',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '231' => {
+                                     'BaseType' => '1',
+                                     'Name' => 'void*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '2315' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '435',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'stmt',
+                                                           'offset' => '0',
+                                                           'type' => '2207'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'offset',
+                                                           'offset' => '8',
+                                                           'type' => '399'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'cardinality',
+                                                           'offset' => '16',
+                                                           'type' => '2258'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyext_substmt',
+                                      'PrivateABI' => 1,
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '2368' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '444',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '27',
+                                                           'type' => '2512'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'argument',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'module',
+                                                           'offset' => '48',
+                                                           'type' => '3269'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'plugin',
+                                                           'offset' => '56',
+                                                           'type' => '3360'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_ext',
+                                      'PrivateABI' => 1,
+                                      'Size' => '64',
+                                      'Type' => 'Struct'
+                                    },
+                          '238' => {
+                                     'BaseType' => '249',
+                                     'Name' => 'char*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '249' => {
+                                     'Name' => 'char',
+                                     'Size' => '1',
+                                     'Type' => 'Intrinsic'
+                                   },
+                          '2512' => {
+                                      'BaseType' => '1532',
+                                      'Name' => 'uint8_t[5]',
+                                      'Size' => '5',
+                                      'Type' => 'Array'
+                                    },
+                          '2528' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '464',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'def',
+                                                           'offset' => '0',
+                                                           'type' => '3366'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '8',
+                                                           'type' => '231'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'ext',
+                                                            'offset' => '32',
+                                                            'type' => '2724'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'priv',
+                                                            'offset' => '40',
+                                                            'type' => '231'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'module',
+                                                            'offset' => '48',
+                                                            'type' => '3269'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'nodetype',
+                                                            'offset' => '56',
+                                                            'type' => '1761'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'arg_value',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'insubstmt_index',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'insubstmt',
+                                                           'offset' => '28',
+                                                           'type' => '1532'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'parent_type',
+                                                           'offset' => '29',
+                                                           'type' => '1532'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ext_type',
+                                                           'offset' => '30',
+                                                           'type' => '1532'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '31',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_ext_instance',
+                                      'PrivateABI' => 1,
+                                      'Size' => '64',
+                                      'Type' => 'Struct'
+                                    },
+                          '256' => {
+                                     'BaseType' => '249',
+                                     'Name' => 'char const',
+                                     'Size' => '1',
+                                     'Type' => 'Const'
+                                   },
+                          '2724' => {
+                                      'BaseType' => '2730',
+                                      'Name' => 'struct lys_ext_instance**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2730' => {
+                                      'BaseType' => '2528',
+                                      'Name' => 'struct lys_ext_instance*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '2736' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '666',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'ctx',
+                                                           'offset' => '0',
+                                                           'type' => '3714'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'name',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'bitfield' => '2',
+                                                            'name' => 'deviated',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '11' => {
+                                                            'bitfield' => '1',
+                                                            'name' => 'disabled',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '12' => {
+                                                            'bitfield' => '1',
+                                                            'name' => 'implemented',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '13' => {
+                                                            'bitfield' => '1',
+                                                            'name' => 'latest_revision',
+                                                            'offset' => '65',
+                                                            'type' => '1532'
+                                                          },
+                                                  '14' => {
+                                                            'bitfield' => '7',
+                                                            'name' => 'padding1',
+                                                            'offset' => '65',
+                                                            'type' => '1532'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'padding2',
+                                                            'offset' => '66',
+                                                            'type' => '3720'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'rev_size',
+                                                            'offset' => '68',
+                                                            'type' => '1532'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'imp_size',
+                                                            'offset' => '69',
+                                                            'type' => '1532'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'inc_size',
+                                                            'offset' => '70',
+                                                            'type' => '1532'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'ident_size',
+                                                            'offset' => '72',
+                                                            'type' => '1548'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'prefix',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'tpdf_size',
+                                                            'offset' => '74',
+                                                            'type' => '1548'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'features_size',
+                                                            'offset' => '76',
+                                                            'type' => '1532'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'augment_size',
+                                                            'offset' => '77',
+                                                            'type' => '1532'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'deviation_size',
+                                                            'offset' => '78',
+                                                            'type' => '1532'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'extensions_size',
+                                                            'offset' => '79',
+                                                            'type' => '1532'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'ext_size',
+                                                            'offset' => '80',
+                                                            'type' => '1532'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'rev',
+                                                            'offset' => '88',
+                                                            'type' => '3815'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'imp',
+                                                            'offset' => '96',
+                                                            'type' => '3926'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'inc',
+                                                            'offset' => '104',
+                                                            'type' => '4024'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'tpdf',
+                                                            'offset' => '112',
+                                                            'type' => '4213'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'ident',
+                                                            'offset' => '120',
+                                                            'type' => '4402'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'features',
+                                                            'offset' => '128',
+                                                            'type' => '4565'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'augment',
+                                                            'offset' => '136',
+                                                            'type' => '4793'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'deviation',
+                                                            'offset' => '144',
+                                                            'type' => '4917'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'extensions',
+                                                            'offset' => '152',
+                                                            'type' => '3366'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'ext',
+                                                            'offset' => '160',
+                                                            'type' => '2724'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'data',
+                                                            'offset' => '168',
+                                                            'type' => '5163'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'ns',
+                                                            'offset' => '176',
+                                                            'type' => '361'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'org',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'contact',
+                                                           'offset' => '48',
+                                                           'type' => '361'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'filepath',
+                                                           'offset' => '56',
+                                                           'type' => '361'
+                                                         },
+                                                  '8' => {
+                                                           'bitfield' => '1',
+                                                           'name' => 'type',
+                                                           'offset' => '64',
+                                                           'type' => '1532'
+                                                         },
+                                                  '9' => {
+                                                           'bitfield' => '3',
+                                                           'name' => 'version',
+                                                           'offset' => '64',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_module',
+                                      'PrivateABI' => 1,
+                                      'Size' => '184',
+                                      'Type' => 'Struct'
+                                    },
+                          '29469' => {
+                                       'BaseType' => '9502',
+                                       'Name' => 'LY_ERR*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '3264' => {
+                                      'BaseType' => '2736',
+                                      'Name' => 'struct lys_module const',
+                                      'Size' => '184',
+                                      'Type' => 'Const'
+                                    },
+                          '3269' => {
+                                      'BaseType' => '2736',
+                                      'Name' => 'struct lys_module*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3275' => {
+                                      'Header' => 'extensions.h',
+                                      'Line' => '178',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '2303'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '4',
+                                                           'type' => '1548'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'check_position',
+                                                           'offset' => '8',
+                                                           'type' => '10584'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'check_result',
+                                                           'offset' => '16',
+                                                           'type' => '10626'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'check_inherit',
+                                                           'offset' => '24',
+                                                           'type' => '10658'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'valid_data',
+                                                           'offset' => '32',
+                                                           'type' => '10695'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyext_plugin',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '3360' => {
+                                      'BaseType' => '3275',
+                                      'Name' => 'struct lyext_plugin*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3366' => {
+                                      'BaseType' => '2368',
+                                      'Name' => 'struct lys_ext*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3372' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '498',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'def',
+                                                           'offset' => '0',
+                                                           'type' => '3366'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '8',
+                                                           'type' => '231'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'ext',
+                                                            'offset' => '32',
+                                                            'type' => '2724'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'priv',
+                                                            'offset' => '40',
+                                                            'type' => '231'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'module',
+                                                            'offset' => '48',
+                                                            'type' => '3269'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'nodetype',
+                                                            'offset' => '56',
+                                                            'type' => '1761'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'substmt',
+                                                            'offset' => '64',
+                                                            'type' => '3594'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'content',
+                                                            'offset' => '72',
+                                                            'type' => '1230'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'arg_value',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'insubstmt_index',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'insubstmt',
+                                                           'offset' => '28',
+                                                           'type' => '1532'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'parent_type',
+                                                           'offset' => '29',
+                                                           'type' => '1532'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ext_type',
+                                                           'offset' => '30',
+                                                           'type' => '1532'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '31',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_ext_instance_complex',
+                                      'PrivateABI' => 1,
+                                      'Size' => '80',
+                                      'Type' => 'Struct'
+                                    },
+                          '35671' => {
+                                       'BaseType' => '5169',
+                                       'Name' => 'struct lys_submodule const',
+                                       'Size' => '176',
+                                       'Type' => 'Const'
+                                     },
+                          '3594' => {
+                                      'BaseType' => '2315',
+                                      'Name' => 'struct lyext_substmt*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3600' => {
+                                      'Header' => 'context.h',
+                                      'Line' => '40',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'dict',
+                                                           'offset' => '0',
+                                                           'type' => '10185'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'models',
+                                                           'offset' => '48',
+                                                           'type' => '12757'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'imp_clb',
+                                                           'offset' => '96',
+                                                           'type' => '9188'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'imp_clb_data',
+                                                           'offset' => '104',
+                                                           'type' => '231'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'data_clb',
+                                                           'offset' => '112',
+                                                           'type' => '9285'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'data_clb_data',
+                                                           'offset' => '120',
+                                                           'type' => '231'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'errlist_key',
+                                                           'offset' => '128',
+                                                           'type' => '674'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'internal_module_count',
+                                                           'offset' => '132',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct ly_ctx',
+                                      'PrivateABI' => 1,
+                                      'Size' => '136',
+                                      'Type' => 'Struct'
+                                    },
+                          '361' => {
+                                     'BaseType' => '256',
+                                     'Name' => 'char const*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '367' => {
+                                     'BaseType' => '361',
+                                     'Name' => 'char const*const',
+                                     'Size' => '8',
+                                     'Type' => 'Const'
+                                   },
+                          '3709' => {
+                                      'BaseType' => '3600',
+                                      'Name' => 'struct ly_ctx const',
+                                      'Size' => '136',
+                                      'Type' => 'Const'
+                                    },
+                          '3714' => {
+                                      'BaseType' => '3600',
+                                      'Name' => 'struct ly_ctx*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3720' => {
+                                      'BaseType' => '1532',
+                                      'Name' => 'uint8_t[2]',
+                                      'Size' => '2',
+                                      'Type' => 'Array'
+                                    },
+                          '3736' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1984',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'date',
+                                                           'offset' => '0',
+                                                           'type' => '8211'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '11',
+                                                           'type' => '1532'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '16',
+                                                           'type' => '2724'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_revision',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '37910' => {
+                                       'Header' => 'tree_data.h',
+                                       'Line' => '45',
+                                       'Memb' => {
+                                                   '0' => {
+                                                            'name' => 'LYD_UNKNOWN',
+                                                            'value' => '0'
+                                                          },
+                                                   '1' => {
+                                                            'name' => 'LYD_XML',
+                                                            'value' => '1'
+                                                          },
+                                                   '2' => {
+                                                            'name' => 'LYD_JSON',
+                                                            'value' => '2'
+                                                          },
+                                                   '3' => {
+                                                            'name' => 'LYD_LYB',
+                                                            'value' => '3'
+                                                          }
+                                                 },
+                                       'Name' => 'enum LYD_FORMAT',
+                                       'PrivateABI' => 1,
+                                       'Size' => '4',
+                                       'Type' => 'Enum'
+                                     },
+                          '3815' => {
+                                      'BaseType' => '3736',
+                                      'Name' => 'struct lys_revision*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3821' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1959',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'module',
+                                                           'offset' => '0',
+                                                           'type' => '3269'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'prefix',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'rev',
+                                                           'offset' => '16',
+                                                           'type' => '8211'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '48',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_import',
+                                      'PrivateABI' => 1,
+                                      'Size' => '56',
+                                      'Type' => 'Struct'
+                                    },
+                          '3926' => {
+                                      'BaseType' => '3821',
+                                      'Name' => 'struct lys_import*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '3932' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1972',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'submodule',
+                                                           'offset' => '0',
+                                                           'type' => '8227'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'rev',
+                                                           'offset' => '8',
+                                                           'type' => '8211'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '19',
+                                                           'type' => '1532'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '24',
+                                                           'type' => '2724'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_include',
+                                      'PrivateABI' => 1,
+                                      'Size' => '48',
+                                      'Type' => 'Struct'
+                                    },
+                          '399' => {
+                                     'BaseType' => '81',
+                                     'Header' => 'stddef.h',
+                                     'Line' => '216',
+                                     'Name' => 'size_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '8',
+                                     'Type' => 'Typedef'
+                                   },
+                          '4024' => {
+                                      'BaseType' => '3932',
+                                      'Name' => 'struct lys_include*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4030' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1995',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'module',
+                                                            'offset' => '48',
+                                                            'type' => '3269'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'type',
+                                                            'offset' => '56',
+                                                            'type' => '7049'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'dflt',
+                                                            'offset' => '120',
+                                                            'type' => '361'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'padding_iffsize',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'has_union_leafref',
+                                                           'offset' => '28',
+                                                           'type' => '1532'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '29',
+                                                           'type' => '5653'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'units',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_tpdf',
+                                      'PrivateABI' => 1,
+                                      'Size' => '128',
+                                      'Type' => 'Struct'
+                                    },
+                          '4213' => {
+                                      'BaseType' => '4030',
+                                      'Name' => 'struct lys_tpdf*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4219' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '2080',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'module',
+                                                            'offset' => '48',
+                                                            'type' => '3269'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'base',
+                                                            'offset' => '56',
+                                                            'type' => '6492'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'der',
+                                                            'offset' => '64',
+                                                            'type' => '7473'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '28',
+                                                           'type' => '5653'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'base_size',
+                                                           'offset' => '31',
+                                                           'type' => '1532'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_ident',
+                                      'PrivateABI' => 1,
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '4402' => {
+                                      'BaseType' => '4219',
+                                      'Name' => 'struct lys_ident*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4408' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '2029',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'depfeatures',
+                                                            'offset' => '56',
+                                                            'type' => '7473'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '28',
+                                                           'type' => '7306'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'module',
+                                                           'offset' => '48',
+                                                           'type' => '3269'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_feature',
+                                      'PrivateABI' => 1,
+                                      'Size' => '64',
+                                      'Type' => 'Struct'
+                                    },
+                          '45' => {
+                                    'Name' => 'unsigned char',
+                                    'Size' => '1',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '4565' => {
+                                      'BaseType' => '4408',
+                                      'Name' => 'struct lys_feature*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4571' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1823',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'target_name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'nodetype',
+                                                            'offset' => '56',
+                                                            'type' => '1761'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'parent',
+                                                            'offset' => '64',
+                                                            'type' => '5163'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'child',
+                                                            'offset' => '72',
+                                                            'type' => '5163'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'when',
+                                                            'offset' => '80',
+                                                            'type' => '7414'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'target',
+                                                            'offset' => '88',
+                                                            'type' => '5163'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'priv',
+                                                            'offset' => '96',
+                                                            'type' => '231'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '28',
+                                                           'type' => '7306'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'module',
+                                                           'offset' => '48',
+                                                           'type' => '3269'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_node_augment',
+                                      'PrivateABI' => 1,
+                                      'Size' => '104',
+                                      'Type' => 'Struct'
+                                    },
+                          '46017' => {
+                                       'Name' => 'void(*)(struct lys_node const*, void*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '13900'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '231'
+                                                           }
+                                                  },
+                                       'Return' => '1',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '4793' => {
+                                      'BaseType' => '4571',
+                                      'Name' => 'struct lys_node_augment*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4799' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1943',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'target_name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'orig_node',
+                                                           'offset' => '24',
+                                                           'type' => '5163'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'deviate_size',
+                                                           'offset' => '32',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '33',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'deviate',
+                                                           'offset' => '40',
+                                                           'type' => '8205'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '48',
+                                                           'type' => '2724'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_deviation',
+                                      'PrivateABI' => 1,
+                                      'Size' => '56',
+                                      'Type' => 'Struct'
+                                    },
+                          '4917' => {
+                                      'BaseType' => '4799',
+                                      'Name' => 'struct lys_deviation*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '4923' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1209',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'nodetype',
+                                                            'offset' => '56',
+                                                            'type' => '1761'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'parent',
+                                                            'offset' => '64',
+                                                            'type' => '5163'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'child',
+                                                            'offset' => '72',
+                                                            'type' => '5163'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'next',
+                                                            'offset' => '80',
+                                                            'type' => '5163'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'prev',
+                                                            'offset' => '88',
+                                                            'type' => '5163'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'priv',
+                                                            'offset' => '96',
+                                                            'type' => '231'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'hash',
+                                                            'offset' => '104',
+                                                            'type' => '7306'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '28',
+                                                           'type' => '7306'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'module',
+                                                           'offset' => '48',
+                                                           'type' => '3269'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_node',
+                                      'PrivateABI' => 1,
+                                      'Size' => '112',
+                                      'Type' => 'Struct'
+                                    },
+                          '504' => {
+                                     'Header' => 'thread-shared-types.h',
+                                     'Line' => '82',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '__prev',
+                                                          'offset' => '0',
+                                                          'type' => '541'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '__next',
+                                                          'offset' => '8',
+                                                          'type' => '541'
+                                                        }
+                                               },
+                                     'Name' => 'struct __pthread_internal_list',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Struct'
+                                   },
+                          '5158' => {
+                                      'BaseType' => '4923',
+                                      'Name' => 'struct lys_node const',
+                                      'Size' => '112',
+                                      'Type' => 'Const'
+                                    },
+                          '5163' => {
+                                      'BaseType' => '4923',
+                                      'Name' => 'struct lys_node*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '5169' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '729',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'ctx',
+                                                           'offset' => '0',
+                                                           'type' => '3714'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'name',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'bitfield' => '2',
+                                                            'name' => 'deviated',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '11' => {
+                                                            'bitfield' => '1',
+                                                            'name' => 'disabled',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '12' => {
+                                                            'bitfield' => '1',
+                                                            'name' => 'implemented',
+                                                            'offset' => '64',
+                                                            'type' => '1532'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'padding',
+                                                            'offset' => '65',
+                                                            'type' => '5653'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'rev_size',
+                                                            'offset' => '68',
+                                                            'type' => '1532'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'imp_size',
+                                                            'offset' => '69',
+                                                            'type' => '1532'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'inc_size',
+                                                            'offset' => '70',
+                                                            'type' => '1532'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'ident_size',
+                                                            'offset' => '72',
+                                                            'type' => '1548'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'tpdf_size',
+                                                            'offset' => '74',
+                                                            'type' => '1548'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'features_size',
+                                                            'offset' => '76',
+                                                            'type' => '1532'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'prefix',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'augment_size',
+                                                            'offset' => '77',
+                                                            'type' => '1532'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'deviation_size',
+                                                            'offset' => '78',
+                                                            'type' => '1532'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'extensions_size',
+                                                            'offset' => '79',
+                                                            'type' => '1532'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'ext_size',
+                                                            'offset' => '80',
+                                                            'type' => '1532'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'rev',
+                                                            'offset' => '88',
+                                                            'type' => '3815'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'imp',
+                                                            'offset' => '96',
+                                                            'type' => '3926'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'inc',
+                                                            'offset' => '104',
+                                                            'type' => '4024'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'tpdf',
+                                                            'offset' => '112',
+                                                            'type' => '4213'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'ident',
+                                                            'offset' => '120',
+                                                            'type' => '4402'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'features',
+                                                            'offset' => '128',
+                                                            'type' => '4565'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'augment',
+                                                            'offset' => '136',
+                                                            'type' => '4793'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'deviation',
+                                                            'offset' => '144',
+                                                            'type' => '4917'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'extensions',
+                                                            'offset' => '152',
+                                                            'type' => '3366'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'ext',
+                                                            'offset' => '160',
+                                                            'type' => '2724'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'belongsto',
+                                                            'offset' => '168',
+                                                            'type' => '3269'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'org',
+                                                           'offset' => '40',
+                                                           'type' => '361'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'contact',
+                                                           'offset' => '48',
+                                                           'type' => '361'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'filepath',
+                                                           'offset' => '56',
+                                                           'type' => '361'
+                                                         },
+                                                  '8' => {
+                                                           'bitfield' => '1',
+                                                           'name' => 'type',
+                                                           'offset' => '64',
+                                                           'type' => '1532'
+                                                         },
+                                                  '9' => {
+                                                           'bitfield' => '3',
+                                                           'name' => 'version',
+                                                           'offset' => '64',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_submodule',
+                                      'PrivateABI' => 1,
+                                      'Size' => '176',
+                                      'Type' => 'Struct'
+                                    },
+                          '53655' => {
+                                       'BaseType' => '35671',
+                                       'Name' => 'struct lys_submodule const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '541' => {
+                                     'BaseType' => '504',
+                                     'Name' => 'struct __pthread_internal_list*',
+                                     'Size' => '8',
+                                     'Type' => 'Pointer'
+                                   },
+                          '54626' => {
+                                       'BaseType' => '367',
+                                       'Name' => 'char const*const*',
+                                       'Size' => '8',
+                                       'Type' => 'Pointer'
+                                     },
+                          '547' => {
+                                     'BaseType' => '504',
+                                     'Header' => 'thread-shared-types.h',
+                                     'Line' => '86',
+                                     'Name' => '__pthread_list_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '16',
+                                     'Type' => 'Typedef'
+                                   },
+                          '558' => {
+                                     'Header' => 'thread-shared-types.h',
+                                     'Line' => '118',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '__lock',
+                                                          'offset' => '0',
+                                                          'type' => '157'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '__count',
+                                                          'offset' => '4',
+                                                          'type' => '69'
+                                                        },
+                                                 '2' => {
+                                                          'name' => '__owner',
+                                                          'offset' => '8',
+                                                          'type' => '157'
+                                                        },
+                                                 '3' => {
+                                                          'name' => '__nusers',
+                                                          'offset' => '12',
+                                                          'type' => '69'
+                                                        },
+                                                 '4' => {
+                                                          'name' => '__kind',
+                                                          'offset' => '16',
+                                                          'type' => '157'
+                                                        },
+                                                 '5' => {
+                                                          'name' => '__spins',
+                                                          'offset' => '20',
+                                                          'type' => '128'
+                                                        },
+                                                 '6' => {
+                                                          'name' => '__elision',
+                                                          'offset' => '22',
+                                                          'type' => '128'
+                                                        },
+                                                 '7' => {
+                                                          'name' => '__list',
+                                                          'offset' => '24',
+                                                          'type' => '547'
+                                                        }
+                                               },
+                                     'Name' => 'struct __pthread_mutex_s',
+                                     'PrivateABI' => 1,
+                                     'Size' => '40',
+                                     'Type' => 'Struct'
+                                   },
+                          '5653' => {
+                                      'BaseType' => '1532',
+                                      'Name' => 'uint8_t[3]',
+                                      'Size' => '3',
+                                      'Type' => 'Array'
+                                    },
+                          '57' => {
+                                    'Name' => 'unsigned short',
+                                    'Size' => '2',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '5810' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '806',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_TYPE_DER',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_TYPE_BINARY',
+                                                           'value' => '1'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'LY_TYPE_STRING',
+                                                            'value' => '10'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'LY_TYPE_UNION',
+                                                            'value' => '11'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'LY_TYPE_INT8',
+                                                            'value' => '12'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'LY_TYPE_UINT8',
+                                                            'value' => '13'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'LY_TYPE_INT16',
+                                                            'value' => '14'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'LY_TYPE_UINT16',
+                                                            'value' => '15'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'LY_TYPE_INT32',
+                                                            'value' => '16'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'LY_TYPE_UINT32',
+                                                            'value' => '17'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'LY_TYPE_INT64',
+                                                            'value' => '18'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'LY_TYPE_UINT64',
+                                                            'value' => '19'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'LY_TYPE_BITS',
+                                                           'value' => '2'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'LY_TYPE_UNKNOWN',
+                                                            'value' => '20'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'LY_TYPE_BOOL',
+                                                           'value' => '3'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'LY_TYPE_DEC64',
+                                                           'value' => '4'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'LY_TYPE_EMPTY',
+                                                           'value' => '5'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'LY_TYPE_ENUM',
+                                                           'value' => '6'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'LY_TYPE_IDENT',
+                                                           'value' => '7'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'LY_TYPE_INST',
+                                                           'value' => '8'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'LY_TYPE_LEAFREF',
+                                                           'value' => '9'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_DATA_TYPE',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '5822' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '812',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'length',
+                                                           'offset' => '0',
+                                                           'type' => '5967'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_binary',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '5849' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '2050',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'expr',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'eapptag',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'emsg',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '40',
+                                                           'type' => '2724'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '48',
+                                                           'type' => '1532'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '50',
+                                                           'type' => '1548'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_restr',
+                                      'PrivateABI' => 1,
+                                      'Size' => '56',
+                                      'Type' => 'Struct'
+                                    },
+                          '5967' => {
+                                      'BaseType' => '5849',
+                                      'Name' => 'struct lys_restr*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '5973' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '820',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'pos',
+                                                           'offset' => '28',
+                                                           'type' => '1559'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_bit',
+                                      'PrivateABI' => 1,
+                                      'Size' => '48',
+                                      'Type' => 'Struct'
+                                    },
+                          '6104' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1070',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'expr',
+                                                           'offset' => '0',
+                                                           'type' => '7294'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '8',
+                                                           'type' => '1532'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'features',
+                                                           'offset' => '16',
+                                                           'type' => '7300'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '24',
+                                                           'type' => '2724'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_iffeature',
+                                      'PrivateABI' => 1,
+                                      'Size' => '32',
+                                      'Type' => 'Struct'
+                                    },
+                          '6170' => {
+                                      'BaseType' => '6104',
+                                      'Name' => 'struct lys_iffeature*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6176' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '839',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'bit',
+                                                           'offset' => '0',
+                                                           'type' => '6216'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'count',
+                                                           'offset' => '8',
+                                                           'type' => '69'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_bits',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '6216' => {
+                                      'BaseType' => '5973',
+                                      'Name' => 'struct lys_type_bit*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6222' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '847',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'range',
+                                                           'offset' => '0',
+                                                           'type' => '5967'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dig',
+                                                           'offset' => '8',
+                                                           'type' => '1532'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'div',
+                                                           'offset' => '16',
+                                                           'type' => '1570'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_dec64',
+                                      'PrivateABI' => 1,
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '6275' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '860',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'value',
+                                                           'offset' => '28',
+                                                           'type' => '1424'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_enum',
+                                      'PrivateABI' => 1,
+                                      'Size' => '48',
+                                      'Type' => 'Struct'
+                                    },
+                          '6406' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '879',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'enm',
+                                                           'offset' => '0',
+                                                           'type' => '6446'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'count',
+                                                           'offset' => '8',
+                                                           'type' => '69'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_enums',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '6446' => {
+                                      'BaseType' => '6275',
+                                      'Name' => 'struct lys_type_enum*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6452' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '887',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '0',
+                                                           'type' => '6492'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'count',
+                                                           'offset' => '8',
+                                                           'type' => '69'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_ident',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '6492' => {
+                                      'BaseType' => '4402',
+                                      'Name' => 'struct lys_ident**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6498' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '895',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'req',
+                                                           'offset' => '0',
+                                                           'type' => '1402'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_inst',
+                                      'PrivateABI' => 1,
+                                      'Size' => '1',
+                                      'Type' => 'Struct'
+                                    },
+                          '6525' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '906',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'range',
+                                                           'offset' => '0',
+                                                           'type' => '5967'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_num',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Struct'
+                                    },
+                          '6552' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '914',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'path',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'target',
+                                                           'offset' => '8',
+                                                           'type' => '6918'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'req',
+                                                           'offset' => '16',
+                                                           'type' => '1402'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_lref',
+                                      'PrivateABI' => 1,
+                                      'Size' => '24',
+                                      'Type' => 'Struct'
+                                    },
+                          '6605' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1345',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'name',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'module',
+                                                            'offset' => '48',
+                                                            'type' => '3269'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'nodetype',
+                                                            'offset' => '56',
+                                                            'type' => '1761'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'parent',
+                                                            'offset' => '64',
+                                                            'type' => '5163'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'child',
+                                                            'offset' => '72',
+                                                            'type' => '231'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'next',
+                                                            'offset' => '80',
+                                                            'type' => '5163'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'prev',
+                                                            'offset' => '88',
+                                                            'type' => '5163'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'priv',
+                                                            'offset' => '96',
+                                                            'type' => '231'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'hash',
+                                                            'offset' => '104',
+                                                            'type' => '7306'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'when',
+                                                            'offset' => '112',
+                                                            'type' => '7414'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'must',
+                                                            'offset' => '120',
+                                                            'type' => '5967'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'type',
+                                                            'offset' => '128',
+                                                            'type' => '7049'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'units',
+                                                            'offset' => '192',
+                                                            'type' => '361'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'dflt',
+                                                            'offset' => '200',
+                                                            'type' => '361'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '26',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'iffeature_size',
+                                                           'offset' => '27',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'padding',
+                                                           'offset' => '28',
+                                                           'type' => '5653'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'must_size',
+                                                           'offset' => '31',
+                                                           'type' => '1532'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '32',
+                                                           'type' => '2724'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'iffeature',
+                                                           'offset' => '40',
+                                                           'type' => '6170'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_node_leaf',
+                                      'PrivateABI' => 1,
+                                      'Size' => '208',
+                                      'Type' => 'Struct'
+                                    },
+                          '674' => {
+                                     'BaseType' => '69',
+                                     'Header' => 'pthreadtypes.h',
+                                     'Line' => '49',
+                                     'Name' => 'pthread_key_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '4',
+                                     'Type' => 'Typedef'
+                                   },
+                          '69' => {
+                                    'Name' => 'unsigned int',
+                                    'Size' => '4',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '6918' => {
+                                      'BaseType' => '6605',
+                                      'Name' => 'struct lys_node_leaf*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6924' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '927',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'length',
+                                                           'offset' => '0',
+                                                           'type' => '5967'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'patterns',
+                                                           'offset' => '8',
+                                                           'type' => '5967'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'pat_count',
+                                                           'offset' => '16',
+                                                           'type' => '69'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'patterns_pcre',
+                                                           'offset' => '24',
+                                                           'type' => '6990'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_str',
+                                      'PrivateABI' => 1,
+                                      'Size' => '32',
+                                      'Type' => 'Struct'
+                                    },
+                          '694211' => {
+                                        'BaseType' => '7420',
+                                        'Name' => 'struct ly_set const',
+                                        'Size' => '16',
+                                        'Type' => 'Const'
+                                      },
+                          '6990' => {
+                                      'BaseType' => '231',
+                                      'Name' => 'void**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '6996' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '947',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'types',
+                                                           'offset' => '0',
+                                                           'type' => '7154'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'count',
+                                                           'offset' => '8',
+                                                           'type' => '69'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'has_ptr_type',
+                                                           'offset' => '12',
+                                                           'type' => '157'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type_info_union',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '7049' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '973',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'base',
+                                                           'offset' => '0',
+                                                           'type' => '5810'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'value_flags',
+                                                           'offset' => '4',
+                                                           'type' => '1532'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '5',
+                                                           'type' => '1532'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '8',
+                                                           'type' => '2724'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'der',
+                                                           'offset' => '16',
+                                                           'type' => '4213'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '24',
+                                                           'type' => '4213'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'info',
+                                                           'offset' => '32',
+                                                           'type' => '7160'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_type',
+                                      'PrivateABI' => 1,
+                                      'Size' => '64',
+                                      'Type' => 'Struct'
+                                    },
+                          '709540' => {
+                                        'BaseType' => '694211',
+                                        'Name' => 'struct ly_set const*',
+                                        'Size' => '8',
+                                        'Type' => 'Pointer'
+                                      },
+                          '7154' => {
+                                      'BaseType' => '7049',
+                                      'Name' => 'struct lys_type*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7160' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '957',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'binary',
+                                                           'offset' => '0',
+                                                           'type' => '5822'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'bits',
+                                                           'offset' => '0',
+                                                           'type' => '6176'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'dec64',
+                                                           'offset' => '0',
+                                                           'type' => '6222'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'enums',
+                                                           'offset' => '0',
+                                                           'type' => '6406'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ident',
+                                                           'offset' => '0',
+                                                           'type' => '6452'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'inst',
+                                                           'offset' => '0',
+                                                           'type' => '6498'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'num',
+                                                           'offset' => '0',
+                                                           'type' => '6525'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'lref',
+                                                           'offset' => '0',
+                                                           'type' => '6552'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'str',
+                                                           'offset' => '0',
+                                                           'type' => '6924'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'uni',
+                                                           'offset' => '0',
+                                                           'type' => '6996'
+                                                         }
+                                                },
+                                      'Name' => 'union lys_type_info',
+                                      'PrivateABI' => 1,
+                                      'Size' => '32',
+                                      'Type' => 'Union'
+                                    },
+                          '727' => {
+                                     'BaseType' => '249',
+                                     'Name' => 'char[40]',
+                                     'Size' => '40',
+                                     'Type' => 'Array'
+                                   },
+                          '7294' => {
+                                      'BaseType' => '1532',
+                                      'Name' => 'uint8_t*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7300' => {
+                                      'BaseType' => '4565',
+                                      'Name' => 'struct lys_feature**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7306' => {
+                                      'BaseType' => '1532',
+                                      'Name' => 'uint8_t[4]',
+                                      'Size' => '4',
+                                      'Type' => 'Array'
+                                    },
+                          '7322' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '2066',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'cond',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'dsc',
+                                                           'offset' => '8',
+                                                           'type' => '361'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ref',
+                                                           'offset' => '16',
+                                                           'type' => '361'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext',
+                                                           'offset' => '24',
+                                                           'type' => '2724'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '32',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '34',
+                                                           'type' => '1548'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_when',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '73467' => {
+                                       'Name' => 'void(*)(LY_LOG_LEVEL, char const*, char const*)',
+                                       'Param' => {
+                                                    '0' => {
+                                                             'type' => '9433'
+                                                           },
+                                                    '1' => {
+                                                             'type' => '361'
+                                                           },
+                                                    '2' => {
+                                                             'type' => '361'
+                                                           }
+                                                  },
+                                       'Return' => '1',
+                                       'Size' => '8',
+                                       'Type' => 'FuncPtr'
+                                     },
+                          '7414' => {
+                                      'BaseType' => '7322',
+                                      'Name' => 'struct lys_when*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7420' => {
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1708',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'size',
+                                                           'offset' => '0',
+                                                           'type' => '69'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'number',
+                                                           'offset' => '4',
+                                                           'type' => '69'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'set',
+                                                           'offset' => '8',
+                                                           'type' => '9344'
+                                                         }
+                                                },
+                                      'Name' => 'struct ly_set',
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '743' => {
+                                     'Header' => 'pthreadtypes.h',
+                                     'Line' => '72',
+                                     'Memb' => {
+                                                 '0' => {
+                                                          'name' => '__data',
+                                                          'offset' => '0',
+                                                          'type' => '558'
+                                                        },
+                                                 '1' => {
+                                                          'name' => '__size',
+                                                          'offset' => '0',
+                                                          'type' => '727'
+                                                        },
+                                                 '2' => {
+                                                          'name' => '__align',
+                                                          'offset' => '0',
+                                                          'type' => '191'
+                                                        }
+                                               },
+                                     'Name' => 'union pthread_mutex_t',
+                                     'PrivateABI' => 1,
+                                     'Size' => '40',
+                                     'Type' => 'Union'
+                                   },
+                          '7473' => {
+                                      'BaseType' => '7420',
+                                      'Name' => 'struct ly_set*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7479' => {
+                                      'BaseType' => '361',
+                                      'Name' => 'char const**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7869' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '2020',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'expr',
+                                                           'offset' => '0',
+                                                           'type' => '7479'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'expr_size',
+                                                           'offset' => '8',
+                                                           'type' => '1532'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'trg_type',
+                                                           'offset' => '9',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_unique',
+                                      'PrivateABI' => 1,
+                                      'Size' => '16',
+                                      'Type' => 'Struct'
+                                    },
+                          '7922' => {
+                                      'BaseType' => '7869',
+                                      'Name' => 'struct lys_unique*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '7928' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1906',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_DEVIATE_NO',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_DEVIATE_ADD',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LY_DEVIATE_RPL',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'LY_DEVIATE_DEL',
+                                                           'value' => '3'
+                                                         }
+                                                },
+                                      'Name' => 'enum lys_deviate_type',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '7971' => {
+                                      'BaseType' => '7928',
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1911',
+                                      'Name' => 'LYS_DEVIATE_TYPE',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '7983' => {
+                                      'Header' => 'tree_schema.h',
+                                      'Line' => '1916',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'mod',
+                                                           'offset' => '0',
+                                                           'type' => '7971'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '4',
+                                                           'type' => '1532'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'must',
+                                                            'offset' => '24',
+                                                            'type' => '5967'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'unique',
+                                                            'offset' => '32',
+                                                            'type' => '7922'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'type',
+                                                            'offset' => '40',
+                                                            'type' => '7154'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'units',
+                                                            'offset' => '48',
+                                                            'type' => '361'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'dflt',
+                                                            'offset' => '56',
+                                                            'type' => '7479'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'ext',
+                                                            'offset' => '64',
+                                                            'type' => '2724'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'dflt_size',
+                                                           'offset' => '5',
+                                                           'type' => '1532'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'ext_size',
+                                                           'offset' => '6',
+                                                           'type' => '1532'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'min_set',
+                                                           'offset' => '7',
+                                                           'type' => '1532'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'max_set',
+                                                           'offset' => '8',
+                                                           'type' => '1532'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'must_size',
+                                                           'offset' => '9',
+                                                           'type' => '1532'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'unique_size',
+                                                           'offset' => '10',
+                                                           'type' => '1532'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'min',
+                                                           'offset' => '12',
+                                                           'type' => '1559'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'max',
+                                                           'offset' => '16',
+                                                           'type' => '1559'
+                                                         }
+                                                },
+                                      'Name' => 'struct lys_deviate',
+                                      'PrivateABI' => 1,
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '81' => {
+                                    'Name' => 'unsigned long',
+                                    'Size' => '8',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '8205' => {
+                                      'BaseType' => '7983',
+                                      'Name' => 'struct lys_deviate*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8211' => {
+                                      'BaseType' => '249',
+                                      'Name' => 'char[11]',
+                                      'Size' => '11',
+                                      'Type' => 'Array'
+                                    },
+                          '8227' => {
+                                      'BaseType' => '5169',
+                                      'Name' => 'struct lys_submodule*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8233' => {
+                                      'Header' => 'xml.h',
+                                      'Line' => '45',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LYXML_ATTR_STD',
+                                                           'value' => '1'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LYXML_ATTR_NS',
+                                                           'value' => '2'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LYXML_ATTR_STD_UNRES',
+                                                           'value' => '3'
+                                                         }
+                                                },
+                                      'Name' => 'enum lyxml_attr_type',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '8269' => {
+                                      'BaseType' => '8233',
+                                      'Header' => 'xml.h',
+                                      'Line' => '49',
+                                      'Name' => 'LYXML_ATTR_TYPE',
+                                      'PrivateABI' => 1,
+                                      'Size' => '4',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8280' => {
+                                      'Header' => 'xml.h',
+                                      'Line' => '58',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '8269'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'next',
+                                                           'offset' => '8',
+                                                           'type' => '8358'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '16',
+                                                           'type' => '8484'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'prefix',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'value',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyxml_ns',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '8353' => {
+                                      'BaseType' => '8280',
+                                      'Name' => 'struct lyxml_ns const',
+                                      'Size' => '40',
+                                      'Type' => 'Const'
+                                    },
+                          '8358' => {
+                                      'BaseType' => '8280',
+                                      'Name' => 'struct lyxml_ns*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8364' => {
+                                      'Header' => 'xml.h',
+                                      'Line' => '92',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'flags',
+                                                           'offset' => '0',
+                                                           'type' => '249'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '8',
+                                                           'type' => '8484'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'attr',
+                                                           'offset' => '16',
+                                                           'type' => '8562'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'child',
+                                                           'offset' => '24',
+                                                           'type' => '8484'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'next',
+                                                           'offset' => '32',
+                                                           'type' => '8484'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'prev',
+                                                           'offset' => '40',
+                                                           'type' => '8484'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'name',
+                                                           'offset' => '48',
+                                                           'type' => '361'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'ns',
+                                                           'offset' => '56',
+                                                           'type' => '8568'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'content',
+                                                           'offset' => '64',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyxml_elem',
+                                      'PrivateABI' => 1,
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '8484' => {
+                                      'BaseType' => '8364',
+                                      'Name' => 'struct lyxml_elem*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8490' => {
+                                      'Header' => 'xml.h',
+                                      'Line' => '75',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'type',
+                                                           'offset' => '0',
+                                                           'type' => '8269'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'next',
+                                                           'offset' => '8',
+                                                           'type' => '8562'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'ns',
+                                                           'offset' => '16',
+                                                           'type' => '8568'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'name',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'value',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyxml_attr',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '8562' => {
+                                      'BaseType' => '8490',
+                                      'Name' => 'struct lyxml_attr*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8568' => {
+                                      'BaseType' => '8353',
+                                      'Name' => 'struct lyxml_ns const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8574' => {
+                                      'Header' => 'tree_data.h',
+                                      'Line' => '94',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'binary',
+                                                           'offset' => '0',
+                                                           'type' => '361'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'bit',
+                                                           'offset' => '0',
+                                                           'type' => '8785'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'int64',
+                                                            'offset' => '0',
+                                                            'type' => '1435'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'leafref',
+                                                            'offset' => '0',
+                                                            'type' => '8941'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'string',
+                                                            'offset' => '0',
+                                                            'type' => '361'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'uint8',
+                                                            'offset' => '0',
+                                                            'type' => '1532'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'uint16',
+                                                            'offset' => '0',
+                                                            'type' => '1548'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'uint32',
+                                                            'offset' => '0',
+                                                            'type' => '1559'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'uint64',
+                                                            'offset' => '0',
+                                                            'type' => '1570'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'ptr',
+                                                            'offset' => '0',
+                                                            'type' => '231'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'bln',
+                                                           'offset' => '0',
+                                                           'type' => '1402'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'dec64',
+                                                           'offset' => '0',
+                                                           'type' => '1435'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'enm',
+                                                           'offset' => '0',
+                                                           'type' => '6446'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'ident',
+                                                           'offset' => '0',
+                                                           'type' => '4402'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'instance',
+                                                           'offset' => '0',
+                                                           'type' => '8941'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'int8',
+                                                           'offset' => '0',
+                                                           'type' => '1402'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'int16',
+                                                           'offset' => '0',
+                                                           'type' => '1413'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'int32',
+                                                           'offset' => '0',
+                                                           'type' => '1424'
+                                                         }
+                                                },
+                                      'Name' => 'union lyd_value_u',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Union'
+                                    },
+                          '8785' => {
+                                      'BaseType' => '6216',
+                                      'Name' => 'struct lys_type_bit**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8791' => {
+                                      'Header' => 'tree_data.h',
+                                      'Line' => '176',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'schema',
+                                                           'offset' => '0',
+                                                           'type' => '5163'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'validity',
+                                                           'offset' => '8',
+                                                           'type' => '1532'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'child',
+                                                            'offset' => '64',
+                                                            'type' => '8941'
+                                                          },
+                                                  '2' => {
+                                                           'bitfield' => '1',
+                                                           'name' => 'dflt',
+                                                           'offset' => '9',
+                                                           'type' => '1532'
+                                                         },
+                                                  '3' => {
+                                                           'bitfield' => '3',
+                                                           'name' => 'when_status',
+                                                           'offset' => '9',
+                                                           'type' => '1532'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'attr',
+                                                           'offset' => '16',
+                                                           'type' => '9067'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'next',
+                                                           'offset' => '24',
+                                                           'type' => '8941'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'prev',
+                                                           'offset' => '32',
+                                                           'type' => '8941'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '40',
+                                                           'type' => '8941'
+                                                         },
+                                                  '8' => {
+                                                           'name' => 'hash',
+                                                           'offset' => '48',
+                                                           'type' => '1559'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'ht',
+                                                           'offset' => '56',
+                                                           'type' => '9176'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyd_node',
+                                      'PrivateABI' => 1,
+                                      'Size' => '72',
+                                      'Type' => 'Struct'
+                                    },
+                          '88' => {
+                                    'BaseType' => '99',
+                                    'Header' => 'types.h',
+                                    'Line' => '36',
+                                    'Name' => '__int8_t',
+                                    'PrivateABI' => 1,
+                                    'Size' => '1',
+                                    'Type' => 'Typedef'
+                                  },
+                          '8941' => {
+                                      'BaseType' => '8791',
+                                      'Name' => 'struct lyd_node*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '8947' => {
+                                      'BaseType' => '8574',
+                                      'Header' => 'tree_data.h',
+                                      'Line' => '116',
+                                      'Name' => 'lyd_val',
+                                      'PrivateABI' => 1,
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '8958' => {
+                                      'Header' => 'tree_data.h',
+                                      'Line' => '128',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'parent',
+                                                           'offset' => '0',
+                                                           'type' => '8941'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'next',
+                                                           'offset' => '8',
+                                                           'type' => '9067'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'annotation',
+                                                           'offset' => '16',
+                                                           'type' => '9073'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'name',
+                                                           'offset' => '24',
+                                                           'type' => '361'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'value_str',
+                                                           'offset' => '32',
+                                                           'type' => '361'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'value',
+                                                           'offset' => '40',
+                                                           'type' => '8947'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'value_type',
+                                                           'offset' => '48',
+                                                           'type' => '5810'
+                                                         },
+                                                  '7' => {
+                                                           'name' => 'value_flags',
+                                                           'offset' => '52',
+                                                           'type' => '1532'
+                                                         }
+                                                },
+                                      'Name' => 'struct lyd_attr',
+                                      'PrivateABI' => 1,
+                                      'Size' => '56',
+                                      'Type' => 'Struct'
+                                    },
+                          '9067' => {
+                                      'BaseType' => '8958',
+                                      'Name' => 'struct lyd_attr*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9073' => {
+                                      'BaseType' => '3372',
+                                      'Name' => 'struct lys_ext_instance_complex*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9079' => {
+                                      'Header' => 'hash_table.h',
+                                      'Line' => '75',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'used',
+                                                           'offset' => '0',
+                                                           'type' => '1559'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'size',
+                                                           'offset' => '4',
+                                                           'type' => '1559'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'val_equal',
+                                                           'offset' => '8',
+                                                           'type' => '10132'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'cb_data',
+                                                           'offset' => '16',
+                                                           'type' => '231'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'resize',
+                                                           'offset' => '24',
+                                                           'type' => '1548'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'rec_size',
+                                                           'offset' => '26',
+                                                           'type' => '1548'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'recs',
+                                                           'offset' => '32',
+                                                           'type' => '10179'
+                                                         }
+                                                },
+                                      'Name' => 'struct hash_table',
+                                      'PrivateABI' => 1,
+                                      'Size' => '40',
+                                      'Type' => 'Struct'
+                                    },
+                          '9176' => {
+                                      'BaseType' => '9079',
+                                      'Name' => 'struct hash_table*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9182' => {
+                                      'BaseType' => '8941',
+                                      'Name' => 'struct lyd_node**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9188' => {
+                                      'BaseType' => '9200',
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1469',
+                                      'Name' => 'ly_module_imp_clb',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9200' => {
+                                      'Name' => 'char const*(*)(char const*, char const*, char const*, char const*, void*, LYS_INFORMAT*, void(**)(void*, void*))',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '231'
+                                                          },
+                                                   '5' => {
+                                                            'type' => '9251'
+                                                          },
+                                                   '6' => {
+                                                            'type' => '9257'
+                                                          }
+                                                 },
+                                      'Return' => '361',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9251' => {
+                                      'BaseType' => '1613',
+                                      'Name' => 'LYS_INFORMAT*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9257' => {
+                                      'BaseType' => '9263',
+                                      'Name' => 'void(**)(void*, void*)',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9263' => {
+                                      'Name' => 'void(*)(void*, void*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '231'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '231'
+                                                          }
+                                                 },
+                                      'Return' => '1',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9285' => {
+                                      'BaseType' => '9297',
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1504',
+                                      'Name' => 'ly_module_data_clb',
+                                      'Size' => '8',
+                                      'Type' => 'Typedef'
+                                    },
+                          '9297' => {
+                                      'Name' => 'struct lys_module const*(*)(struct ly_ctx*, char const*, char const*, int, void*)',
+                                      'Param' => {
+                                                   '0' => {
+                                                            'type' => '3714'
+                                                          },
+                                                   '1' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '2' => {
+                                                            'type' => '361'
+                                                          },
+                                                   '3' => {
+                                                            'type' => '157'
+                                                          },
+                                                   '4' => {
+                                                            'type' => '231'
+                                                          }
+                                                 },
+                                      'Return' => '9338',
+                                      'Size' => '8',
+                                      'Type' => 'FuncPtr'
+                                    },
+                          '9338' => {
+                                      'BaseType' => '3264',
+                                      'Name' => 'struct lys_module const*',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9344' => {
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1691',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 's',
+                                                           'offset' => '0',
+                                                           'type' => '9388'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'd',
+                                                           'offset' => '0',
+                                                           'type' => '9182'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'g',
+                                                           'offset' => '0',
+                                                           'type' => '6990'
+                                                         }
+                                                },
+                                      'Name' => 'union ly_set_set',
+                                      'Size' => '8',
+                                      'Type' => 'Union'
+                                    },
+                          '9388' => {
+                                      'BaseType' => '5163',
+                                      'Name' => 'struct lys_node**',
+                                      'Size' => '8',
+                                      'Type' => 'Pointer'
+                                    },
+                          '9433' => {
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1866',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_LLERR',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_LLWRN',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LY_LLVRB',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'LY_LLDBG',
+                                                           'value' => '3'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_LOG_LEVEL',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '9502' => {
+                                      'Header' => 'libyang.h',
+                                      'Line' => '1968',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LY_SUCCESS',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LY_EMEM',
+                                                           'value' => '1'
+                                                         },
+                                                  '2' => {
+                                                           'name' => 'LY_ESYS',
+                                                           'value' => '2'
+                                                         },
+                                                  '3' => {
+                                                           'name' => 'LY_EINVAL',
+                                                           'value' => '3'
+                                                         },
+                                                  '4' => {
+                                                           'name' => 'LY_EINT',
+                                                           'value' => '4'
+                                                         },
+                                                  '5' => {
+                                                           'name' => 'LY_EVALID',
+                                                           'value' => '5'
+                                                         },
+                                                  '6' => {
+                                                           'name' => 'LY_EPLUGIN',
+                                                           'value' => '6'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_ERR',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    },
+                          '99' => {
+                                    'Name' => 'signed char',
+                                    'Size' => '1',
+                                    'Type' => 'Intrinsic'
+                                  },
+                          '9997' => {
+                                      'Header' => 'libyang.h',
+                                      'Line' => '2070',
+                                      'Memb' => {
+                                                  '0' => {
+                                                           'name' => 'LYVE_SUCCESS',
+                                                           'value' => '0'
+                                                         },
+                                                  '1' => {
+                                                           'name' => 'LYVE_XML_MISS',
+                                                           'value' => '1'
+                                                         },
+                                                  '10' => {
+                                                            'name' => 'LYVE_MISSSTMT',
+                                                            'value' => '10'
+                                                          },
+                                                  '11' => {
+                                                            'name' => 'LYVE_MISSARG',
+                                                            'value' => '11'
+                                                          },
+                                                  '12' => {
+                                                            'name' => 'LYVE_TOOMANY',
+                                                            'value' => '12'
+                                                          },
+                                                  '13' => {
+                                                            'name' => 'LYVE_DUPID',
+                                                            'value' => '13'
+                                                          },
+                                                  '14' => {
+                                                            'name' => 'LYVE_DUPLEAFLIST',
+                                                            'value' => '14'
+                                                          },
+                                                  '15' => {
+                                                            'name' => 'LYVE_DUPLIST',
+                                                            'value' => '15'
+                                                          },
+                                                  '16' => {
+                                                            'name' => 'LYVE_NOUNIQ',
+                                                            'value' => '16'
+                                                          },
+                                                  '17' => {
+                                                            'name' => 'LYVE_ENUM_INVAL',
+                                                            'value' => '17'
+                                                          },
+                                                  '18' => {
+                                                            'name' => 'LYVE_ENUM_INNAME',
+                                                            'value' => '18'
+                                                          },
+                                                  '19' => {
+                                                            'name' => 'LYVE_ENUM_WS',
+                                                            'value' => '19'
+                                                          },
+                                                  '2' => {
+                                                           'name' => 'LYVE_XML_INVAL',
+                                                           'value' => '2'
+                                                         },
+                                                  '20' => {
+                                                            'name' => 'LYVE_BITS_INVAL',
+                                                            'value' => '20'
+                                                          },
+                                                  '21' => {
+                                                            'name' => 'LYVE_BITS_INNAME',
+                                                            'value' => '21'
+                                                          },
+                                                  '22' => {
+                                                            'name' => 'LYVE_INMOD',
+                                                            'value' => '22'
+                                                          },
+                                                  '23' => {
+                                                            'name' => 'LYVE_KEY_NLEAF',
+                                                            'value' => '23'
+                                                          },
+                                                  '24' => {
+                                                            'name' => 'LYVE_KEY_TYPE',
+                                                            'value' => '24'
+                                                          },
+                                                  '25' => {
+                                                            'name' => 'LYVE_KEY_CONFIG',
+                                                            'value' => '25'
+                                                          },
+                                                  '26' => {
+                                                            'name' => 'LYVE_KEY_MISS',
+                                                            'value' => '26'
+                                                          },
+                                                  '27' => {
+                                                            'name' => 'LYVE_KEY_DUP',
+                                                            'value' => '27'
+                                                          },
+                                                  '28' => {
+                                                            'name' => 'LYVE_INREGEX',
+                                                            'value' => '28'
+                                                          },
+                                                  '29' => {
+                                                            'name' => 'LYVE_INRESOLV',
+                                                            'value' => '29'
+                                                          },
+                                                  '3' => {
+                                                           'name' => 'LYVE_XML_INCHAR',
+                                                           'value' => '3'
+                                                         },
+                                                  '30' => {
+                                                            'name' => 'LYVE_INSTATUS',
+                                                            'value' => '30'
+                                                          },
+                                                  '31' => {
+                                                            'name' => 'LYVE_CIRC_LEAFREFS',
+                                                            'value' => '31'
+                                                          },
+                                                  '32' => {
+                                                            'name' => 'LYVE_CIRC_FEATURES',
+                                                            'value' => '32'
+                                                          },
+                                                  '33' => {
+                                                            'name' => 'LYVE_CIRC_IMPORTS',
+                                                            'value' => '33'
+                                                          },
+                                                  '34' => {
+                                                            'name' => 'LYVE_CIRC_INCLUDES',
+                                                            'value' => '34'
+                                                          },
+                                                  '35' => {
+                                                            'name' => 'LYVE_INVER',
+                                                            'value' => '35'
+                                                          },
+                                                  '36' => {
+                                                            'name' => 'LYVE_SUBMODULE',
+                                                            'value' => '36'
+                                                          },
+                                                  '37' => {
+                                                            'name' => 'LYVE_OBSDATA',
+                                                            'value' => '37'
+                                                          },
+                                                  '38' => {
+                                                            'name' => 'LYVE_NORESOLV',
+                                                            'value' => '38'
+                                                          },
+                                                  '39' => {
+                                                            'name' => 'LYVE_INELEM',
+                                                            'value' => '39'
+                                                          },
+                                                  '4' => {
+                                                           'name' => 'LYVE_EOF',
+                                                           'value' => '4'
+                                                         },
+                                                  '40' => {
+                                                            'name' => 'LYVE_MISSELEM',
+                                                            'value' => '40'
+                                                          },
+                                                  '41' => {
+                                                            'name' => 'LYVE_INVAL',
+                                                            'value' => '41'
+                                                          },
+                                                  '42' => {
+                                                            'name' => 'LYVE_INMETA',
+                                                            'value' => '42'
+                                                          },
+                                                  '43' => {
+                                                            'name' => 'LYVE_INATTR',
+                                                            'value' => '43'
+                                                          },
+                                                  '44' => {
+                                                            'name' => 'LYVE_MISSATTR',
+                                                            'value' => '44'
+                                                          },
+                                                  '45' => {
+                                                            'name' => 'LYVE_NOCONSTR',
+                                                            'value' => '45'
+                                                          },
+                                                  '46' => {
+                                                            'name' => 'LYVE_INCHAR',
+                                                            'value' => '46'
+                                                          },
+                                                  '47' => {
+                                                            'name' => 'LYVE_INPRED',
+                                                            'value' => '47'
+                                                          },
+                                                  '48' => {
+                                                            'name' => 'LYVE_MCASEDATA',
+                                                            'value' => '48'
+                                                          },
+                                                  '49' => {
+                                                            'name' => 'LYVE_NOMUST',
+                                                            'value' => '49'
+                                                          },
+                                                  '5' => {
+                                                           'name' => 'LYVE_INSTMT',
+                                                           'value' => '5'
+                                                         },
+                                                  '50' => {
+                                                            'name' => 'LYVE_NOWHEN',
+                                                            'value' => '50'
+                                                          },
+                                                  '51' => {
+                                                            'name' => 'LYVE_INORDER',
+                                                            'value' => '51'
+                                                          },
+                                                  '52' => {
+                                                            'name' => 'LYVE_INWHEN',
+                                                            'value' => '52'
+                                                          },
+                                                  '53' => {
+                                                            'name' => 'LYVE_NOMIN',
+                                                            'value' => '53'
+                                                          },
+                                                  '54' => {
+                                                            'name' => 'LYVE_NOMAX',
+                                                            'value' => '54'
+                                                          },
+                                                  '55' => {
+                                                            'name' => 'LYVE_NOREQINS',
+                                                            'value' => '55'
+                                                          },
+                                                  '56' => {
+                                                            'name' => 'LYVE_NOLEAFREF',
+                                                            'value' => '56'
+                                                          },
+                                                  '57' => {
+                                                            'name' => 'LYVE_NOMANDCHOICE',
+                                                            'value' => '57'
+                                                          },
+                                                  '58' => {
+                                                            'name' => 'LYVE_XPATH_INTOK',
+                                                            'value' => '58'
+                                                          },
+                                                  '59' => {
+                                                            'name' => 'LYVE_XPATH_EOF',
+                                                            'value' => '59'
+                                                          },
+                                                  '6' => {
+                                                           'name' => 'LYVE_INPAR',
+                                                           'value' => '6'
+                                                         },
+                                                  '60' => {
+                                                            'name' => 'LYVE_XPATH_INOP',
+                                                            'value' => '60'
+                                                          },
+                                                  '61' => {
+                                                            'name' => 'LYVE_XPATH_INCTX',
+                                                            'value' => '61'
+                                                          },
+                                                  '62' => {
+                                                            'name' => 'LYVE_XPATH_INMOD',
+                                                            'value' => '62'
+                                                          },
+                                                  '63' => {
+                                                            'name' => 'LYVE_XPATH_INFUNC',
+                                                            'value' => '63'
+                                                          },
+                                                  '64' => {
+                                                            'name' => 'LYVE_XPATH_INARGCOUNT',
+                                                            'value' => '64'
+                                                          },
+                                                  '65' => {
+                                                            'name' => 'LYVE_XPATH_INARGTYPE',
+                                                            'value' => '65'
+                                                          },
+                                                  '66' => {
+                                                            'name' => 'LYVE_XPATH_DUMMY',
+                                                            'value' => '66'
+                                                          },
+                                                  '67' => {
+                                                            'name' => 'LYVE_XPATH_NOEND',
+                                                            'value' => '67'
+                                                          },
+                                                  '68' => {
+                                                            'name' => 'LYVE_PATH_INCHAR',
+                                                            'value' => '68'
+                                                          },
+                                                  '69' => {
+                                                            'name' => 'LYVE_PATH_INMOD',
+                                                            'value' => '69'
+                                                          },
+                                                  '7' => {
+                                                           'name' => 'LYVE_INID',
+                                                           'value' => '7'
+                                                         },
+                                                  '70' => {
+                                                            'name' => 'LYVE_PATH_MISSMOD',
+                                                            'value' => '70'
+                                                          },
+                                                  '71' => {
+                                                            'name' => 'LYVE_PATH_INNODE',
+                                                            'value' => '71'
+                                                          },
+                                                  '72' => {
+                                                            'name' => 'LYVE_PATH_INKEY',
+                                                            'value' => '72'
+                                                          },
+                                                  '73' => {
+                                                            'name' => 'LYVE_PATH_MISSKEY',
+                                                            'value' => '73'
+                                                          },
+                                                  '74' => {
+                                                            'name' => 'LYVE_PATH_INIDENTREF',
+                                                            'value' => '74'
+                                                          },
+                                                  '75' => {
+                                                            'name' => 'LYVE_PATH_EXISTS',
+                                                            'value' => '75'
+                                                          },
+                                                  '76' => {
+                                                            'name' => 'LYVE_PATH_MISSPAR',
+                                                            'value' => '76'
+                                                          },
+                                                  '77' => {
+                                                            'name' => 'LYVE_PATH_PREDTOOMANY',
+                                                            'value' => '77'
+                                                          },
+                                                  '8' => {
+                                                           'name' => 'LYVE_INDATE',
+                                                           'value' => '8'
+                                                         },
+                                                  '9' => {
+                                                           'name' => 'LYVE_INARG',
+                                                           'value' => '9'
+                                                         }
+                                                },
+                                      'Name' => 'enum LY_VECODE',
+                                      'Size' => '4',
+                                      'Type' => 'Enum'
+                                    }
+                        },
+          'UndefinedSymbols' => {
+                                  'libyang.so.1.8.4' => {
+                                                          '_IO_getc@GLIBC_2.2.5' => 0,
+                                                          '_ITM_deregisterTMCloneTable' => 0,
+                                                          '_ITM_registerTMCloneTable' => 0,
+                                                          '__asprintf_chk@GLIBC_2.8' => 0,
+                                                          '__assert_fail@GLIBC_2.2.5' => 0,
+                                                          '__ctype_b_loc@GLIBC_2.3' => 0,
+                                                          '__ctype_tolower_loc@GLIBC_2.3' => 0,
+                                                          '__cxa_finalize@GLIBC_2.2.5' => 0,
+                                                          '__errno_location@GLIBC_2.2.5' => 0,
+                                                          '__fprintf_chk@GLIBC_2.3.4' => 0,
+                                                          '__fxstat@GLIBC_2.2.5' => 0,
+                                                          '__gmon_start__' => 0,
+                                                          '__realpath_chk@GLIBC_2.4' => 0,
+                                                          '__sprintf_chk@GLIBC_2.3.4' => 0,
+                                                          '__stack_chk_fail@GLIBC_2.4' => 0,
+                                                          '__strcat_chk@GLIBC_2.3.4' => 0,
+                                                          '__strcpy_chk@GLIBC_2.3.4' => 0,
+                                                          '__tls_get_addr@GLIBC_2.3' => 0,
+                                                          '__vasprintf_chk@GLIBC_2.8' => 0,
+                                                          '__vdprintf_chk@GLIBC_2.8' => 0,
+                                                          '__vfprintf_chk@GLIBC_2.3.4' => 0,
+                                                          '__xstat@GLIBC_2.2.5' => 0,
+                                                          'abort@GLIBC_2.2.5' => 0,
+                                                          'access@GLIBC_2.2.5' => 0,
+                                                          'calloc@GLIBC_2.2.5' => 0,
+                                                          'clearerr@GLIBC_2.2.5' => 0,
+                                                          'close@GLIBC_2.2.5' => 0,
+                                                          'closedir@GLIBC_2.2.5' => 0,
+                                                          'dlclose@GLIBC_2.2.5' => 0,
+                                                          'dlerror@GLIBC_2.2.5' => 0,
+                                                          'dlopen@GLIBC_2.2.5' => 0,
+                                                          'dlsym@GLIBC_2.2.5' => 0,
+                                                          'exit@GLIBC_2.2.5' => 0,
+                                                          'fclose@GLIBC_2.2.5' => 0,
+                                                          'fcntl@GLIBC_2.2.5' => 0,
+                                                          'fdopen@GLIBC_2.2.5' => 0,
+                                                          'ferror@GLIBC_2.2.5' => 0,
+                                                          'fflush@GLIBC_2.2.5' => 0,
+                                                          'fileno@GLIBC_2.2.5' => 0,
+                                                          'fopen@GLIBC_2.2.5' => 0,
+                                                          'fread@GLIBC_2.2.5' => 0,
+                                                          'free@GLIBC_2.2.5' => 0,
+                                                          'fseek@GLIBC_2.2.5' => 0,
+                                                          'ftell@GLIBC_2.2.5' => 0,
+                                                          'fwrite@GLIBC_2.2.5' => 0,
+                                                          'get_current_dir_name@GLIBC_2.2.5' => 0,
+                                                          'getenv@GLIBC_2.2.5' => 0,
+                                                          'getpid@GLIBC_2.2.5' => 0,
+                                                          'isatty@GLIBC_2.2.5' => 0,
+                                                          'malloc@GLIBC_2.2.5' => 0,
+                                                          'memcmp@GLIBC_2.2.5' => 0,
+                                                          'memcpy@GLIBC_2.14' => 0,
+                                                          'memmove@GLIBC_2.2.5' => 0,
+                                                          'memset@GLIBC_2.2.5' => 0,
+                                                          'mkdir@GLIBC_2.2.5' => 0,
+                                                          'mktime@GLIBC_2.2.5' => 0,
+                                                          'mmap@GLIBC_2.2.5' => 0,
+                                                          'munmap@GLIBC_2.2.5' => 0,
+                                                          'open@GLIBC_2.2.5' => 0,
+                                                          'opendir@GLIBC_2.2.5' => 0,
+                                                          'pcre_compile' => 0,
+                                                          'pcre_exec' => 0,
+                                                          'pcre_free' => 0,
+                                                          'pcre_free_study' => 0,
+                                                          'pcre_study' => 0,
+                                                          'pthread_getspecific@GLIBC_2.2.5' => 0,
+                                                          'pthread_key_create@GLIBC_2.2.5' => 0,
+                                                          'pthread_key_delete@GLIBC_2.2.5' => 0,
+                                                          'pthread_mutex_destroy@GLIBC_2.2.5' => 0,
+                                                          'pthread_mutex_init@GLIBC_2.2.5' => 0,
+                                                          'pthread_mutex_lock@GLIBC_2.2.5' => 0,
+                                                          'pthread_mutex_unlock@GLIBC_2.2.5' => 0,
+                                                          'pthread_setspecific@GLIBC_2.2.5' => 0,
+                                                          'qsort@GLIBC_2.2.5' => 0,
+                                                          'readdir@GLIBC_2.2.5' => 0,
+                                                          'readlink@GLIBC_2.2.5' => 0,
+                                                          'realloc@GLIBC_2.2.5' => 0,
+                                                          'realpath@GLIBC_2.3' => 0,
+                                                          'setbuf@GLIBC_2.2.5' => 0,
+                                                          'stderr@GLIBC_2.2.5' => 0,
+                                                          'stdin@GLIBC_2.2.5' => 0,
+                                                          'stdout@GLIBC_2.2.5' => 0,
+                                                          'strcat@GLIBC_2.2.5' => 0,
+                                                          'strchr@GLIBC_2.2.5' => 0,
+                                                          'strcmp@GLIBC_2.2.5' => 0,
+                                                          'strcpy@GLIBC_2.2.5' => 0,
+                                                          'strdup@GLIBC_2.2.5' => 0,
+                                                          'strerror@GLIBC_2.2.5' => 0,
+                                                          'strlen@GLIBC_2.2.5' => 0,
+                                                          'strncmp@GLIBC_2.2.5' => 0,
+                                                          'strncpy@GLIBC_2.2.5' => 0,
+                                                          'strndup@GLIBC_2.2.5' => 0,
+                                                          'strpbrk@GLIBC_2.2.5' => 0,
+                                                          'strptime@GLIBC_2.2.5' => 0,
+                                                          'strrchr@GLIBC_2.2.5' => 0,
+                                                          'strstr@GLIBC_2.2.5' => 0,
+                                                          'strtod@GLIBC_2.2.5' => 0,
+                                                          'strtok_r@GLIBC_2.2.5' => 0,
+                                                          'strtol@GLIBC_2.2.5' => 0,
+                                                          'strtold@GLIBC_2.2.5' => 0,
+                                                          'strtoll@GLIBC_2.2.5' => 0,
+                                                          'strtoul@GLIBC_2.2.5' => 0,
+                                                          'strtoull@GLIBC_2.2.5' => 0,
+                                                          'sysconf@GLIBC_2.2.5' => 0,
+                                                          'write@GLIBC_2.2.5' => 0
+                                                        }
+                                },
+          'WordSize' => '8'
+        };

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -3,7 +3,7 @@ project(libyang-cpp)
 set(CMAKE_CXX_FLAGS         "${CMAKE_CXX_FLAGS} -Wall -Wextra -std=c++11")
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
 set(CMAKE_CXX_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
-set(CMAKE_CXX_FLAGS_DEBUG   "-g -O0")
+set(CMAKE_CXX_FLAGS_DEBUG   "-g -Og")
 
 # temporary bugfix
 add_compile_options(-std=c++11)

--- a/tools/abi-check.sh
+++ b/tools/abi-check.sh
@@ -6,4 +6,10 @@ LC_ALL=C.UTF-8 PATH=/snap/bin:$PATH abi-dumper ./build/libyang.so -o ./build/lib
 abi-compliance-checker -l libyang.so -old ./libyang.dump -new ./build/libyang.dump -s || status=$?
 # Generate and dump text output
 w3m -dump -O ascii -T text/html "$(find "compat_reports/${SONAME}" -name '*.html')"
+# Dump the new libyang ABI dump if it differs
+if [ "$status" -ne 0 ]; then
+    echo "-- cut here --"
+    cat ./build/libyang.dump
+    echo "-- cut here --"
+fi
 exit $status

--- a/tools/abi-check.sh
+++ b/tools/abi-check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 status=0
 # Dump the current ABI
-abi-dumper ./build/libyang.so -o ./build/libyang.dump -lver "$(PKG_CONFIG_PATH=./build pkg-config --modversion libyang)"
+LC_ALL=C.UTF-8 PATH=/snap/bin:$PATH abi-dumper ./build/libyang.so -o ./build/libyang.dump -lver "$(PKG_CONFIG_PATH=./build pkg-config --modversion libyang)" -public-headers ./src -public-headers ./build/src
 # Compare the current ABI with previous ABI
 abi-compliance-checker -l libyang.so -old ./libyang.dump -new ./build/libyang.dump -s || status=$?
 # Generate and dump text output

--- a/tools/abi-check.sh
+++ b/tools/abi-check.sh
@@ -1,5 +1,9 @@
 #!/bin/sh -e
+status=0
 # Dump the current ABI
 abi-dumper ./build/libyang.so -o ./build/libyang.dump -lver "$(PKG_CONFIG_PATH=./build pkg-config --modversion libyang)"
 # Compare the current ABI with previous ABI
-abi-compliance-checker -l libyang.so -old ./libyang.dump -new ./build/libyang.dump -s
+abi-compliance-checker -l libyang.so -old ./libyang.dump -new ./build/libyang.dump -s || status=$?
+# Generate and dump text output
+w3m -dump -O ascii -T text/html "$(find "compat_reports/${SONAME}" -name '*.html')"
+exit $status

--- a/tools/abi-check.sh
+++ b/tools/abi-check.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+# Dump the current ABI
+abi-dumper ./build/libyang.so -o ./build/libyang.dump -lver "$(PKG_CONFIG_PATH=./build pkg-config --modversion libyang)"
+# Compare the current ABI with previous ABI
+abi-compliance-checker -l libyang.so -old ./libyang.dump -new ./build/libyang.dump -s


### PR DESCRIPTION
This PR adds support for checking the ABI difference between master (committed as libyang.dump) and the working branch.  When the API change is intentional, the `libyang.dump` needs to be updated with `build/libyang.dump` (created by `tools/abi-check.sh`).