### PR TITLE
Rename RPM package to libyang1 for coexisting with libyang 0.x

### DIFF
--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PACKAGE "libyang")
 set(CPP_PACKAGE "libyang-cpp")
 set(PYTHON_PACKAGE "python3-yang")
+set(TOOLS_PACKAGE "yang-tools")
 
 find_program(DEB_BUILDER NAMES debuild)
 find_program(RPM_BUILDER NAMES rpmbuild)

--- a/packages/CMakeLists.txt
+++ b/packages/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(PACKAGE "libyang")
 set(CPP_PACKAGE "libyang-cpp")
 set(PYTHON_PACKAGE "python3-yang")
-set(TOOLS_PACKAGE "yang-tools")
+set(TOOLS_PACKAGE "libyang-tools")
 
 find_program(DEB_BUILDER NAMES debuild)
 find_program(RPM_BUILDER NAMES rpmbuild)

--- a/packages/libyang.spec.in
+++ b/packages/libyang.spec.in
@@ -43,7 +43,7 @@ BuildRequires:  python36-devel
 
 %endif
 
-%package devel
+%package -n @PACKAGE@-devel
 Summary:    Headers of libyang library
 Requires:   %{name} = %{version}-%{release}
 Requires:   pcre-devel
@@ -77,7 +77,7 @@ Headers of bindings to c++ language.
 Bindings of libyang library to python language.
 %endif
 
-%description devel
+%description -n @PACKAGE@-devel
 Headers of libyang library.
 
 %description -n @TOOLS_PACKAGE@
@@ -136,7 +136,7 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/libyang1/*
 %dir %{_libdir}/libyang1/
 
-%files devel
+%files -n @PACKAGE@-devel
 %defattr(-,root,root)
 %{_libdir}/libyang.so
 %{_libdir}/pkgconfig/libyang.pc

--- a/packages/libyang.spec.in
+++ b/packages/libyang.spec.in
@@ -1,4 +1,4 @@
-name: @PACKAGE@1
+name: @PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 Version: @LIBYANG_VERSION@
 Release: 0
 Summary: Libyang library
@@ -53,27 +53,27 @@ Summary:    Helper Tools
 Requires:   %{name} = %{version}-%{release}
 
 %if %{with_lang_bind}
-%package -n @CPP_PACKAGE@1
+%package -n @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 Summary:    Bindings to c++ language
 Requires:   %{name} = %{version}-%{release}
 
 %package -n @CPP_PACKAGE@-devel
 Summary:    Headers of bindings to c++ language
-Requires:   @CPP_PACKAGE@1 = %{version}-%{release}
+Requires:   @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@ = %{version}-%{release}
 Requires:   pcre-devel
 
-%package -n @PYTHON_PACKAGE@1
+%package -n @PYTHON_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 Summary:    Binding to python
-Requires:   @CPP_PACKAGE@1 = %{version}-%{release}
+Requires:   @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@ = %{version}-%{release}
 Requires:   %{name} = %{version}-%{release}
 
-%description -n @CPP_PACKAGE@1
+%description -n @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 Bindings of libyang library to C++ language.
 
 %description -n @CPP_PACKAGE@-devel
 Headers of bindings to c++ language.
 
-%description -n @PYTHON_PACKAGE@1
+%description -n @PYTHON_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 Bindings of libyang library to python language.
 %endif
 
@@ -122,19 +122,19 @@ make DESTDIR=%{buildroot} install
 
 %post -p /sbin/ldconfig
 %if %{with_lang_bind}
-%post -n @CPP_PACKAGE@1 -p /sbin/ldconfig
+%post -n @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@ -p /sbin/ldconfig
 %endif
 
 %postun -p /sbin/ldconfig
 %if %{with_lang_bind}
-%postun -n @CPP_PACKAGE@1 -p /sbin/ldconfig
+%postun -n @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@ -p /sbin/ldconfig
 %endif
 
 %files
 %defattr(-,root,root)
 %{_libdir}/libyang.so.*
-%{_libdir}/libyang1/*
-%dir %{_libdir}/libyang1/
+%{_libdir}/libyang@LIBYANG_MAJOR_SOVERSION@/*
+%dir %{_libdir}/libyang@LIBYANG_MAJOR_SOVERSION@/
 
 %files -n @PACKAGE@-devel
 %defattr(-,root,root)
@@ -150,7 +150,7 @@ make DESTDIR=%{buildroot} install
 %{_datadir}/man/man1/yangre.1.gz
 
 %if %{with_lang_bind}
-%files -n @CPP_PACKAGE@1
+%files -n @CPP_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 %defattr(-,root,root)
 %{_libdir}/libyang-cpp.so.*
 
@@ -161,7 +161,7 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/pkgconfig/libyang-cpp.pc
 %dir %{_includedir}/libyang/
 
-%files -n @PYTHON_PACKAGE@1
+%files -n @PYTHON_PACKAGE@@LIBYANG_MAJOR_SOVERSION@
 %defattr(-,root,root)
 %{_libdir}/python*
 

--- a/packages/libyang.spec.in
+++ b/packages/libyang.spec.in
@@ -1,4 +1,4 @@
-Name: @PACKAGE@
+name: @PACKAGE@1
 Version: @LIBYANG_VERSION@
 Release: 0
 Summary: Libyang library
@@ -28,7 +28,6 @@ BuildRequires:  gcc
 BuildRequires:  libcmocka-devel
 
 %if %{with_lang_bind}
-
 BuildRequires:  gcc-c++
 %if 0%{?rhel} == 7
 BuildRequires:  swig3 >= 3.0.12
@@ -49,33 +48,40 @@ Summary:    Headers of libyang library
 Requires:   %{name} = %{version}-%{release}
 Requires:   pcre-devel
 
+%package -n @TOOLS_PACKAGE@
+Summary:    Helper Tools
+Requires:   %{name} = %{version}-%{release}
+
 %if %{with_lang_bind}
-%package -n @CPP_PACKAGE@
+%package -n @CPP_PACKAGE@1
 Summary:    Bindings to c++ language
 Requires:   %{name} = %{version}-%{release}
 
 %package -n @CPP_PACKAGE@-devel
 Summary:    Headers of bindings to c++ language
-Requires:   @CPP_PACKAGE@ = %{version}-%{release}
+Requires:   @CPP_PACKAGE@1 = %{version}-%{release}
 Requires:   pcre-devel
 
-%package -n @PYTHON_PACKAGE@
+%package -n @PYTHON_PACKAGE@1
 Summary:    Binding to python
-Requires:   @CPP_PACKAGE@ = %{version}-%{release}
+Requires:   @CPP_PACKAGE@1 = %{version}-%{release}
 Requires:   %{name} = %{version}-%{release}
 
-%description -n @CPP_PACKAGE@
+%description -n @CPP_PACKAGE@1
 Bindings of libyang library to C++ language.
 
 %description -n @CPP_PACKAGE@-devel
 Headers of bindings to c++ language.
 
-%description -n @PYTHON_PACKAGE@
+%description -n @PYTHON_PACKAGE@1
 Bindings of libyang library to python language.
 %endif
 
 %description devel
 Headers of libyang library.
+
+%description -n @TOOLS_PACKAGE@
+Helper Tools and examples for libyang library.
 
 %description
 @LIBYANG_DESCRIPTION@
@@ -116,20 +122,16 @@ make DESTDIR=%{buildroot} install
 
 %post -p /sbin/ldconfig
 %if %{with_lang_bind}
-%post -n @CPP_PACKAGE@ -p /sbin/ldconfig
+%post -n @CPP_PACKAGE@1 -p /sbin/ldconfig
 %endif
 
 %postun -p /sbin/ldconfig
 %if %{with_lang_bind}
-%postun -n @CPP_PACKAGE@ -p /sbin/ldconfig
+%postun -n @CPP_PACKAGE@1 -p /sbin/ldconfig
 %endif
 
 %files
 %defattr(-,root,root)
-%{_bindir}/yanglint
-%{_bindir}/yangre
-%{_datadir}/man/man1/yanglint.1.gz
-%{_datadir}/man/man1/yangre.1.gz
 %{_libdir}/libyang.so.*
 %{_libdir}/libyang1/*
 %dir %{_libdir}/libyang1/
@@ -141,8 +143,14 @@ make DESTDIR=%{buildroot} install
 %{_includedir}/libyang/*.h
 %dir %{_includedir}/libyang/
 
+%files -n @TOOLS_PACKAGE@
+%{_bindir}/yanglint
+%{_bindir}/yangre
+%{_datadir}/man/man1/yanglint.1.gz
+%{_datadir}/man/man1/yangre.1.gz
+
 %if %{with_lang_bind}
-%files -n @CPP_PACKAGE@
+%files -n @CPP_PACKAGE@1
 %defattr(-,root,root)
 %{_libdir}/libyang-cpp.so.*
 
@@ -153,9 +161,10 @@ make DESTDIR=%{buildroot} install
 %{_libdir}/pkgconfig/libyang-cpp.pc
 %dir %{_includedir}/libyang/
 
-%files -n @PYTHON_PACKAGE@
+%files -n @PYTHON_PACKAGE@1
 %defattr(-,root,root)
 %{_libdir}/python*
+
 %endif
 
 %changelog


### PR DESCRIPTION
Renamed packages similar to official debian package
Moved yanglint/yangre utilities to new yang-tools package
Changes allow libyang 0.x version and libyang 1.x lib package
to be installed at the same time.

Signed-off-by: Martin Winter <mwinter@opensourcerouting.org>