### PR TITLE
fix deviation replace config failure  when a leaf node  has not the property 'config' explicitly

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -4491,10 +4491,6 @@ yang_check_deviate(struct lys_module *module, struct unres_schema *unres, struct
             LOGVAL(module->ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, "config");
             LOGVAL(module->ctx, LYE_SPEC, LY_VLOG_NONE, NULL, "Adding property that already exists.");
             goto error;
-        } else if ((deviate->mod == LY_DEVIATE_RPL) && !(dev_target->flags & LYS_CONFIG_SET)) {
-            LOGVAL(module->ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, "config");
-            LOGVAL(module->ctx, LYE_SPEC, LY_VLOG_NONE, NULL, "Replacing a property that does not exist.");
-            goto error;
         }
 
         /* add and replace are the same in this case */

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -2439,10 +2439,6 @@ fill_yin_deviation(struct lys_module *module, struct lyxml_elem *yin, struct lys
                     LOGVAL(ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, "config");
                     LOGVAL(ctx, LYE_SPEC, LY_VLOG_NONE, NULL, "Adding property that already exists.");
                     goto error;
-                } else if ((d->mod == LY_DEVIATE_RPL) && !(dev_target->flags & LYS_CONFIG_SET)) {
-                    LOGVAL(ctx, LYE_INSTMT, LY_VLOG_NONE, NULL, "config");
-                    LOGVAL(ctx, LYE_SPEC, LY_VLOG_NONE, NULL, "Replacing a property that does not exist.");
-                    goto error;
                 } else { /* add and replace are the same in this case */
                     /* remove current config value of the target ... */
                     dev_target->flags &= ~LYS_CONFIG_MASK;

--- a/tests/conformance/sec7_18_3_2/mod14.yang
+++ b/tests/conformance/sec7_18_3_2/mod14.yang
@@ -1,0 +1,14 @@
+module mod14 {
+    prefix abc;
+    namespace "urn:cesnet:mod14";
+
+    import mod {
+        prefix mod;
+    }
+
+    deviation "/mod:test1" {
+        deviate replace {
+            config true;
+        }
+    }
+}

--- a/tests/conformance/test_sec7_18_3_2.c
+++ b/tests/conformance/test_sec7_18_3_2.c
@@ -27,8 +27,8 @@
 
 #define TEST_DIR "sec7_18_3_2"
 #define TEST_NAME test_sec7_18_3_2
-#define TEST_SCHEMA_COUNT 13
-#define TEST_SCHEMA_LOAD_FAIL 1,1,1,1,1,1,1,1,1,1,1,1,0
+#define TEST_SCHEMA_COUNT 14
+#define TEST_SCHEMA_LOAD_FAIL 1,1,1,1,1,1,1,1,1,1,1,1,0,0
 #define TEST_DATA_FILE_COUNT 7
 #define TEST_DATA_FILE_LOAD_FAIL 1,1,1,0,0,1,1
 


### PR DESCRIPTION
Hi, Michal,
I find deviation replace the property 'config' which does not exist in a leaf node fails,the error msg is that :
`err : Invalid keyword "config".
err : Replacing a property that does not exist.
err : Module "mod1" parsing failed.`
It seems like the devition fails beacase leaf node  does not explicitly have  `config true` or `config false`, but according to  RFC 7950 (https://tools.ietf.org/html/rfc7950#section-7.21.1), `config true` is implied when it is not present, in this case, I think it is no need to check whether there is the propery `config`. 

yang modules are as follows:
1 )  mod.yang
```
module mod {
    namespace "urn:cesnet:mod";
    prefix m;

    leaf l {
        type string;
        //config true;
    }
}
```
2 ) mod1.yang
```
module mod1 {
    namespace "urn:cesnet:mod1";
    prefix m1;

    import mod {
        prefix m;
    }

    deviation "/m:l" {
        deviate replace {
            config true;
        }
    }
}
```
using yanglint, the result  is as follows:
```
root@oss-0007:/libyang/deviation# yanglint -f yang mod1.yang
err : Invalid keyword "config".
err : Replacing a property that does not exist.
err : Module "mod1" parsing failed.

```
