### PR TITLE
FIX segmentation fault in yang.y.in's YANG_ADDELEM

### DIFF
--- a/src/parser_yang_bis.c
+++ b/src/parser_yang_bis.c
@@ -96,7 +96,8 @@
         memset((char *)tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
         (current_ptr) = tmp;                                                             \
     }                                                                                    \
-    actual = &(current_ptr)[(size)++];                                                   \
+    (size)++;                                                                            \
+    actual = &(current_ptr)[(size)-1];                                                   \
 
 void yyerror(YYLTYPE *yylloc, void *scanner, struct yang_parameter *param, ...);
 /* pointer on the current parsed element 'actual' */

--- a/src/yang.y.in
+++ b/src/yang.y.in
@@ -50,7 +50,8 @@
         memset((char *)tmp + (sizeof *(current_ptr)) * (size), 0, (sizeof *(current_ptr)) * LY_YANG_ARRAY_SIZE); \
         (current_ptr) = tmp;                                                             \
     }                                                                                    \
-    actual = &(current_ptr)[(size)++];                                                   \
+    (size)++;                                                                            \
+    actual = &(current_ptr)[(size)-1];                                                   \
 
 void yyerror(YYLTYPE *yylloc, void *scanner, struct yang_parameter *param, ...);
 /* pointer on the current parsed element 'actual' */


### PR DESCRIPTION
This fixes a segmentation fault in Bison parser's macro YANG_ADDELEM.
When the element counter in "size" depends on the "actual" pointer, it must not be incremented after "actual" has been changed.

An occurrence of this segmentation fault is at line 1629: YANG_ADDELEM(((struct yang_type *)actual)->type->info.enums.enm, ((struct yang_type *)actual)->type->info.enums.count, "enums");
This clearly manifests in MSVC. When it does not on a given compiler, let's say GCC, I suspect a memory ordering artifact to cover this bug up.