### PR TITLE
libyang REFACTOR prefix format always decides the callback

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -459,22 +459,6 @@ LY_ERR ly_parse_instance_predicate(const char **pred, size_t limit, LYD_FORMAT f
                                    const char **value, size_t *value_len, const char **errmsg);
 
 /**
- * @brief ly_get_prefix_clb implementation for JSON. For its simplicity, this implementation is used
- * internally for various purposes.
- *
- * Implemented in printer_json.c
- */
-const char *json_print_get_prefix(const struct lys_module *mod, void *private);
-
-/**
- * @brief ly_type_resolve_prefix implementation for JSON. For its simplicity, this implementation is used
- * internally for various purposes.
- *
- * Implemented in parser_json.c
- */
-const struct lys_module *lydjson_resolve_prefix(const struct ly_ctx *ctx, const char *prefix, size_t prefix_len, void *parser);
-
-/**
  * @brief mmap(2) wrapper to map input files into memory to unify parsing.
  *
  * The address space is allocate only for reading.

--- a/src/context.c
+++ b/src/context.c
@@ -560,7 +560,7 @@ ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, cons
     /* compile */
     oper = output ? LY_PATH_OPER_OUTPUT : LY_PATH_OPER_INPUT;
     ret = ly_path_compile(ctx, NULL, ctx_node, exp, LY_PATH_LREF_FALSE, oper, LY_PATH_TARGET_MANY,
-                          lydjson_resolve_prefix, NULL, LYD_JSON, &p);
+                          LY_PREF_JSON, NULL, &p);
     LY_CHECK_GOTO(ret, cleanup);
 
     /* get last node */

--- a/src/lyb.h
+++ b/src/lyb.h
@@ -71,7 +71,6 @@ struct lyd_lyb_ctx {
 
     /* callbacks */
     lyd_ctx_free_clb free;           /* destructor */
-    ly_resolve_prefix_clb resolve_prefix;
 
     struct lylyb_ctx *lybctx;      /* lyb format context */
 };

--- a/src/parser.c
+++ b/src/parser.c
@@ -407,12 +407,11 @@ lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *snode)
 
 LY_ERR
 lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-                       int *dynamic, int value_hints, ly_resolve_prefix_clb get_prefix, void *prefix_data,
-                       LYD_FORMAT format, struct lyd_node **node)
+                       int *dynamic, int value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
 {
     LY_ERR ret;
 
-    ret = lyd_create_term(schema, value, value_len, dynamic, value_hints, get_prefix, prefix_data, format, node);
+    ret = lyd_create_term(schema, value, value_len, dynamic, value_hints, format, prefix_data, node);
     if (ret == LY_EINCOMPLETE) {
         if (!(lydctx->parse_options & LYD_PARSE_ONLY)) {
             ly_set_add(&lydctx->unres_node_type, *node, LY_SET_OPT_USEASLIST);
@@ -425,10 +424,11 @@ lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, c
 LY_ERR
 lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod,
                        const char *name, size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hints,
-                       ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format, const struct lysc_node *ctx_snode)
+                       LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode)
 {
     LY_ERR ret;
-    ret = lyd_create_meta(parent, meta, mod, name, name_len, value, value_len, dynamic, value_hints, resolve_prefix, prefix_data, format, ctx_snode);
+    ret = lyd_create_meta(parent, meta, mod, name, name_len, value, value_len, dynamic, value_hints, format, prefix_data,
+                          ctx_snode);
     if (ret == LY_EINCOMPLETE) {
         ly_set_add(&lydctx->unres_meta_type, *meta, LY_SET_OPT_USEASLIST);
         ret = LY_SUCCESS;

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -16,6 +16,7 @@
 #define LY_PARSER_INTERNAL_H_
 
 #include "parser.h"
+#include "plugins_types.h"
 #include "tree_schema_internal.h"
 
 /**
@@ -24,11 +25,12 @@
 #define LYD_PARSE_OPTS_MASK    0xFFFF0000
 
 /**
- * @brief Mask for checking LYD_VALIDATEP_ options (@ref datavalidationoptions)
+ * @brief Mask for checking LYD_VALIDATE_ options (@ref datavalidationoptions)
  */
 #define LYD_VALIDATE_OPTS_MASK 0x0000FFFF
 
 struct lyd_ctx;
+
 /**
  * @brief Callback for lyd_ctx to free the structure
  *
@@ -53,7 +55,6 @@ struct lyd_ctx {
 
     /* callbacks */
     lyd_ctx_free_clb free;             /* destructor */
-    ly_resolve_prefix_clb resolve_prefix;
 
     struct {
         const struct ly_ctx *ctx;
@@ -170,8 +171,7 @@ LY_ERR lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *s
  * @param[in] value_hints Data parser's hint for the value's type.
  */
 LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-                              int *dynamic, int value_hints, ly_resolve_prefix_clb get_prefix, void *prefix_data,
-                              LYD_FORMAT format, struct lyd_node **node);
+                              int *dynamic, int value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
 
 /**
  * @brief Wrapper around lyd_create_meta() for data parsers.
@@ -179,8 +179,9 @@ LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *sc
  * @param[in] lydctx Data parser context.
  * @param[in] value_hints [Value hint](@ref lydvalueparseopts) from the parser regarding the value type.
  */
-LY_ERR lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod,
-                              const char *name, size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hints,
-                              ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format, const struct lysc_node *ctx_snode);
+LY_ERR lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta,
+                              const struct lys_module *mod, const char *name, size_t name_len, const char *value,
+                              size_t value_len, int *dynamic, int value_hints, LY_PREFIX_FORMAT format,
+                              void *prefix_data, const struct lysc_node *ctx_snode);
 
 #endif /* LY_PARSER_INTERNAL_H_ */

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -380,8 +380,8 @@ lyb_parse_metadata(struct lyd_lyb_ctx *lybctx, const struct lysc_node *sparent, 
         dynamic = 1;
 
         /* create metadata */
-        ret = lyd_parser_create_meta((struct lyd_ctx*)lybctx, NULL, meta, mod, meta_name, strlen(meta_name), meta_value, ly_strlen(meta_value),
-                                     &dynamic, 0, lydjson_resolve_prefix, NULL, LYD_JSON, sparent);
+        ret = lyd_parser_create_meta((struct lyd_ctx *)lybctx, NULL, meta, mod, meta_name, strlen(meta_name), meta_value,
+                                     ly_strlen(meta_value), &dynamic, 0, LY_PREF_JSON, NULL, sparent);
 
         /* free strings */
         free(meta_name);
@@ -767,8 +767,8 @@ lyb_parse_subtree_r(struct lyd_lyb_ctx *lybctx, struct lyd_node_inner *parent, s
         dynamic = 1;
 
         /* create node */
-        ret = lyd_parser_create_term((struct lyd_ctx*)lybctx, snode, value, ly_strlen(value), &dynamic, 0,
-                                     lydjson_resolve_prefix, NULL, LYD_JSON, &node);
+        ret = lyd_parser_create_term((struct lyd_ctx *)lybctx, snode, value, ly_strlen(value), &dynamic, 0,
+                                     LY_PREF_JSON, NULL, &node);
         if (dynamic) {
             free(value);
             dynamic = 0;

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -69,7 +69,7 @@ yin_match_keyword(struct lys_yin_parser_ctx *ctx, const char *name, size_t name_
         return LY_STMT_NONE;
     }
 
-    ns = lyxml_ns_get(ctx->xmlctx, prefix, prefix_len);
+    ns = lyxml_ns_get(&ctx->xmlctx->ns, prefix, prefix_len);
     if (ns) {
         if (!IS_YIN_NS(ns->uri)) {
             return LY_STMT_EXTENSION_INSTANCE;
@@ -2738,7 +2738,7 @@ yin_check_relative_order(struct lys_yin_parser_ctx *ctx, enum ly_stmt kw, enum l
 static const char *
 name2nsname(struct lys_yin_parser_ctx *ctx, const char *name, size_t name_len, const char *prefix, size_t prefix_len)
 {
-    const struct lyxml_ns *ns = lyxml_ns_get(ctx->xmlctx, prefix, prefix_len);
+    const struct lyxml_ns *ns = lyxml_ns_get(&ctx->xmlctx->ns, prefix, prefix_len);
     LY_CHECK_ERR_RET(!ns, LOGINT(ctx->xmlctx->ctx), NULL);
 
     if (!strcmp(ns->uri, YIN_NS_URI)) {

--- a/src/path.c
+++ b/src/path.c
@@ -353,9 +353,8 @@ error:
  * @param[in] expr Parsed path.
  * @param[in] tok_idx Index in @p expr.
  * @param[in] lref Lref option.
- * @param[in] resolve_prefix Callback for prefix resolution.
- * @param[in] prefix_data Data for @p resolve_prefix.
  * @param[in] format Format of the path.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes.
  * @param[out] mod Resolved module.
  * @param[out] name Parsed node name.
  * @param[out] name_len Length of @p name.
@@ -364,8 +363,8 @@ error:
 static LY_ERR
 ly_path_compile_prefix(const struct ly_ctx *ctx, const struct lysc_node *cur_node, const struct lys_module *cur_mod,
                        const struct lysc_node *prev_ctx_node, const struct lyxp_expr *expr, uint16_t tok_idx,
-                       uint8_t lref, ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format,
-                       const struct lys_module **mod, const char **name, size_t *name_len)
+                       uint8_t lref, LY_PREFIX_FORMAT format, void *prefix_data, const struct lys_module **mod,
+                       const char **name, size_t *name_len)
 {
     const char *ptr;
     size_t len;
@@ -378,7 +377,7 @@ ly_path_compile_prefix(const struct ly_ctx *ctx, const struct lysc_node *cur_nod
 
     /* find next node module */
     if (ptr) {
-        *mod = resolve_prefix(ctx, expr->expr + expr->tok_pos[tok_idx], len, prefix_data);
+        *mod = ly_resolve_prefix(ctx, expr->expr + expr->tok_pos[tok_idx], len, format, prefix_data);
         if (!*mod) {
             LOGVAL_P(ctx, cur_node, LYVE_XPATH, "Prefix \"%.*s\" not found of a module in path.",
                      len, expr->expr + expr->tok_pos[tok_idx]);
@@ -392,17 +391,16 @@ ly_path_compile_prefix(const struct ly_ctx *ctx, const struct lysc_node *cur_nod
         }
     } else {
         switch (format) {
-        case LYD_SCHEMA:
+        case LY_PREF_SCHEMA:
             *mod = cur_mod;
             break;
-        case LYD_JSON:
+        case LY_PREF_JSON:
             if (!prev_ctx_node) {
                 LOGINT_RET(ctx);
             }
             *mod = prev_ctx_node->module;
             break;
-        case LYD_XML:
-        case LYD_LYB:
+        case LY_PREF_XML:
             /* not really defined */
             LOGINT_RET(ctx);
         }
@@ -423,8 +421,8 @@ ly_path_compile_prefix(const struct ly_ctx *ctx, const struct lysc_node *cur_nod
 LY_ERR
 ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_node, const struct lys_module *cur_mod,
                           const struct lysc_node *ctx_node, const struct lyxp_expr *expr, uint16_t *tok_idx,
-                          ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format,
-                          struct ly_path_predicate **predicates, enum ly_path_pred_type *pred_type)
+                          LY_PREFIX_FORMAT format, void *prefix_data, struct ly_path_predicate **predicates,
+                          enum ly_path_pred_type *pred_type)
 {
     struct ly_path_predicate *p;
     const struct lysc_node *key;
@@ -456,7 +454,7 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
         do {
             /* NameTest, find the key */
             LY_CHECK_RET(ly_path_compile_prefix(ctx, cur_node, cur_mod, ctx_node, expr, *tok_idx, LY_PATH_LREF_FALSE,
-                                                resolve_prefix, prefix_data, format, &mod, &name, &name_len));
+                                                format, prefix_data, &mod, &name, &name_len));
             key = lys_find_child(ctx_node, mod, name, name_len, 0, LYS_GETNEXT_NOSTATECHECK);
             if (!key) {
                 LOGVAL_P(ctx, cur_node, LYVE_XPATH, "Not found node \"%.*s\" in path.", name_len, name);
@@ -483,7 +481,7 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
             /* Literal */
             assert(expr->tokens[*tok_idx] == LYXP_TOKEN_LITERAL);
             LY_CHECK_RET(lyd_value_store(&p->value, key, expr->expr + expr->tok_pos[*tok_idx] + 1,
-                                         expr->tok_len[*tok_idx] - 2, NULL, resolve_prefix, prefix_data, format));
+                                         expr->tok_len[*tok_idx] - 2, NULL, format, prefix_data));
             ++(*tok_idx);
 
             /* ']' */
@@ -526,7 +524,7 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
         assert(expr->tokens[*tok_idx] == LYXP_TOKEN_LITERAL);
         /* store the value */
         LY_CHECK_RET(lyd_value_store(&p->value, ctx_node, expr->expr + expr->tok_pos[*tok_idx] + 1,
-                                     expr->tok_len[*tok_idx] - 2, NULL, resolve_prefix, prefix_data, format));
+                                     expr->tok_len[*tok_idx] - 2, NULL, format, prefix_data));
         ++(*tok_idx);
 
         /* ']' */
@@ -567,15 +565,13 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
  * @param[in] cur_node Current (original context) node.
  * @param[in] expr Parsed path.
  * @param[in,out] tok_idx Index in @p expr, is adjusted for parsed tokens.
- * @param[in] resolve_prefix Callback for prefix resolution.
- * @param[in] prefix_data Data for @p resolve_prefix.
  * @param[in] format Format of the path.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes.
  * @return LY_ERR value.
  */
 static LY_ERR
 ly_path_compile_predicate_leafref(const struct lysc_node *ctx_node, const struct lysc_node *cur_node,
-                                  const struct lyxp_expr *expr, uint16_t *tok_idx, ly_resolve_prefix_clb resolve_prefix,
-                                  void *prefix_data, LYD_FORMAT format)
+                                  const struct lyxp_expr *expr, uint16_t *tok_idx, LY_PREFIX_FORMAT format, void *prefix_data)
 {
     const struct lysc_node *key, *node, *node2;
     const struct lys_module *mod;
@@ -601,7 +597,7 @@ ly_path_compile_predicate_leafref(const struct lysc_node *ctx_node, const struct
     do {
         /* NameTest, find the key */
         LY_CHECK_RET(ly_path_compile_prefix(cur_node->module->ctx, cur_node, cur_node->module, ctx_node, expr, *tok_idx,
-                                            LY_PATH_LREF_TRUE, resolve_prefix, prefix_data, format, &mod, &name, &name_len));
+                                            LY_PATH_LREF_TRUE, format, prefix_data, &mod, &name, &name_len));
         key = lys_find_child(ctx_node, mod, name, name_len, 0, LYS_GETNEXT_NOSTATECHECK);
         if (!key) {
             LOGVAL_P(cur_node->module->ctx, cur_node, LYVE_XPATH, "Not found node \"%.*s\" in path.", name_len, name);
@@ -660,7 +656,7 @@ ly_path_compile_predicate_leafref(const struct lysc_node *ctx_node, const struct
             /* NameTest */
             assert(expr->tokens[*tok_idx] == LYXP_TOKEN_NAMETEST);
             LY_CHECK_RET(ly_path_compile_prefix(cur_node->module->ctx, cur_node, cur_node->module, node, expr, *tok_idx,
-                                                LY_PATH_LREF_TRUE, resolve_prefix, prefix_data, format, &mod, &name, &name_len));
+                                                LY_PATH_LREF_TRUE, format, prefix_data, &mod, &name, &name_len));
             node2 = lys_find_child(node, mod, name, name_len, 0, LYS_GETNEXT_NOSTATECHECK);
             if (!node2) {
                 LOGVAL_P(cur_node->module->ctx, cur_node, LYVE_XPATH, "Not found node \"%.*s\" in path.", name_len, name);
@@ -693,8 +689,8 @@ ly_path_compile_predicate_leafref(const struct lysc_node *ctx_node, const struct
 
 LY_ERR
 ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mod, const struct lysc_node *ctx_node,
-                const struct lyxp_expr *expr, uint8_t lref, uint8_t oper, uint8_t target,
-                ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format, struct ly_path **path)
+                const struct lyxp_expr *expr, uint8_t lref, uint8_t oper, uint8_t target, LY_PREFIX_FORMAT format,
+                void *prefix_data, struct ly_path **path)
 {
     LY_ERR ret = LY_SUCCESS;
     uint16_t tok_idx = 0;
@@ -760,8 +756,8 @@ ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mod, cons
         }
 
         /* get module and node name */
-        LY_CHECK_GOTO(ret = ly_path_compile_prefix(ctx, cur_node, cur_mod, ctx_node, expr, tok_idx, lref, resolve_prefix,
-                                                   prefix_data, format, &mod, &name, &name_len), cleanup);
+        LY_CHECK_GOTO(ret = ly_path_compile_prefix(ctx, cur_node, cur_mod, ctx_node, expr, tok_idx, lref, format,
+                                                   prefix_data, &mod, &name, &name_len), cleanup);
         ++tok_idx;
 
         /* find the next node */
@@ -779,10 +775,10 @@ ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mod, cons
 
         /* compile any predicates */
         if (lref == LY_PATH_LREF_TRUE) {
-            ret = ly_path_compile_predicate_leafref(ctx_node, cur_node, expr, &tok_idx, resolve_prefix, prefix_data, format);
+            ret = ly_path_compile_predicate_leafref(ctx_node, cur_node, expr, &tok_idx, format, prefix_data);
         } else {
-            ret = ly_path_compile_predicate(ctx, cur_node, cur_mod, ctx_node, expr, &tok_idx, resolve_prefix,
-                                            prefix_data, format, &p->predicates, &p->pred_type);
+            ret = ly_path_compile_predicate(ctx, cur_node, cur_mod, ctx_node, expr, &tok_idx, format, prefix_data,
+                                            &p->predicates, &p->pred_type);
         }
         LY_CHECK_GOTO(ret, cleanup);
     } while (!lyxp_next_token(NULL, expr, &tok_idx, LYXP_TOKEN_OPER_PATH));

--- a/src/path.c
+++ b/src/path.c
@@ -354,7 +354,7 @@ error:
  * @param[in] tok_idx Index in @p expr.
  * @param[in] lref Lref option.
  * @param[in] format Format of the path.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[out] mod Resolved module.
  * @param[out] name Parsed node name.
  * @param[out] name_len Length of @p name.
@@ -566,7 +566,7 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
  * @param[in] expr Parsed path.
  * @param[in,out] tok_idx Index in @p expr, is adjusted for parsed tokens.
  * @param[in] format Format of the path.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @return LY_ERR value.
  */
 static LY_ERR

--- a/src/path.h
+++ b/src/path.h
@@ -152,15 +152,14 @@ LY_ERR ly_path_parse_predicate(const struct ly_ctx *ctx, const struct lysc_node 
  * @param[in] lref Lref option (@ref path_lref_options).
  * @param[in] oper Oper option (@ref path_oper_options).
  * @param[in] target Target option (@ref path_target_options).
- * @param[in] resolve_prefix Callback for prefix resolution.
- * @param[in] prefix_data Data for @p resolve_prefix.
  * @param[in] format Format of the path.
+ * @param[in] prefix_data Data for resolving any prefixes.
  * @param[out] path Compiled path.
  * @return LY_ERR value.
  */
 LY_ERR ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mod, const struct lysc_node *ctx_node,
                        const struct lyxp_expr *expr, uint8_t lref, uint8_t oper, uint8_t target,
-                       ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format, struct ly_path **path);
+                       LY_PREFIX_FORMAT format, void *prefix_data, struct ly_path **path);
 
 /**
  * @brief Compile predicate into ly_path_predicate structure. Only simple predicates (not leafref) are supported.
@@ -171,17 +170,16 @@ LY_ERR ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mo
  * @param[in] ctx_node Context node, node for which the predicate is defined.
  * @param[in] expr Parsed path.
  * @param[in,out] tok_idx Index in @p expr, is adjusted for parsed tokens.
- * @param[in] resolve_prefix Callback for prefix resolution.
- * @param[in] prefix_data Data for @p resolve_prefix.
  * @param[in] format Format of the path.
+ * @param[in] prefix_data Data for resolving any prefixes.
  * @param[out] predicates Compiled predicates.
  * @param[out] pred_type Type of the compiled predicate(s).
  * @return LY_ERR value.
  */
 LY_ERR ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_node, const struct lys_module *cur_mod,
                                  const struct lysc_node *ctx_node, const struct lyxp_expr *expr, uint16_t *tok_idx,
-                                 ly_resolve_prefix_clb resolve_prefix, void *prefix_data, LYD_FORMAT format,
-                                 struct ly_path_predicate **predicates, enum ly_path_pred_type *pred_type);
+                                 LY_PREFIX_FORMAT format, void *prefix_data, struct ly_path_predicate **predicates,
+                                 enum ly_path_pred_type *pred_type);
 
 /**
  * @brief Resolve at least partially the target defined by ly_path structure. Not supported for leafref!

--- a/src/path.h
+++ b/src/path.h
@@ -153,7 +153,7 @@ LY_ERR ly_path_parse_predicate(const struct ly_ctx *ctx, const struct lysc_node 
  * @param[in] oper Oper option (@ref path_oper_options).
  * @param[in] target Target option (@ref path_target_options).
  * @param[in] format Format of the path.
- * @param[in] prefix_data Data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[out] path Compiled path.
  * @return LY_ERR value.
  */
@@ -171,7 +171,7 @@ LY_ERR ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mo
  * @param[in] expr Parsed path.
  * @param[in,out] tok_idx Index in @p expr, is adjusted for parsed tokens.
  * @param[in] format Format of the path.
- * @param[in] prefix_data Data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[out] predicates Compiled predicates.
  * @param[out] pred_type Type of the compiled predicate(s).
  * @return LY_ERR value.

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -190,7 +190,7 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format,
  * @param[in] value_len Length (number of bytes) of the given \p value.
  * @param[in] options [Type plugin options](@ref plugintypeopts).
  * @param[in] format Input format of the data.
- * @param[in] prefix_data Parser's resolve data for the format-specific callback.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[in] context_node The @p value's node for the case that the require-instance restriction is supposed to be resolved.
  *            This argument is a lys_node (in case LY_TYPE_OPTS_INCOMPLETE_DATA or LY_TYPE_OPTS_SCHEMA set in @p options)
  *            or lyd_node structure.
@@ -234,7 +234,7 @@ typedef LY_ERR (*ly_type_compare_clb)(const struct lyd_value *val1, const struct
  * @param[in] value Value to print.
  * @param[in] format Format in which the data are supposed to be printed.
  *            Only 2 formats are currently implemented: LYD_XML and LYD_JSON.
- * @param[in] prefix_data Private data for the format-specific callback.
+ * @param[in] prefix_data Format-specific data for getting any prefixes (see ::ly_get_prefix).
  * @param[out] dynamic Flag if the returned string is dynamically allocated. In such a case the caller is responsible
  *            for freeing it.
  * @return String with the value of @p value in specified @p format. According to the returned @p dynamic flag, caller

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -103,35 +103,35 @@ struct ly_err_item *ly_err_new(LY_LOG_LEVEL level, LY_ERR code, LY_VECODE vecode
 void ly_err_free(void *ptr);
 
 /**
- * @brief Callback provided by the data/schema parsers to type plugins to resolve (format-specific) mapping between prefixes used
- * in the value strings to the YANG schemas.
+ * @brief Resolve format-specific prefixes to modules.
  *
- * Reverse function to ly_clb_get_prefix.
- *
- * XML uses XML namespaces, JSON uses schema names as prefixes, YIN/YANG uses prefixes of the imports.
- *
- * @param[in] ctx libyang context to find the schema.
- * @param[in] prefix Prefix found in the value string
- * @param[in] prefix_len Length of the @p prefix.
- * @param[in] private Internal data needed by the callback.
- * @return Pointer to the YANG schema identified by the provided prefix or NULL if no mapping found.
+ * @param[in] ctx libyang context.
+ * @param[in] prefix Prefix to resolve.
+ * @param[in] prefix_len Length of @p prefix.
+ * @param[in] format Format of the prefix.
+ * @param[in] prefix_data Format-specific data:
+ *      LY_PREF_SCHEMA  - const struct lys_module * (local module)
+ *      LY_PREF_XML     - const struct ly_set * (set with used namespaces)
+ *      LY_PREF_JSON    - NULL
+ * @return Resolved prefix module,
+ * @return NULL otherwise.
  */
-typedef const struct lys_module *(*ly_clb_resolve_prefix)(const struct ly_ctx *ctx, const char *prefix, size_t prefix_len,
-                                                          void *private);
+const struct lys_module *ly_resolve_prefix(const struct ly_ctx *ctx, const char *prefix, size_t prefix_len,
+                                           LY_PREFIX_FORMAT format, void *prefix_data);
 
 /**
- * @brief Callback provided by the data/schema printers to type plugins to resolve (format-specific) mapping between YANG module of a data object
- * to prefixes used in the value strings.
+ * @brief Get format-specific prefix for a module.
  *
- * Reverse function to ly_clb_resolve_prefix.
- *
- * XML uses XML namespaces, JSON uses schema names as prefixes, YIN/YANG uses prefixes of the imports.
- *
- * @param[in] mod YANG module of the object.
- * @param[in] private Internal data needed by the callback.
- * @return String representing prefix for the object of the given YANG module @p mod.
+ * @param[in] mod Module whose prefix to get.
+ * @param[in] format Format of the prefix.
+ * @param[in] prefix_data Format-specific data:
+ *      LY_PREF_SCHEMA  - const struct lys_module * (local module)
+ *      LY_PREF_XML     - struct ly_set * (set of used namespaces)
+ *      LY_PREF_JSON    - NULL
+ * @return Module prefix to print.
+ * @return NULL on error.
  */
-typedef const char *(*ly_clb_get_prefix)(const struct lys_module *mod, void *private);
+const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format, void *prefix_data);
 
 /**
  * @defgroup plugintypeopts Options for type plugin callbacks. The same set of the options is passed to all the type's callbacks used together.
@@ -189,9 +189,8 @@ typedef const char *(*ly_clb_get_prefix)(const struct lys_module *mod, void *pri
  *            It is never NULL, empty string is represented as "" with zero @p value_len.
  * @param[in] value_len Length (number of bytes) of the given \p value.
  * @param[in] options [Type plugin options](@ref plugintypeopts).
- * @param[in] resolve_prefix Parser-specific callback to resolve prefixes used in the value strings.
- * @param[in] parser Parser's data for @p resolve_prefix
  * @param[in] format Input format of the data.
+ * @param[in] prefix_data Parser's resolve data for the format-specific callback.
  * @param[in] context_node The @p value's node for the case that the require-instance restriction is supposed to be resolved.
  *            This argument is a lys_node (in case LY_TYPE_OPTS_INCOMPLETE_DATA or LY_TYPE_OPTS_SCHEMA set in @p options)
  *            or lyd_node structure.
@@ -209,9 +208,9 @@ typedef const char *(*ly_clb_get_prefix)(const struct lys_module *mod, void *pri
  * @return LY_ERR value if an error occurred and the value could not be canonized following the type's rules.
  */
 typedef LY_ERR (*ly_type_store_clb)(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len,
-                                    int options, ly_resolve_prefix_clb resolve_prefix, void *parser, LYD_FORMAT format,
-                                    const void *context_node, const struct lyd_node *tree,
-                                    struct lyd_value *storage, const char **canonized, struct ly_err_item **err);
+                                    int options, LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node,
+                                    const struct lyd_node *tree, struct lyd_value *storage, const char **canonized,
+                                    struct ly_err_item **err);
 
 /**
  * @brief Callback for comparing 2 values of the same type.
@@ -235,16 +234,15 @@ typedef LY_ERR (*ly_type_compare_clb)(const struct lyd_value *val1, const struct
  * @param[in] value Value to print.
  * @param[in] format Format in which the data are supposed to be printed.
  *            Only 2 formats are currently implemented: LYD_XML and LYD_JSON.
- * @param[in] get_prefix Callback to get prefix to use when printing objects supposed to be prefixed.
- * @param[in] printer Private data for the @p get_prefix callback.
+ * @param[in] prefix_data Private data for the format-specific callback.
  * @param[out] dynamic Flag if the returned string is dynamically allocated. In such a case the caller is responsible
  *            for freeing it.
  * @return String with the value of @p value in specified @p format. According to the returned @p dynamic flag, caller
  *         can be responsible for freeing allocated memory.
  * @return NULL in case of error.
  */
-typedef const char *(*ly_type_print_clb)(const struct lyd_value *value, LYD_FORMAT format, ly_get_prefix_clb get_prefix,
-                                         void *printer, int *dynamic);
+typedef const char *(*ly_type_print_clb)(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
+                                         int *dynamic);
 
 /**
  * @brief Callback to duplicate data in data structure. Note that callback is even responsible for duplicating lyd_value::canonized.
@@ -359,7 +357,8 @@ LY_ERR ly_type_identity_isderived(struct lysc_ident *base, struct lysc_ident *de
  * @param[out] err Error information in case of failure. The error structure can be freed by ly_err_free().
  * @return LY_ERR value according to the result of the validation.
  */
-LY_ERR ly_type_validate_range(LY_DATA_TYPE basetype, struct lysc_range *range, int64_t value, const char *strval, struct ly_err_item **err);
+LY_ERR ly_type_validate_range(LY_DATA_TYPE basetype, struct lysc_range *range, int64_t value, const char *strval,
+                              struct ly_err_item **err);
 
 /**
  * @brief Data type validator for pattern-restricted string values.
@@ -388,19 +387,6 @@ LY_ERR ly_type_validate_patterns(struct lysc_pattern **patterns, const char *str
  */
 LY_ERR ly_type_find_leafref(const struct lysc_type_leafref *lref, const struct lyd_node *node, struct lyd_value *value,
                             const struct lyd_node *tree, struct lyd_node **target, char **errmsg);
-
-/**
- * @brief Helper function for type validation callbacks to prepare list of all possible prefixes used in the value string.
- *
- * @param[in] ctx libyang context.
- * @param[in] value Value string to be parsed.
- * @param[in] value_len Length of the @p value string.
- * @param[in] get_prefix Parser-specific getter to resolve prefixes used in the value strings.
- * @param[in] parser Parser's data for @p get_prefix.
- * @return Created [sized array](@ref sizedarrays) of prefix mappings, NULL in case of error.
- */
-struct lyd_value_prefix *ly_type_get_prefixes(const struct ly_ctx *ctx, const char *value, size_t value_len,
-                                              ly_resolve_prefix_clb get_prefix, void *parser);
 
 /** @} types */
 

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -111,7 +111,7 @@ void ly_err_free(void *ptr);
  * @param[in] format Format of the prefix.
  * @param[in] prefix_data Format-specific data:
  *      LY_PREF_SCHEMA  - const struct lys_module * (local module)
- *      LY_PREF_XML     - const struct ly_set * (set with used namespaces)
+ *      LY_PREF_XML     - const struct ly_set * (set with defined namespaces stored as ::lyxml_ns)
  *      LY_PREF_JSON    - NULL
  * @return Resolved prefix module,
  * @return NULL otherwise.
@@ -126,7 +126,7 @@ const struct lys_module *ly_resolve_prefix(const struct ly_ctx *ctx, const char 
  * @param[in] format Format of the prefix.
  * @param[in] prefix_data Format-specific data:
  *      LY_PREF_SCHEMA  - const struct lys_module * (local module)
- *      LY_PREF_XML     - struct ly_set * (set of used namespaces)
+ *      LY_PREF_XML     - struct ly_set * (set of all returned modules as ::struct lys_module)
  *      LY_PREF_JSON    - NULL
  * @return Module prefix to print.
  * @return NULL on error.

--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -22,6 +22,7 @@
 #include "printer.h"
 #include "printer_internal.h"
 #include "tree_data.h"
+#include "tree_schema.h"
 
 static LY_ERR
 lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options)
@@ -38,9 +39,9 @@ lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, i
     case LYD_LYB:
         ret = lyb_print_data(out, root, options);
         break;
-    case LYD_SCHEMA:
-        LOGERR(out->ctx, LY_EINVAL, "Invalid output format.");
-        ret = LY_EINVAL;
+    case LYD_UNKNOWN:
+        LOGINT(root ? LYD_NODE_CTX(root) : NULL);
+        ret = LY_EINT;
         break;
     }
 

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -57,17 +57,6 @@ struct jsonpr_ctx {
 static LY_ERR json_print_node(struct jsonpr_ctx *ctx, const struct lyd_node *node);
 
 /**
- * @brief JSON mapping of YANG modules to prefixes in values.
- *
- * Implementation of ly_get_prefix_clb.
- */
-const char *
-json_print_get_prefix(const struct lys_module *mod, void *UNUSED(private))
-{
-    return mod->name;
-}
-
-/**
  * Compare 2 nodes, despite it is regular data node or an opaq node, and
  * decide if they corresponds to the same schema node.
  *
@@ -174,8 +163,8 @@ node_prefix(const struct lyd_node *node)
                 return NULL;
             }
             return mod->name;
-        case LYD_SCHEMA:
         case LYD_LYB:
+        case LYD_UNKNOWN:
             /* cannot be created */
             LOGINT(LYD_NODE_CTX(node));
         }
@@ -317,8 +306,8 @@ json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FO
                 module_name = mod->name;
             }
             break;
-        case LYD_SCHEMA:
         case LYD_LYB:
+        case LYD_UNKNOWN:
             /* cannot be created */
             LOGINT_RET(ctx->ctx);
         }
@@ -345,7 +334,7 @@ static LY_ERR
 json_print_value(struct jsonpr_ctx *ctx, const struct lyd_value *val)
 {
     int dynamic = 0;
-    const char *value = val->realtype->plugin->print(val, LYD_JSON, json_print_get_prefix, NULL, &dynamic);
+    const char *value = val->realtype->plugin->print(val, LY_PREF_JSON, NULL, &dynamic);
 
     /* leafref is not supported */
     switch (val->realtype->basetype) {

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -119,27 +119,13 @@ xml_print_ns_opaq(struct xmlpr_ctx *ctx, LYD_FORMAT format, const struct ly_pref
             }
         }
         break;
-    case LYD_SCHEMA:
     case LYD_LYB:
+    case LYD_UNKNOWN:
         /* cannot be created */
         LOGINT(ctx->ctx);
     }
 
     return NULL;
-}
-
-/**
- * @brief XML mapping of YANG modules to prefixes in values.
- *
- * Implementation of ly_get_prefix_clb
- */
-static const char *
-xml_print_get_prefix(const struct lys_module *mod, void *private)
-{
-    struct ly_set *ns_list = (struct ly_set*)private;
-
-    ly_set_add(ns_list, (void*)mod, 0);
-    return mod->prefix;
 }
 
 /**
@@ -181,7 +167,7 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
     }
 #endif
     for (meta = node->meta; meta; meta = meta->next) {
-        const char *value = meta->value.realtype->plugin->print(&meta->value, LYD_XML, xml_print_get_prefix, &ns_list, &dynamic);
+        const char *value = meta->value.realtype->plugin->print(&meta->value, LY_PREF_XML, &ns_list, &dynamic);
 
         /* print namespaces connected with the value's prefixes */
         for (u = 0; u < ns_list.count; ++u) {
@@ -309,7 +295,7 @@ xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
     const char *value;
 
     xml_print_node_open(ctx, (struct lyd_node *)node);
-    value = ((struct lysc_node_leaf *)node->schema)->type->plugin->print(&node->value, LYD_XML, xml_print_get_prefix, &ns_list, &dynamic);
+    value = ((struct lysc_node_leaf *)node->schema)->type->plugin->print(&node->value, LY_PREF_XML, &ns_list, &dynamic);
 
     /* print namespaces connected with the values's prefixes */
     for (u = 0; u < ns_list.count; ++u) {

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -935,7 +935,7 @@ yprc_dflt_value(struct ypr_ctx *ctx, const struct lyd_value *value, const struct
     int dynamic;
     const char *str;
 
-    str = value->realtype->plugin->print(value, LYD_JSON, lys_get_prefix, (void*)value_mod, &dynamic);
+    str = value->realtype->plugin->print(value, LY_PREF_SCHEMA, (void *)value_mod, &dynamic);
     ypr_substmt(ctx, LYEXT_SUBSTMT_DEFAULT, 0, str, exts);
     if (dynamic) {
         free((void*)str);

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -186,8 +186,10 @@ typedef enum {
 struct lyd_value_subvalue {
     struct lyd_value *value;     /**< representation of the value according to the selected union's subtype
                                       (stored as lyd_value::realpath here, in subvalue structure */
-    LY_PREFIX_FORMAT format;     /**< Prefix format of the value */
-    void *prefix_data;           /**< Format-specific data for prefix resolution */
+    LY_PREFIX_FORMAT format;     /**< Prefix format of the value. However, this information is also used to decide
+                                      whether a value is valid for the specific format or not on later validations
+                                      (instance-identifier in XML looks different than in JSON). */
+    void *prefix_data;           /**< Format-specific data for prefix resolution (see ::ly_resolve_prefix) */
     int parser_hint;             /**< Hint options from the parser */
 };
 

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -69,37 +69,6 @@ int lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_modul
 struct lyd_node **lyd_node_children_p(struct lyd_node *node);
 
 /**
- * @brief Callback provided by the data/schema parsers to type plugins to resolve (format-specific) mapping between prefixes used
- * in the value strings to the YANG schemas.
- *
- * Reverse function to ly_get_prefix_clb.
- *
- * XML uses XML namespaces, JSON uses schema names as prefixes, YIN/YANG uses prefixes of the imports.
- *
- * @param[in] ctx libyang context to find the schema.
- * @param[in] prefix Prefix found in the value string
- * @param[in] prefix_len Length of the @p prefix.
- * @param[in] data Format-specific data needed by the callback.
- * @return Pointer to the YANG schema identified by the provided prefix or NULL if no mapping found.
- */
-typedef const struct lys_module *(*ly_resolve_prefix_clb)(const struct ly_ctx *ctx, const char *prefix, size_t prefix_len,
-                                                          void *data);
-
-/**
- * @brief Callback provided by the data/schema printers to type plugins to resolve (format-specific) mapping between
- * YANG module of a data object to prefixes used in the value strings.
- *
- * Reverse function to ly_resolve_prefix_clb.
- *
- * XML uses XML namespaces, JSON uses schema names as prefixes, YIN/YANG uses prefixes of the imports.
- *
- * @param[in] mod YANG module of the object.
- * @param[in] data Format-specific data needed by the callback.
- * @return String representing prefix for the object of the given YANG module @p mod.
- */
-typedef const char *(*ly_get_prefix_clb)(const struct lys_module *mod, void *data);
-
-/**
  * @brief Just like lys_getnext() but iterates over all data instances of the schema nodes.
  *
  * @param[in] last Last returned data node.

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -127,7 +127,7 @@ struct lyd_node *lys_getnext_data(const struct lyd_node *last, const struct lyd_
  * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
  * @param[in] value_hint [Hint options](@ref lydvalueparseopts) from the parser regarding the value type.
  * @param[in] format Input format of @p value.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[out] node Created node.
  * @return LY_SUCCESS on success.
  * @return LY_EINCOMPLETE in case data tree is needed to finish the validation.
@@ -272,7 +272,7 @@ void lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta);
  * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
  * @param[in] value_hint [Value hint](@ref lydvalueparseopts) from the parser regarding the value type.
  * @param[in] format Input format of @p value.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[in] ctx_snode Context node for value resolution in schema.
  * @return LY_SUCCESS on success.
  * @return LY_EINCOMPLETE in case data tree is needed to finish the validation.
@@ -338,7 +338,7 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @param[in] second Flag for the second call after returning LY_EINCOMPLETE
  * @param[in] value_hint [Value hint](@ref lydvalueparseopts) from the parser.
  * @param[in] format Input format of @p value.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[in] tree Data tree (e.g. when validating RPC/Notification) where the required
  *            data instance (leafref target, instance-identifier) can be placed. NULL in case the data tree are not yet complete,
  *            then LY_EINCOMPLETE can be returned.
@@ -364,7 +364,7 @@ LY_ERR lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, co
  * @param[in] second Flag for the second call after returning LY_EINCOMPLETE
  * @param[in] value_hint [Value hint](@ref lydvalueparseopts) from the parser.
  * @param[in] format Input format of the data.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[in] ctx_snode Context node for value resolution in schema.
  * @param[in] tree Data tree (e.g. when validating RPC/Notification) where the required
  *            data instance (leafref target, instance-identifier) can be placed. NULL in case the data tree are not yet complete,

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -309,7 +309,7 @@ lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, int optio
     LY_CHECK_ERR_GOTO(!exp, ret = LY_EINVAL, cleanup);
 
     /* atomize expression */
-    ret = lyxp_atomize(exp, LYD_JSON, ctx_node->module, ctx_node, LYXP_NODE_ELEM, &xp_set, options);
+    ret = lyxp_atomize(exp, LY_PREF_JSON, ctx_node->module, ctx_node, LYXP_NODE_ELEM, &xp_set, options);
     LY_CHECK_GOTO(ret, cleanup);
 
     /* allocate return set */
@@ -353,7 +353,7 @@ lys_find_xpath(const struct lysc_node *ctx_node, const char *xpath, int options,
     LY_CHECK_ERR_GOTO(!exp, ret = LY_EINVAL, cleanup);
 
     /* atomize expression */
-    ret = lyxp_atomize(exp, LYD_JSON, ctx_node->module, ctx_node, LYXP_NODE_ELEM, &xp_set, options);
+    ret = lyxp_atomize(exp, LY_PREF_JSON, ctx_node->module, ctx_node, LYXP_NODE_ELEM, &xp_set, options);
     LY_CHECK_GOTO(ret, cleanup);
 
     /* allocate return set */

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -1634,46 +1634,6 @@ lysp_ext_instance_iter(struct lysp_ext_instance *ext, LY_ARRAY_COUNT_TYPE index,
     return LY_ARRAY_COUNT(ext);
 }
 
-/**
- * @brief Schema mapping of YANG modules to prefixes in values.
- *
- * Implementation of ly_get_prefix_clb. Inverse function to lys_resolve_prefix.
- *
- * In this case the @p mod is searched in the list of imports and the import's prefix
- * (not the module's itself) prefix is returned.
- */
-const char *
-lys_get_prefix(const struct lys_module *mod, void *private)
-{
-    struct lys_module *context_mod = (struct lys_module*)private;
-    LY_ARRAY_COUNT_TYPE u;
-
-    if (context_mod == mod) {
-        return context_mod->prefix;
-    }
-    LY_ARRAY_FOR(context_mod->parsed->imports, u) {
-        if (context_mod->parsed->imports[u].module == mod) {
-            /* match */
-            return context_mod->parsed->imports[u].prefix;
-        }
-    }
-
-    return NULL;
-}
-
-/**
- * @brief Schema mapping of prefix in values to YANG modules (imports).
- *
- * Implementation of ly_resolve_prefix_clb. Inverse function to lys_get_prefix().
- *
- * In this case the @p prefix is searched in the list of imports' prefixes (not the prefixes of the imported modules themselves).
- */
-const struct lys_module *
-lys_resolve_prefix(const struct ly_ctx *UNUSED(ctx), const char *prefix, size_t prefix_len, void *private)
-{
-    return lys_module_find_prefix((const struct lys_module*)private, prefix, prefix_len);
-}
-
 const struct lysc_node *
 lysc_data_parent(const struct lysc_node *schema)
 {

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -212,33 +212,6 @@ LY_ERR lysp_check_stringchar(struct lys_parser_ctx *ctx, unsigned int c);
 LY_ERR lysp_check_identifierchar(struct lys_parser_ctx *ctx, unsigned int c, int first, int *prefix);
 
 /**
- * @brief Internal structure for lys_get_prefix().
- */
-struct lys_get_prefix_data {
-    const struct lys_module *context_mod;
-    struct ly_set prefixes;
-};
-
-/**
- * @brief Schema mapping of YANG modules to prefixes in values.
- *
- * Implementation of ly_get_prefix_clb. Inverse function to lys_resolve_prefix.
- *
- * In this case the @p mod is searched in the list of imports and the import's prefix
- * (not the module's itself) prefix is returned.
- */
-const char *lys_get_prefix(const struct lys_module *mod, void *private);
-
-/**
- * @brief Schema mapping of prefix in values to YANG modules (imports).
- *
- * Implementation of ly_resolve_prefix_clb. Inverse function to lys_get_prefix().
- *
- * In this case the @p prefix is searched in the list of imports' prefixes (not the prefixes of the imported modules themselves).
- */
-const struct lys_module *lys_resolve_prefix(const struct ly_ctx *ctx, const char *prefix, size_t prefix_len, void *private);
-
-/**
  * @brief Check the currently present prefixes in the module for collision with the new one.
  *
  * @param[in] ctx Context for logging.

--- a/src/validation.h
+++ b/src/validation.h
@@ -42,7 +42,7 @@ LY_ERR lyd_val_diff_add(const struct lyd_node *node, enum lyd_diff_op op, struct
  * @param[in] node_types Set with nodes with unresolved types, can be NULL
  * @param[in] meta_types Set with metdata with unresolved types, can be NULL.
  * @param[in] format Format of the unresolved data.
- * @param[in] prefix_data Format-specific data for resolving any prefixes.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
  * @param[in,out] diff Validation diff.
  * @return LY_ERR value.
  */

--- a/src/validation.h
+++ b/src/validation.h
@@ -42,13 +42,12 @@ LY_ERR lyd_val_diff_add(const struct lyd_node *node, enum lyd_diff_op op, struct
  * @param[in] node_types Set with nodes with unresolved types, can be NULL
  * @param[in] meta_types Set with metdata with unresolved types, can be NULL.
  * @param[in] format Format of the unresolved data.
- * @param[in] get_prefix_clb Format-specific getter to resolve prefixes.
- * @param[in] parser_data Parser's data for @p get_prefix_clb.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes.
  * @param[in,out] diff Validation diff.
  * @return LY_ERR value.
  */
 LY_ERR lyd_validate_unres(struct lyd_node **tree, struct ly_set *node_when, struct ly_set *node_types, struct ly_set *meta_types,
-                          LYD_FORMAT format, ly_resolve_prefix_clb get_prefix_clb, void *parser_data, struct lyd_node **diff);
+                          LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **diff);
 
 /**
  * @brief Validate new siblings. Specifically, check duplicated instances, autodelete default values and cases.

--- a/src/xml.c
+++ b/src/xml.c
@@ -197,13 +197,13 @@ lyxml_ns_rm(struct lyxml_ctx *xmlctx)
 }
 
 const struct lyxml_ns *
-lyxml_ns_get(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_len)
+lyxml_ns_get(const struct ly_set *ns_set, const char *prefix, size_t prefix_len)
 {
     unsigned int u;
     struct lyxml_ns *ns;
 
-    for (u = xmlctx->ns.count - 1; u + 1 > 0; --u) {
-        ns = (struct lyxml_ns *)xmlctx->ns.objs[u];
+    for (u = ns_set->count - 1; u + 1 > 0; --u) {
+        ns = (struct lyxml_ns *)ns_set->objs[u];
         if (prefix && prefix_len) {
             if (ns->prefix && !ly_strncmp(ns->prefix, prefix, prefix_len)) {
                 return ns;
@@ -1097,7 +1097,7 @@ lyxml_get_prefixes(struct lyxml_ctx *xmlctx, const char *value, size_t value_len
             if (*stop == ':') {
                 /* we have a possible prefix */
                 len = stop - start;
-                ns = lyxml_ns_get(xmlctx, start, len);
+                ns = lyxml_ns_get(&xmlctx->ns, start, len);
                 if (ns) {
                     struct ly_prefix *p = NULL;
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -136,14 +136,14 @@ LY_ERR lyxml_ctx_peek(struct lyxml_ctx *xmlctx, enum LYXML_PARSER_STATUS *next);
 /**
  * @brief Get a namespace record for the given prefix in the current context.
  *
- * @param[in] xmlctx XML context to work with.
+ * @param[in] ns_set Set with namespaces from the XML context.
  * @param[in] prefix Pointer to the namespace prefix as taken from lyxml_get_attribute() or lyxml_get_element().
  * Can be NULL for default namespace.
  * @param[in] prefix_len Length of the prefix string (since it is not NULL-terminated when returned from lyxml_get_attribute() or
  * lyxml_get_element()).
  * @return The namespace record or NULL if the record for the specified prefix not found.
  */
-const struct lyxml_ns *lyxml_ns_get(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_len);
+const struct lyxml_ns *lyxml_ns_get(const struct ly_set *ns_set, const char *prefix, size_t prefix_len);
 
 /**
  * @brief Print the given @p text as XML string which replaces some of the characters which cannot appear in XML data.

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -20,6 +20,7 @@
 
 #include "config.h"
 #include "log.h"
+#include "plugins_types.h"
 #include "tree_schema.h"
 
 struct ly_ctx;
@@ -259,7 +260,7 @@ struct lyxp_set {
     const struct lysc_node *context_op;
     const struct lys_module *local_mod;
     const struct lyd_node *tree;
-    LYD_FORMAT format;
+    LY_PREFIX_FORMAT format;
 };
 
 /**
@@ -289,8 +290,9 @@ const char *lyxp_print_token(enum lyxp_token tok);
  * @return LY_EINCOMPLETE for unresolved when,
  * @return LY_EINVAL, LY_EMEM, LY_EINT for other errors.
  */
-LY_ERR lyxp_eval(struct lyxp_expr *exp, LYD_FORMAT format, const struct lys_module *local_mod, const struct lyd_node *ctx_node,
-                 enum lyxp_node_type ctx_node_type, const struct lyd_node *tree, struct lyxp_set *set, int options);
+LY_ERR lyxp_eval(struct lyxp_expr *exp, LY_PREFIX_FORMAT format, const struct lys_module *local_mod,
+                 const struct lyd_node *ctx_node, enum lyxp_node_type ctx_node_type, const struct lyd_node *tree,
+                 struct lyxp_set *set, int options);
 
 #define LYXP_SCHEMA 0x01        /**< Apply data node access restrictions defined for 'when' and 'must' evaluation. */
 
@@ -308,8 +310,9 @@ LY_ERR lyxp_eval(struct lyxp_expr *exp, LYD_FORMAT format, const struct lys_modu
  * @param[in] options Whether to apply some evaluation restrictions, one flag must always be used.
  * @return LY_ERR (same as lyxp_eval()).
  */
-LY_ERR lyxp_atomize(struct lyxp_expr *exp, LYD_FORMAT format, const struct lys_module *local_mod, const struct lysc_node *ctx_scnode,
-                    enum lyxp_node_type ctx_scnode_type, struct lyxp_set *set, int options);
+LY_ERR lyxp_atomize(struct lyxp_expr *exp, LY_PREFIX_FORMAT format, const struct lys_module *local_mod,
+                    const struct lysc_node *ctx_scnode, enum lyxp_node_type ctx_scnode_type, struct lyxp_set *set,
+                    int options);
 
 /* used only internally */
 #define LYXP_SCNODE_ALL 0x0E

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -296,7 +296,7 @@ test_target(void **state)
     assert_int_equal(LY_SUCCESS, ly_path_parse(ctx, NULL, path_str, strlen(path_str), LY_PATH_BEGIN_EITHER, LY_PATH_LREF_FALSE,
                                                LY_PATH_PREFIX_OPTIONAL, LY_PATH_PRED_SIMPLE, &exp));
     assert_int_equal(LY_SUCCESS, ly_path_compile(ctx, NULL, NULL, exp, LY_PATH_LREF_FALSE, LY_PATH_OPER_INPUT,
-                                                 LY_PATH_TARGET_SINGLE, lydjson_resolve_prefix, NULL, LYD_JSON, &path));
+                                                 LY_PATH_TARGET_SINGLE, LY_PREF_JSON, NULL, &path));
     term = lyd_target(path, tree);
 
     assert_string_equal(term->schema->name, "d");

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -246,16 +246,16 @@ test_node_leaflist(void **state)
     assert_non_null(ll->dflts);
     assert_int_equal(6, ll->type->refcount); /* 3x type's reference, 3x default value's reference (typedef's default does not reference own type) */
     assert_int_equal(2, LY_ARRAY_COUNT(ll->dflts));
-    assert_string_equal("1", dflt = ll->dflts[0]->realtype->plugin->print(ll->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("1", dflt = ll->dflts[0]->realtype->plugin->print(ll->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
-    assert_string_equal("1", dflt = ll->dflts[1]->realtype->plugin->print(ll->dflts[1], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("1", dflt = ll->dflts[1]->realtype->plugin->print(ll->dflts[1], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(LYS_CONFIG_R | LYS_STATUS_CURR | LYS_ORDBY_SYSTEM | LYS_SET_DFLT | LYS_SET_CONFIG, ll->flags);
     assert_non_null((ll = (struct lysc_node_leaflist*)mod->compiled->data->next));
     assert_non_null(ll->dflts);
     assert_int_equal(6, ll->type->refcount); /* 3x type's reference, 3x default value's reference */
     assert_int_equal(1, LY_ARRAY_COUNT(ll->dflts));
-    assert_string_equal("10", dflt = ll->dflts[0]->realtype->plugin->print(ll->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("10", dflt = ll->dflts[0]->realtype->plugin->print(ll->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(LYS_CONFIG_W | LYS_STATUS_CURR | LYS_ORDBY_USER, ll->flags);
 
@@ -2042,7 +2042,7 @@ test_type_dflt(void **state)
     assert_int_equal(3, type->refcount); /* 2x type reference, 1x default value's reference (typedf's default does not reference own type)*/
     assert_int_equal(LY_TYPE_STRING, type->basetype);
     assert_non_null(leaf = (struct lysc_node_leaf*)mod->compiled->data);
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_string_equal("xxx", leaf->units);
 
@@ -2053,7 +2053,7 @@ test_type_dflt(void **state)
     assert_int_equal(3, type->refcount); /* 2x type reference, 1x default value's reference */
     assert_int_equal(LY_TYPE_STRING, type->basetype);
     leaf = (struct lysc_node_leaf*)mod->compiled->data;
-    assert_string_equal("goodbye", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("goodbye", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_string_equal("yyy", leaf->units);
 
@@ -2065,7 +2065,7 @@ test_type_dflt(void **state)
     assert_int_equal(6, type->refcount); /* 4x type reference, 2x default value's reference (1 shared compiled type of typedefs which default does not reference own type) */
     assert_int_equal(LY_TYPE_STRING, type->basetype);
     leaf = (struct lysc_node_leaf*)mod->compiled->data;
-    assert_string_equal("goodbye", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("goodbye", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_string_equal("yyy", leaf->units);
     type = ((struct lysc_node_leaf*)mod->compiled->data->next)->type;
@@ -2073,7 +2073,7 @@ test_type_dflt(void **state)
     assert_int_equal(6, type->refcount); /* 4x type reference, 2x default value's reference (1 shared compiled type of typedefs which default does not reference own type) */
     assert_int_equal(LY_TYPE_STRING, type->basetype);
     leaf = (struct lysc_node_leaf*)mod->compiled->data->next;
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_string_equal("xxx", leaf->units);
 
@@ -2084,7 +2084,7 @@ test_type_dflt(void **state)
     assert_int_equal(4, type->refcount); /* 3x type reference, 1x default value's reference (typedef's default does not reference own type) */
     assert_int_equal(LY_TYPE_STRING, type->basetype);
     leaf = (struct lysc_node_leaf*)mod->compiled->data;
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_string_equal("xxx", leaf->units);
 
@@ -2383,16 +2383,16 @@ test_refine(void **state)
     assert_non_null((leaf = (struct lysc_node_leaf*)((struct lysc_node_container*)parent)->child));
     assert_int_equal(LYS_LEAF, leaf->nodetype);
     assert_string_equal("l", leaf->name);
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(LYS_CONFIG_R, leaf->flags & LYS_CONFIG_MASK);
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_int_equal(LYS_LEAFLIST, llist->nodetype);
     assert_string_equal("ll", llist->name);
     assert_int_equal(2, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
-    assert_string_equal("world", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("world", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(2, llist->min);
     assert_int_equal(5, llist->max);
@@ -2408,7 +2408,7 @@ test_refine(void **state)
     assert_int_equal(LYS_LEAF, leaf->nodetype);
     assert_string_equal("x", leaf->name);
     assert_false(LYS_MAND_TRUE & leaf->flags);
-    assert_string_equal("cheers!", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("cheers!", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_non_null(leaf->musts);
     assert_int_equal(2, LY_ARRAY_COUNT(leaf->musts));
@@ -2437,7 +2437,7 @@ test_refine(void **state)
     assert_int_equal(LYS_LEAF, leaf->nodetype);
     assert_string_equal("x", leaf->name);
     assert_false(LYS_MAND_TRUE & leaf->flags);
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
 
     /* invalid */
@@ -2755,15 +2755,15 @@ test_deviation(void **state)
     assert_null(leaf->dflt);
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_int_equal(1, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_non_null(leaf = (struct lysc_node_leaf*)llist->next);
-    assert_string_equal("nothing", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("nothing", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(5, leaf->dflt->realtype->refcount); /* 3x type reference, 2x default value reference (typedef's default does not reference own type) */
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_int_equal(1, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("nothing", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("nothing", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
 
     assert_int_equal(LY_SUCCESS, lys_parse_mem(ctx, "module g {yang-version 1.1; namespace urn:g;prefix g;import e {prefix x;}"
@@ -2780,19 +2780,19 @@ test_deviation(void **state)
     assert_string_equal("b", ((struct lysc_node_choice*)node)->dflt->name);
     assert_non_null(leaf = (struct lysc_node_leaf*)node->next);
     assert_non_null(leaf->dflt);
-    assert_string_equal("bye", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("bye", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_int_equal(3, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
-    assert_string_equal("all", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("all", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
-    assert_string_equal("people", llist->dflts[2]->realtype->plugin->print(llist->dflts[2], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("people", llist->dflts[2]->realtype->plugin->print(llist->dflts[2], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_non_null(leaf = (struct lysc_node_leaf*)llist->next);
     assert_non_null(leaf->dflt);
-    assert_string_equal("hi", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hi", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(6, leaf->dflt->realtype->refcount); /* 3x type reference, 3x default value reference
     - previous type's default values were replaced by node's default values where d2 now has 2 default values */
@@ -2800,9 +2800,9 @@ test_deviation(void **state)
     assert_ptr_equal(leaf->musts[0].module, ly_ctx_get_module_implemented(ctx, "g"));
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_int_equal(2, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("hi", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hi", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
-    assert_string_equal("all", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("all", llist->dflts[1]->realtype->plugin->print(llist->dflts[1], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
 
     assert_int_equal(LY_SUCCESS, lys_parse_mem(ctx, "module h {yang-version 1.1; namespace urn:h;prefix h;import e {prefix x;}"
@@ -2816,7 +2816,7 @@ test_deviation(void **state)
     assert_string_equal("a", ((struct lysc_node_choice*)node)->dflt->name);
     assert_non_null(leaf = (struct lysc_node_leaf*)node->next);
     assert_non_null(leaf->dflt);
-    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("hello", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
 
     ly_ctx_set_module_imp_clb(ctx, test_imp_clb, "module i {namespace urn:i;prefix i;"
@@ -2933,14 +2933,14 @@ test_deviation(void **state)
     assert_non_null(leaf = (struct lysc_node_leaf*)mod->compiled->data);
     assert_string_equal("a", leaf->name);
     assert_int_equal(LY_TYPE_INT8, leaf->type->basetype);
-    assert_string_equal("10", leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("10", leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(10, leaf->dflt->uint8);
     assert_non_null(llist = (struct lysc_node_leaflist*)leaf->next);
     assert_string_equal("b", llist->name);
     assert_int_equal(LY_TYPE_INT8, llist->type->basetype);
     assert_int_equal(1, LY_ARRAY_COUNT(llist->dflts));
-    assert_string_equal("1", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LYD_XML, NULL, NULL, &dynamic));
+    assert_string_equal("1", llist->dflts[0]->realtype->plugin->print(llist->dflts[0], LY_PREF_SCHEMA, NULL, &dynamic));
     assert_int_equal(0, dynamic);
     assert_int_equal(1, llist->dflts[0]->uint8);
 
@@ -2986,8 +2986,7 @@ test_deviation(void **state)
     assert_non_null(leaf = (struct lysc_node_leaf*)mod->compiled->data);
     assert_string_equal("s", leaf->name);
     assert_non_null(leaf->dflt);
-    assert_non_null(str = leaf->dflt->realtype->plugin->print(leaf->dflt, LYD_XML, lys_get_prefix,
-                                                              (struct lys_module *)mod, &dynamic));
+    assert_non_null(str = leaf->dflt->realtype->plugin->print(leaf->dflt, LY_PREF_SCHEMA, (struct lys_module *)mod, &dynamic));
     assert_string_equal("/s:y", str);
     if (dynamic) { free((char*)str); }
 

--- a/tests/utests/test_xml.c
+++ b/tests/utests/test_xml.c
@@ -579,12 +579,12 @@ test_ns(void **state)
     assert_int_equal(3, xmlctx->ns.count);
     assert_int_not_equal(0, xmlctx->ns.size);
 
-    ns = lyxml_ns_get(xmlctx, NULL, 0);
+    ns = lyxml_ns_get(&xmlctx->ns, NULL, 0);
     assert_non_null(ns);
     assert_null(ns->prefix);
     assert_string_equal("urn:default", ns->uri);
 
-    ns = lyxml_ns_get(xmlctx, "nc", 2);
+    ns = lyxml_ns_get(&xmlctx->ns, "nc", 2);
     assert_non_null(ns);
     assert_string_equal("nc", ns->prefix);
     assert_string_equal("urn:nc2", ns->uri);
@@ -594,7 +594,7 @@ test_ns(void **state)
     lyxml_ns_rm(xmlctx);
     assert_int_equal(2, xmlctx->ns.count);
 
-    ns = lyxml_ns_get(xmlctx, "nc", 2);
+    ns = lyxml_ns_get(&xmlctx->ns, "nc", 2);
     assert_non_null(ns);
     assert_string_equal("nc", ns->prefix);
     assert_string_equal("urn:nc1", ns->uri);
@@ -604,8 +604,8 @@ test_ns(void **state)
     assert_int_equal(LY_SUCCESS, lyxml_ctx_next(xmlctx));
     assert_int_equal(0, xmlctx->ns.count);
 
-    assert_null(lyxml_ns_get(xmlctx, "nc", 2));
-    assert_null(lyxml_ns_get(xmlctx, NULL, 0));
+    assert_null(lyxml_ns_get(&xmlctx->ns, "nc", 2));
+    assert_null(lyxml_ns_get(&xmlctx->ns, NULL, 0));
 
     lyxml_ctx_free(xmlctx);
     ly_in_free(in, 0);

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -273,7 +273,7 @@ main(int argc, char* argv[])
     }
 
     type = ((struct lysc_node_leaf*)mod->compiled->data)->type;
-    match = type->plugin->store(ctx, type, str, strlen(str), 0, NULL, NULL, LYD_XML, NULL, NULL, NULL, NULL, &err);
+    match = type->plugin->store(ctx, type, str, strlen(str), 0, LY_PREF_JSON, NULL, NULL, NULL, NULL, NULL, &err);
     if (verbose) {
         for (i = 0; i < patterns_count; i++) {
             fprintf(stdout, "pattern  %d: %s\n", i + 1, patterns[i]);


### PR DESCRIPTION
So the callback is no longer needed as a parameter.
Also, union no longer uses its own prefix mappings
but instead uses the original format and copies any
required prefix data.