### PR TITLE
plugin types REFACTOR remove STORE and CANONIZE flags

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -1798,7 +1798,7 @@ lyd_parse_json_reply(const struct lyd_node *request, struct ly_in *in, struct ly
     enum LYJSON_PARSER_STATUS status;
 
     /* init */
-    ret = lyd_parse_json_init(LYD_NODE_CTX(request), in, LYD_PARSE_ONLY | LYD_PARSE_STRICT, 0, &lydctx);
+    ret = lyd_parse_json_init(LYD_CTX(request), in, LYD_PARSE_ONLY | LYD_PARSE_STRICT, 0, &lydctx);
     LY_CHECK_GOTO(ret || !lydctx, cleanup);
     lydctx->int_opts = LYD_INTOPT_REPLY;
 
@@ -1810,7 +1810,7 @@ lyd_parse_json_reply(const struct lyd_node *request, struct ly_in *in, struct ly
         LYD_TREE_DFS_END(request, req_op);
     }
     if (!(req_op->schema->nodetype & (LYS_RPC | LYS_ACTION))) {
-        LOGERR(LYD_NODE_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
+        LOGERR(LYD_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
         ret = LY_EINVAL;
         goto cleanup;
     }

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -1106,7 +1106,7 @@ lyd_parse_lyb_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
 {
     LY_ERR ret;
     struct lyd_node *req_op, *rep_op = NULL;
-    const struct ly_ctx *ctx = LYD_NODE_CTX(request);
+    const struct ly_ctx *ctx = LYD_CTX(request);
 
     /* find request OP */
     LYD_TREE_DFS_BEGIN((struct lyd_node *)request, req_op) {
@@ -1116,7 +1116,7 @@ lyd_parse_lyb_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
         LYD_TREE_DFS_END(request, req_op);
     }
     if (!(req_op->schema->nodetype & (LYS_RPC | LYS_ACTION))) {
-        LOGERR(LYD_NODE_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
+        LOGERR(LYD_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
         return LY_EINVAL;
     }
 

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -976,7 +976,7 @@ lyd_parse_xml_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
     struct lyd_node *rpcr_e = NULL, *tree, *req_op, *rep_op = NULL;
 
     /* init */
-    LY_CHECK_GOTO(ret = lyxml_ctx_new(LYD_NODE_CTX(request), in, &lydctx.xmlctx), cleanup);
+    LY_CHECK_GOTO(ret = lyxml_ctx_new(LYD_CTX(request), in, &lydctx.xmlctx), cleanup);
     lydctx.parse_options = LYD_PARSE_ONLY | LYD_PARSE_STRICT;
     lydctx.int_opts = LYD_INTOPT_REPLY;
 
@@ -988,7 +988,7 @@ lyd_parse_xml_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
         LYD_TREE_DFS_END(request, req_op);
     }
     if (!(req_op->schema->nodetype & (LYS_RPC | LYS_ACTION))) {
-        LOGERR(LYD_NODE_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
+        LOGERR(LYD_CTX(request), LY_EINVAL, "No RPC/action in the request found.");
         ret = LY_EINVAL;
         goto cleanup;
     }
@@ -1010,7 +1010,7 @@ lyd_parse_xml_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
     if (rpcr_e) {
         if (lydctx.xmlctx->status != LYXML_ELEM_CLOSE) {
             assert(lydctx.xmlctx->status == LYXML_ELEMENT);
-            LOGVAL(LYD_NODE_CTX(request), LY_VLOG_LINE, &lydctx.xmlctx->line, LYVE_SYNTAX,
+            LOGVAL(LYD_CTX(request), LY_VLOG_LINE, &lydctx.xmlctx->line, LYVE_SYNTAX,
                    "Unexpected sibling element \"%.*s\" of \"rpc-reply\".", lydctx.xmlctx->name_len, lydctx.xmlctx->name);
             ret = LY_EVALID;
             goto cleanup;

--- a/src/path.c
+++ b/src/path.c
@@ -947,7 +947,6 @@ ly_path_dup(const struct ly_ctx *ctx, const struct ly_path *path, struct ly_path
                 case LY_PATH_PREDTYPE_LEAFLIST:
                     /* key-predicate or leaf-list-predicate */
                     (*dup)[u].predicates[v].key = pred->key;
-                    (*dup)[u].predicates[v].value.realtype = pred->value.realtype;
                     pred->value.realtype->plugin->duplicate(ctx, &pred->value, &(*dup)[u].predicates[v].value);
                     break;
                 case LY_PATH_PREDTYPE_NONE:

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -136,26 +136,23 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format,
 /**
  * @defgroup plugintypeopts Options for type plugin callbacks. The same set of the options is passed to all the type's callbacks used together.
  *
- * Options applicable to ly_type_validate_clb() and ly_type_store_clb.
+ * Options applicable to ly_type_store_clb().
  * @{
  */
-#define LY_TYPE_OPTS_CANONIZE     0x01 /**< Canonize the given value and store it (insert into the context's dictionary)
-                                            as the value's canonized string */
-#define LY_TYPE_OPTS_DYNAMIC      0x02 /**< Flag for the dynamically allocated string value, in this case the value
+#define LY_TYPE_OPTS_DYNAMIC      0x01 /**< Flag for the dynamically allocated string value, in this case the value
                                             is supposed to be freed or directly inserted into the context's dictionary
                                             (e.g. in case of canonization).
                                             In any case, the caller of the callback does not free the provided string value after calling
                                             the type's callbacks with this option */
-#define LY_TYPE_OPTS_STORE        0x04 /**< Flag announcing calling of ly_type_store_clb() */
-#define LY_TYPE_OPTS_SCHEMA       0x08 /**< Flag for the value used in schema instead of the data tree. With this flag also the meaning of
+#define LY_TYPE_OPTS_SCHEMA       0x02 /**< Flag for the value used in schema instead of the data tree. With this flag also the meaning of
                                             LY_TYPE_OPTS_INCOMPLETE_DATA changes and means that the schema tree is not complete (data tree
                                             is not taken into account at all). */
-#define LY_TYPE_OPTS_INCOMPLETE_DATA 0x10 /**< Flag for the case the data trees (schema trees in case it is used in combination with
+#define LY_TYPE_OPTS_INCOMPLETE_DATA 0x04 /**< Flag for the case the data trees (schema trees in case it is used in combination with
                                             LY_TYPE_OPTS_SCHEMA) are not yet complete. In this case the plugin should do what it
                                             can (e.g. store the canonical/auxiliary value if it is requested) and in the case of need to use
                                             data trees (checking require-instance), it returns LY_EINCOMPLETE.
                                             Caller is supposed to call such validation callback again later with complete data trees. */
-#define LY_TYPE_OPTS_SECOND_CALL  0x20 /**< Flag for the second call of the callback when the first call returns LY_EINCOMPLETE,
+#define LY_TYPE_OPTS_SECOND_CALL  0x08 /**< Flag for the second call of the callback when the first call returns LY_EINCOMPLETE,
                                             other options should be the same as for the first call. **!!** Note that this second call
                                             can occur even if the first call succeeded, in which case the plugin should immediately
                                             return LY_SUCCESS. */
@@ -195,11 +192,7 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format,
  *            This argument is a lys_node (in case LY_TYPE_OPTS_INCOMPLETE_DATA or LY_TYPE_OPTS_SCHEMA set in @p options)
  *            or lyd_node structure.
  * @param[in] tree External data tree (e.g. when validating RPC/Notification) where the required data instance can be placed.
- * @param[in,out] storage If LY_TYPE_OPTS_STORE option set, the parsed data are stored into this structure in the type's specific way.
- *             If the @p canonized differs from the storage's canonized member, the canonized value is also stored here despite the
- *             LY_TYPE_OPTS_CANONIZE option.
- * @param[out] canonized If LY_TYPE_OPTS_CANONIZE option set, the canonized string stored in the @p ctx dictionary
- *             is returned via this parameter.
+ * @param[in] storage Storage for the value in the type's specific encoding. All the members should be filled by the plugin.
  * @param[out] err Optionally provided error information in case of failure. If not provided to the caller, a generic
  *             error message is prepared instead.
  *             The error structure can be created by ly_err_new().
@@ -209,8 +202,7 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format,
  */
 typedef LY_ERR (*ly_type_store_clb)(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len,
                                     int options, LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node,
-                                    const struct lyd_node *tree, struct lyd_value *storage, const char **canonized,
-                                    struct ly_err_item **err);
+                                    const struct lyd_node *tree, struct lyd_value *storage, struct ly_err_item **err);
 
 /**
  * @brief Callback for comparing 2 values of the same type.

--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -40,7 +40,7 @@ lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, i
         ret = lyb_print_data(out, root, options);
         break;
     case LYD_UNKNOWN:
-        LOGINT(root ? LYD_NODE_CTX(root) : NULL);
+        LOGINT(root ? LYD_CTX(root) : NULL);
         ret = LY_EINT;
         break;
     }

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -166,7 +166,7 @@ node_prefix(const struct lyd_node *node)
         case LYD_LYB:
         case LYD_UNKNOWN:
             /* cannot be created */
-            LOGINT(LYD_NODE_CTX(node));
+            LOGINT(LYD_CTX(node));
         }
     }
 
@@ -455,7 +455,7 @@ json_print_attributes(struct jsonpr_ctx *ctx, const struct lyd_node *node, int i
     if ((node->flags & LYD_DEFAULT) && (ctx->options & (LYD_PRINT_WD_ALL_TAG | LYD_PRINT_WD_IMPL_TAG))) {
         /* we have implicit OR explicit default node */
         /* get with-defaults module */
-        wdmod = ly_ctx_get_module_implemented(LYD_NODE_CTX(node), "ietf-netconf-with-defaults");
+        wdmod = ly_ctx_get_module_implemented(LYD_CTX(node), "ietf-netconf-with-defaults");
     }
 
     if (node->schema && node->meta) {
@@ -863,7 +863,7 @@ json_print_data(struct ly_out *out, const struct lyd_node *root, int options)
     ctx.level = 1;
     ctx.level_printed = 0;
     ctx.options = options;
-    ctx.ctx = LYD_NODE_CTX(root);
+    ctx.ctx = LYD_CTX(root);
 
     /* start */
     ly_print_(ctx.out, "{%s", delimiter);

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -672,20 +672,8 @@ cleanup:
 static LY_ERR
 lyb_print_term(struct lyd_node_term *term, struct ly_out *out, struct lylyb_ctx *lybctx)
 {
-    LY_ERR ret;
-    int dynamic;
-    const char *str;
-
-    /* get value */
-    str = lyd_value2str(term, &dynamic);
-
-    /* print it */
-    ret = lyb_write_string(str, 0, 0, out, lybctx);
-
-    if (dynamic) {
-        free((char *)str);
-    }
-    return ret;
+    /* print the value */
+    return lyb_write_string(LYD_CANONICAL(term), 0, 0, out, lybctx);
 }
 
 /**
@@ -699,12 +687,9 @@ lyb_print_term(struct lyd_node_term *term, struct ly_out *out, struct lylyb_ctx 
 static LY_ERR
 lyb_print_metadata(struct ly_out *out, const struct lyd_node *node, struct lyd_lyb_ctx *lybctx)
 {
-    LY_ERR ret;
-    int dynamic;
     uint8_t count = 0;
     const struct lys_module *wd_mod = NULL;
     struct lyd_meta *iter;
-    const char *str;
 
     /* with-defaults */
     if (node->schema->nodetype & LYD_NODE_TERM) {
@@ -750,15 +735,8 @@ lyb_print_metadata(struct ly_out *out, const struct lyd_node *node, struct lyd_l
         /* annotation name with length */
         LY_CHECK_RET(lyb_write_string(iter->name, 0, 1, out, lybctx->lybctx));
 
-        /* get the value */
-        str = lyd_meta2str(iter, &dynamic);
-
         /* metadata value */
-        ret = lyb_write_string(str, 0, 0, out, lybctx->lybctx);
-        if (dynamic) {
-            free((char *)str);
-        }
-        LY_CHECK_RET(ret);
+        LY_CHECK_RET(lyb_write_string(iter->value.canonical, 0, 0, out, lybctx->lybctx));
 
         /* finish metadata subtree */
         LY_CHECK_RET(lyb_write_stop_subtree(out, lybctx->lybctx));

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -673,7 +673,7 @@ static LY_ERR
 lyb_print_term(struct lyd_node_term *term, struct ly_out *out, struct lylyb_ctx *lybctx)
 {
     /* print the value */
-    return lyb_write_string(LYD_CANONICAL(term), 0, 0, out, lybctx);
+    return lyb_write_string(LYD_CANON_VALUE(term), 0, 0, out, lybctx);
 }
 
 /**
@@ -942,7 +942,7 @@ lyb_print_data(struct ly_out *out, const struct lyd_node *root, int options)
     struct hash_table *top_sibling_ht = NULL;
     const struct lys_module *prev_mod = NULL;
     struct lyd_lyb_ctx *lybctx;
-    const struct ly_ctx *ctx = root ? LYD_NODE_CTX(root) : NULL;
+    const struct ly_ctx *ctx = root ? LYD_CTX(root) : NULL;
 
     lybctx = calloc(1, sizeof *lybctx);
     LY_CHECK_ERR_RET(!lybctx, LOGMEM(ctx), LY_EMEM);

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -372,7 +372,7 @@ no_content:
             prev_lo = ly_log_options(0);
 
             /* try to parse it into a data tree */
-            if (lyd_parse_data_mem((struct ly_ctx *)LYD_NODE_CTX(node), any->value.mem, LYD_LYB, LYD_PARSE_ONLY | LYD_PARSE_OPAQ | LYD_PARSE_STRICT, 0, &iter) == LY_SUCCESS) {
+            if (lyd_parse_data_mem((struct ly_ctx *)LYD_CTX(node), any->value.mem, LYD_LYB, LYD_PARSE_ONLY | LYD_PARSE_OPAQ | LYD_PARSE_STRICT, 0, &iter) == LY_SUCCESS) {
                 /* successfully parsed */
                 free(any->value.mem);
                 any->value.tree = iter;
@@ -418,7 +418,7 @@ no_content:
         case LYD_ANYDATA_JSON:
         case LYD_ANYDATA_LYB:
             /* JSON and LYB format is not supported */
-            LOGWRN(LYD_NODE_CTX(node), "Unable to print anydata content (type %d) as XML.", any->value_type);
+            LOGWRN(LYD_CTX(node), "Unable to print anydata content (type %d) as XML.", any->value_type);
             goto no_content;
         }
 
@@ -550,7 +550,7 @@ xml_print_data(struct ly_out *out, const struct lyd_node *root, int options)
     ctx.out = out;
     ctx.level = (options & LYD_PRINT_FORMAT ? 1 : 0);
     ctx.options = options;
-    ctx.ctx = LYD_NODE_CTX(root);
+    ctx.ctx = LYD_CTX(root);
 
     /* content */
     LY_LIST_FOR(root, node) {

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -928,12 +928,12 @@ yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
 }
 
 static void
-yprc_dflt_value(struct ypr_ctx *ctx, const struct lyd_value *value, const struct lys_module *value_mod, struct lysc_ext_instance *exts)
+yprc_dflt_value(struct ypr_ctx *ctx, const struct lyd_value *value, struct lysc_ext_instance *exts)
 {
     int dynamic;
     const char *str;
 
-    str = value->realtype->plugin->print(value, LY_PREF_SCHEMA, (void *)value_mod, &dynamic);
+    str = value->realtype->plugin->print(value, LY_PREF_JSON, NULL, &dynamic);
     ypr_substmt(ctx, LYEXT_SUBSTMT_DEFAULT, 0, str, exts);
     if (dynamic) {
         free((void*)str);
@@ -950,10 +950,6 @@ yprc_type(struct ypr_ctx *ctx, const struct lysc_type *type)
     LEVEL++;
 
     yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, type->exts, &flag, 0);
-    if (type->dflt) {
-        ypr_open(ctx->out, &flag);
-        yprc_dflt_value(ctx, type->dflt, type->dflt_mod, type->exts);
-    }
 
     switch (type->basetype) {
     case LY_TYPE_BINARY: {
@@ -1577,7 +1573,7 @@ yprc_leaf(struct ypr_ctx *ctx, const struct lysc_node *node)
     }
 
     if (leaf->dflt) {
-        yprc_dflt_value(ctx, leaf->dflt, leaf->dflt_mod, leaf->exts);
+        yprc_dflt_value(ctx, leaf->dflt, leaf->exts);
     }
 
     yprc_node_common2(ctx, node, NULL);
@@ -1642,7 +1638,7 @@ yprc_leaflist(struct ypr_ctx *ctx, const struct lysc_node *node)
         yprc_must(ctx, &llist->musts[u], NULL);
     }
     LY_ARRAY_FOR(llist->dflts, u) {
-        yprc_dflt_value(ctx, llist->dflts[u], llist->dflts_mods[u], llist->exts);
+        yprc_dflt_value(ctx, llist->dflts[u], llist->exts);
     }
 
     ypr_config(ctx, node->flags, node->exts, NULL);

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -470,10 +470,10 @@ lyd_parse_reply(const struct lyd_node *request, struct ly_in *in, LYD_FORMAT for
                 struct lyd_node **op)
 {
     LY_CHECK_ARG_RET(NULL, request, LY_EINVAL);
-    LY_CHECK_ARG_RET(LYD_NODE_CTX(request), in, tree || op, LY_EINVAL);
+    LY_CHECK_ARG_RET(LYD_CTX(request), in, tree || op, LY_EINVAL);
 
     format = lyd_parse_get_format(in, format);
-    LY_CHECK_ARG_RET(LYD_NODE_CTX(request), format, LY_EINVAL);
+    LY_CHECK_ARG_RET(LYD_CTX(request), format, LY_EINVAL);
 
     /* init */
     if (tree) {
@@ -497,7 +497,7 @@ lyd_parse_reply(const struct lyd_node *request, struct ly_in *in, LYD_FORMAT for
         break;
     }
 
-    LOGINT_RET(LYD_NODE_CTX(request));
+    LOGINT_RET(LYD_CTX(request));
 }
 
 API LY_ERR
@@ -971,7 +971,7 @@ lyd_new_path_update(struct lyd_node *node, const void *value, LYD_ANYDATA_VALUET
         lyd_free_tree(new_any);
         break;
     default:
-        LOGINT(LYD_NODE_CTX(node));
+        LOGINT(LYD_CTX(node));
         ret = LY_EINT;
         break;
     }
@@ -990,7 +990,7 @@ lyd_new_meta(struct lyd_node *parent, const struct lys_module *module, const cha
 
     LY_CHECK_ARG_RET(NULL, parent, name, module || strchr(name, ':'), LY_EINVAL);
 
-    ctx = LYD_NODE_CTX(parent);
+    ctx = LYD_CTX(parent);
 
     /* parse the name */
     tmp = name;
@@ -1028,7 +1028,7 @@ lyd_new_opaq(struct lyd_node *parent, const struct ly_ctx *ctx, const char *name
     LY_CHECK_ARG_RET(ctx, parent || ctx, parent || node, name, module_name, LY_EINVAL);
 
     if (!ctx) {
-        ctx = LYD_NODE_CTX(parent);
+        ctx = LYD_CTX(parent);
     }
     if (!value) {
         value = "";
@@ -1057,7 +1057,7 @@ lyd_new_attr(struct lyd_node *parent, const char *module_name, const char *name,
 
     LY_CHECK_ARG_RET(NULL, parent, !parent->schema, name, LY_EINVAL);
 
-    ctx = LYD_NODE_CTX(parent);
+    ctx = LYD_CTX(parent);
 
     /* parse the name */
     tmp = name;
@@ -1104,7 +1104,7 @@ lyd_change_term(struct lyd_node *term, const char *val_str)
     /* compare original and new value */
     if (type->plugin->compare(&t->value, &val)) {
         /* values differ, switch them */
-        type->plugin->free(LYD_NODE_CTX(term), &t->value);
+        type->plugin->free(LYD_CTX(term), &t->value);
         t->value = val;
         memset(&val, 0, sizeof val);
         val_change = 1;
@@ -1154,7 +1154,7 @@ lyd_change_term(struct lyd_node *term, const char *val_str)
     } /* else value changed, LY_SUCCESS */
 
 cleanup:
-    type->plugin->free(LYD_NODE_CTX(term), &val);
+    type->plugin->free(LYD_CTX(term), &val);
     return ret;
 }
 
@@ -1219,7 +1219,7 @@ lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *pat
     LY_CHECK_ARG_RET(ctx, parent || ctx, path, (path[0] == '/') || parent, LY_EINVAL);
 
     if (!ctx) {
-        ctx = LYD_NODE_CTX(parent);
+        ctx = LYD_CTX(parent);
     }
 
     /* parse path */
@@ -1534,7 +1534,7 @@ lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, int impli
         *diff = NULL;
     }
     if (!ctx) {
-        ctx = LYD_NODE_CTX(*tree);
+        ctx = LYD_CTX(*tree);
     }
 
     /* add nodes for each module one-by-one */
@@ -1932,7 +1932,7 @@ lyd_insert_sibling(struct lyd_node *sibling, struct lyd_node *node, struct lyd_n
 
     while (node) {
         if (node->schema->flags & LYS_KEY) {
-            LOGERR(LYD_NODE_CTX(node), LY_EINVAL, "Cannot insert key \"%s\".", node->schema->name);
+            LOGERR(LYD_CTX(node), LY_EINVAL, "Cannot insert key \"%s\".", node->schema->name);
             return LY_EINVAL;
         }
 
@@ -1963,7 +1963,7 @@ lyd_insert_before(struct lyd_node *sibling, struct lyd_node *node)
     LY_CHECK_RET(lyd_insert_check_schema(lysc_data_parent(sibling->schema), node->schema));
 
     if (!(node->schema->nodetype & (LYS_LIST | LYS_LEAFLIST)) || !(node->schema->flags & LYS_ORDBY_USER)) {
-        LOGERR(LYD_NODE_CTX(sibling), LY_EINVAL, "Can be used only for user-ordered nodes.");
+        LOGERR(LYD_CTX(sibling), LY_EINVAL, "Can be used only for user-ordered nodes.");
         return LY_EINVAL;
     }
 
@@ -1998,7 +1998,7 @@ lyd_insert_after(struct lyd_node *sibling, struct lyd_node *node)
     LY_CHECK_RET(lyd_insert_check_schema(lysc_data_parent(sibling->schema), node->schema));
 
     if (!(node->schema->nodetype & (LYS_LIST | LYS_LEAFLIST)) || !(node->schema->flags & LYS_ORDBY_USER)) {
-        LOGERR(LYD_NODE_CTX(sibling), LY_EINVAL, "Can be used only for user-ordered nodes.");
+        LOGERR(LYD_CTX(sibling), LY_EINVAL, "Can be used only for user-ordered nodes.");
         return LY_EINVAL;
     }
 
@@ -2273,7 +2273,7 @@ lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, i
         }
     }
 
-    if ((LYD_NODE_CTX(node1) != LYD_NODE_CTX(node2)) || (node1->schema != node2->schema)) {
+    if ((LYD_CTX(node1) != LYD_CTX(node2)) || (node1->schema != node2->schema)) {
         return LY_ENOT;
     }
 
@@ -2303,7 +2303,7 @@ lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, i
         case LYD_LYB:
         case LYD_UNKNOWN:
             /* not allowed */
-            LOGINT(LYD_NODE_CTX(node1));
+            LOGINT(LYD_CTX(node1));
             return LY_EINT;
         }
         if (options & LYD_COMPARE_FULL_RECURSION) {
@@ -2423,7 +2423,7 @@ lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, i
         }
     }
 
-    LOGINT(LYD_NODE_CTX(node1));
+    LOGINT(LYD_CTX(node1));
     return LY_EINT;
 }
 
@@ -2451,7 +2451,7 @@ lyd_compare_meta(const struct lyd_meta *meta1, const struct lyd_meta *meta2)
         }
     }
 
-    if ((LYD_NODE_CTX(meta1->parent) != LYD_NODE_CTX(meta2->parent)) || (meta1->annotation != meta2->annotation)) {
+    if ((LYD_CTX(meta1->parent) != LYD_CTX(meta2->parent)) || (meta1->annotation != meta2->annotation)) {
         return LY_ENOT;
     }
 
@@ -2506,12 +2506,12 @@ lyd_dup_r(const struct lyd_node *node, struct lyd_node *parent, struct lyd_node 
             dup = calloc(1, sizeof(struct lyd_node_any));
             break;
         default:
-            LOGINT(LYD_NODE_CTX(node));
+            LOGINT(LYD_CTX(node));
             ret = LY_EINT;
             goto error;
         }
     }
-    LY_CHECK_ERR_GOTO(!dup, LOGMEM(LYD_NODE_CTX(node)); ret = LY_EMEM, error);
+    LY_CHECK_ERR_GOTO(!dup, LOGMEM(LYD_CTX(node)); ret = LY_EMEM, error);
 
     if (options & LYD_DUP_WITH_FLAGS) {
         dup->flags = node->flags;
@@ -2540,29 +2540,29 @@ lyd_dup_r(const struct lyd_node *node, struct lyd_node *parent, struct lyd_node 
                 LY_CHECK_GOTO(ret = lyd_dup_r(child, dup, NULL, options, NULL), error);
             }
         }
-        opaq->name = lydict_insert(LYD_NODE_CTX(node), orig->name, 0);
+        opaq->name = lydict_insert(LYD_CTX(node), orig->name, 0);
         opaq->format = orig->format;
         if (orig->prefix.id) {
-            opaq->prefix.id = lydict_insert(LYD_NODE_CTX(node), orig->prefix.id, 0);
+            opaq->prefix.id = lydict_insert(LYD_CTX(node), orig->prefix.id, 0);
         }
-        opaq->prefix.module_ns = lydict_insert(LYD_NODE_CTX(node), orig->prefix.module_ns, 0);
+        opaq->prefix.module_ns = lydict_insert(LYD_CTX(node), orig->prefix.module_ns, 0);
         if (orig->val_prefs) {
-            LY_ARRAY_CREATE_GOTO(LYD_NODE_CTX(node), opaq->val_prefs, LY_ARRAY_COUNT(orig->val_prefs), ret, error);
+            LY_ARRAY_CREATE_GOTO(LYD_CTX(node), opaq->val_prefs, LY_ARRAY_COUNT(orig->val_prefs), ret, error);
             LY_ARRAY_FOR(orig->val_prefs, u) {
-                opaq->val_prefs[u].id = lydict_insert(LYD_NODE_CTX(node), orig->val_prefs[u].id, 0);
-                opaq->val_prefs[u].module_ns = lydict_insert(LYD_NODE_CTX(node), orig->val_prefs[u].module_ns, 0);
+                opaq->val_prefs[u].id = lydict_insert(LYD_CTX(node), orig->val_prefs[u].id, 0);
+                opaq->val_prefs[u].module_ns = lydict_insert(LYD_CTX(node), orig->val_prefs[u].module_ns, 0);
                 LY_ARRAY_INCREMENT(opaq->val_prefs);
             }
         }
-        opaq->value = lydict_insert(LYD_NODE_CTX(node), orig->value, 0);
+        opaq->value = lydict_insert(LYD_CTX(node), orig->value, 0);
         opaq->ctx = orig->ctx;
     } else if (dup->schema->nodetype & LYD_NODE_TERM) {
         struct lyd_node_term *term = (struct lyd_node_term *)dup;
         struct lyd_node_term *orig = (struct lyd_node_term *)node;
 
         term->hash = orig->hash;
-        LY_CHECK_ERR_GOTO(orig->value.realtype->plugin->duplicate(LYD_NODE_CTX(node), &orig->value, &term->value),
-                          LOGERR(LYD_NODE_CTX(node), LY_EINT, "Value duplication failed."); ret = LY_EINT, error);
+        LY_CHECK_ERR_GOTO(orig->value.realtype->plugin->duplicate(LYD_CTX(node), &orig->value, &term->value),
+                          LOGERR(LYD_CTX(node), LY_EINT, "Value duplication failed."); ret = LY_EINT, error);
     } else if (dup->schema->nodetype & LYD_NODE_INNER) {
         struct lyd_node_inner *orig = (struct lyd_node_inner *)node;
         struct lyd_node *child;
@@ -2652,7 +2652,7 @@ lyd_dup_get_local_parent(const struct lyd_node *node, const struct lyd_node_inne
 
     if (repeat && parent) {
         /* given parent and created parents chain actually do not interconnect */
-        LOGERR(LYD_NODE_CTX(node), LY_EINVAL,
+        LOGERR(LYD_CTX(node), LY_EINVAL,
                "Invalid argument parent (%s()) - does not interconnect with the created node's parents chain.", __func__);
         return LY_EINVAL;
     }
@@ -2728,12 +2728,12 @@ lyd_dup_meta_single(const struct lyd_meta *meta, struct lyd_node *node, struct l
 
     /* create a copy */
     mt = calloc(1, sizeof *mt);
-    LY_CHECK_ERR_RET(!mt, LOGMEM(LYD_NODE_CTX(node)), LY_EMEM);
+    LY_CHECK_ERR_RET(!mt, LOGMEM(LYD_CTX(node)), LY_EMEM);
     mt->parent = node;
     mt->annotation = meta->annotation;
-    ret = meta->value.realtype->plugin->duplicate(LYD_NODE_CTX(node), &meta->value, &mt->value);
-    LY_CHECK_ERR_RET(ret, LOGERR(LYD_NODE_CTX(node), LY_EINT, "Value duplication failed."), ret);
-    mt->name = lydict_insert(LYD_NODE_CTX(node), meta->name, 0);
+    ret = meta->value.realtype->plugin->duplicate(LYD_CTX(node), &meta->value, &mt->value);
+    LY_CHECK_ERR_RET(ret, LOGERR(LYD_CTX(node), LY_EINT, "Value duplication failed."), ret);
+    mt->name = lydict_insert(LYD_CTX(node), meta->name, 0);
 
     /* insert as the last attribute */
     if (node->meta) {
@@ -2785,8 +2785,8 @@ lyd_merge_sibling_r(struct lyd_node **first_trg, struct lyd_node *parent_trg, co
             /* update value (or only LYD_DEFAULT flag) only if flag set or the source node is not default */
             if ((options & LYD_MERGE_DEFAULTS) || !(sibling_src->flags & LYD_DEFAULT)) {
                 type = ((struct lysc_node_leaf *)match_trg->schema)->type;
-                type->plugin->free(LYD_NODE_CTX(match_trg), &((struct lyd_node_term *)match_trg)->value);
-                LY_CHECK_RET(type->plugin->duplicate(LYD_NODE_CTX(match_trg), &((struct lyd_node_term *)sibling_src)->value,
+                type->plugin->free(LYD_CTX(match_trg), &((struct lyd_node_term *)match_trg)->value);
+                LY_CHECK_RET(type->plugin->duplicate(LYD_CTX(match_trg), &((struct lyd_node_term *)sibling_src)->value,
                                                      &((struct lyd_node_term *)match_trg)->value));
 
                 /* copy flags and add LYD_NEW */
@@ -2842,7 +2842,7 @@ lyd_merge(struct lyd_node **target, const struct lyd_node *source, int options, 
     }
 
     if (lysc_data_parent((*target)->schema) || lysc_data_parent(source->schema)) {
-        LOGERR(LYD_NODE_CTX(source), LY_EINVAL, "Invalid arguments - can merge only 2 top-level subtrees (%s()).", __func__);
+        LOGERR(LYD_CTX(source), LY_EINVAL, "Invalid arguments - can merge only 2 top-level subtrees (%s()).", __func__);
         return LY_EINVAL;
     }
 
@@ -2910,7 +2910,7 @@ lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *bufl
     char quot;
 
     for (key = lyd_node_children(node, 0); key && (key->schema->flags & LYS_KEY); key = key->next) {
-        val = LYD_CANONICAL(key);
+        val = LYD_CANON_VALUE(key);
         len = 1 + strlen(key->schema->name) + 2 + strlen(val) + 2;
         LY_CHECK_RET(lyd_path_str_enlarge(buffer, buflen, *bufused + len, is_static));
 
@@ -2941,7 +2941,7 @@ lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *
     const char *val;
     char quot;
 
-    val = LYD_CANONICAL(node);
+    val = LYD_CANON_VALUE(node);
     len = 4 + strlen(val) + 2;
     LY_CHECK_RET(lyd_path_str_enlarge(buffer, buflen, *bufused + len, is_static));
 
@@ -3327,7 +3327,7 @@ lyd_find_xpath(const struct lyd_node *ctx_node, const char *xpath, struct ly_set
     memset(&xp_set, 0, sizeof xp_set);
 
     /* compile expression */
-    exp = lyxp_expr_parse((struct ly_ctx *)LYD_NODE_CTX(ctx_node), xpath, 0, 1);
+    exp = lyxp_expr_parse((struct ly_ctx *)LYD_CTX(ctx_node), xpath, 0, 1);
     LY_CHECK_ERR_GOTO(!exp, ret = LY_EINVAL, cleanup);
 
     /* evaluate expression */
@@ -3336,13 +3336,13 @@ lyd_find_xpath(const struct lyd_node *ctx_node, const char *xpath, struct ly_set
 
     /* allocate return set */
     *set = ly_set_new();
-    LY_CHECK_ERR_GOTO(!*set, LOGMEM(LYD_NODE_CTX(ctx_node)); ret = LY_EMEM, cleanup);
+    LY_CHECK_ERR_GOTO(!*set, LOGMEM(LYD_CTX(ctx_node)); ret = LY_EMEM, cleanup);
 
     /* transform into ly_set */
     if (xp_set.type == LYXP_SET_NODE_SET) {
         /* allocate memory for all the elements once (even though not all items must be elements but most likely will be) */
         (*set)->objs = malloc(xp_set.used * sizeof *(*set)->objs);
-        LY_CHECK_ERR_GOTO(!(*set)->objs, LOGMEM(LYD_NODE_CTX(ctx_node)); ret = LY_EMEM, cleanup);
+        LY_CHECK_ERR_GOTO(!(*set)->objs, LOGMEM(LYD_CTX(ctx_node)); ret = LY_EMEM, cleanup);
         (*set)->size = xp_set.used;
 
         for (i = 0; i < xp_set.used; ++i) {
@@ -3354,6 +3354,6 @@ lyd_find_xpath(const struct lyd_node *ctx_node, const char *xpath, struct ly_set
 
 cleanup:
     lyxp_set_free_content(&xp_set);
-    lyxp_expr_free((struct ly_ctx *)LYD_NODE_CTX(ctx_node), exp);
+    lyxp_expr_free((struct ly_ctx *)LYD_CTX(ctx_node), exp);
     return ret;
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -136,7 +136,7 @@ struct lysc_node;
 /**
  * @brief Macro to get context from a data tree node.
  */
-#define LYD_NODE_CTX(node) ((node)->schema ? (node)->schema->module->ctx : ((struct lyd_node_opaq *)(node))->ctx)
+#define LYD_CTX(node) ((node)->schema ? (node)->schema->module->ctx : ((struct lyd_node_opaq *)(node))->ctx)
 
 /**
  * @brief Data input/output formats supported by libyang [parser](@ref howtodataparsers) and
@@ -235,7 +235,7 @@ struct lyd_value {
  * @param[in] node Term node with the value.
  * @return Canonical value.
  */
-#define LYD_CANONICAL(node) ((struct lyd_node_term *)(node))->value.canonical
+#define LYD_CANON_VALUE(node) ((struct lyd_node_term *)(node))->value.canonical
 
 /**
  * @brief Metadata structure.

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -175,11 +175,11 @@ lyd_free_subtree(struct lyd_node *node, int top)
             lyd_free_subtree(iter, 0);
         }
 
-        FREE_STRING(LYD_NODE_CTX(opaq), opaq->name);
-        FREE_STRING(LYD_NODE_CTX(opaq), opaq->prefix.id);
-        FREE_STRING(LYD_NODE_CTX(opaq), opaq->prefix.module_ns);
-        ly_free_val_prefs(LYD_NODE_CTX(opaq), opaq->val_prefs);
-        FREE_STRING(LYD_NODE_CTX(opaq), opaq->value);
+        FREE_STRING(LYD_CTX(opaq), opaq->name);
+        FREE_STRING(LYD_CTX(opaq), opaq->prefix.id);
+        FREE_STRING(LYD_CTX(opaq), opaq->prefix.module_ns);
+        ly_free_val_prefs(LYD_CTX(opaq), opaq->val_prefs);
+        FREE_STRING(LYD_CTX(opaq), opaq->value);
     } else if (node->schema->nodetype & LYD_NODE_INNER) {
         /* remove children hash table in case of inner data node */
         lyht_free(((struct lyd_node_inner *)node)->children_ht);
@@ -194,11 +194,11 @@ lyd_free_subtree(struct lyd_node *node, int top)
         /* only frees the value this way */
         lyd_any_copy_value(node, NULL, 0);
     } else if (node->schema->nodetype & LYD_NODE_TERM) {
-        ((struct lysc_node_leaf *)node->schema)->type->plugin->free(LYD_NODE_CTX(node), &((struct lyd_node_term *)node)->value);
+        ((struct lysc_node_leaf *)node->schema)->type->plugin->free(LYD_CTX(node), &((struct lyd_node_term *)node)->value);
     }
 
     if (!node->schema) {
-        ly_free_attr_siblings(LYD_NODE_CTX(node), opaq->attr);
+        ly_free_attr_siblings(LYD_CTX(node), opaq->attr);
     } else {
         /* free the node's metadata */
         lyd_free_meta_siblings(node->meta);

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -66,7 +66,7 @@ lyd_hash(struct lyd_node *node)
         if (!(node->schema->flags & LYS_KEYLESS)) {
             /* list's hash is made of its keys */
             for (iter = list->child; iter && (iter->schema->flags & LYS_KEY); iter = iter->next) {
-                const char *value = LYD_CANONICAL(iter);
+                const char *value = LYD_CANON_VALUE(iter);
                 node->hash = dict_hash_multi(node->hash, value, strlen(value));
             }
         } else {
@@ -74,7 +74,7 @@ lyd_hash(struct lyd_node *node)
             lyd_hash_keyless_list_dfs(list->child, &node->hash);
         }
     } else if (node->schema->nodetype == LYS_LEAFLIST) {
-        const char *value = LYD_CANONICAL(node);
+        const char *value = LYD_CANON_VALUE(node);
         node->hash = dict_hash_multi(node->hash, value, strlen(value));
     }
     /* finish the hash */
@@ -128,7 +128,7 @@ lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, int empty_ht)
 
     /* add node itself */
     if (lyht_insert(ht, &node, node->hash, NULL)) {
-        LOGINT(LYD_NODE_CTX(node));
+        LOGINT(LYD_CTX(node));
         return LY_EINT;
     }
 
@@ -143,14 +143,14 @@ lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, int empty_ht)
         /* remove any previous stored instance, only if we did not start with an empty HT */
         if (!empty_ht && node->next && (node->next->schema == node->schema)) {
             if (lyht_remove(ht, &node->next, hash)) {
-                LOGINT(LYD_NODE_CTX(node));
+                LOGINT(LYD_CTX(node));
                 return LY_EINT;
             }
         }
 
         /* insert this instance as the first (leaf-)list instance */
         if (lyht_insert(ht, &node, hash, NULL)) {
-            LOGINT(LYD_NODE_CTX(node));
+            LOGINT(LYD_CTX(node));
             return LY_EINT;
         }
     }
@@ -208,7 +208,7 @@ lyd_unlink_hash(struct lyd_node *node)
 
     /* remove from the parent HT */
     if (lyht_remove(node->parent->children_ht, &node, node->hash)) {
-        LOGINT(LYD_NODE_CTX(node));
+        LOGINT(LYD_CTX(node));
         return;
     }
 
@@ -221,14 +221,14 @@ lyd_unlink_hash(struct lyd_node *node)
 
         /* remove the instance */
         if (lyht_remove(node->parent->children_ht, &node, hash)) {
-            LOGINT(LYD_NODE_CTX(node));
+            LOGINT(LYD_CTX(node));
             return;
         }
 
         /* add the next instance */
         if (node->next && (node->next->schema == node->schema)) {
             if (lyht_insert(node->parent->children_ht, &node->next, hash, NULL)) {
-                LOGINT(LYD_NODE_CTX(node));
+                LOGINT(LYD_CTX(node));
                 return;
             }
         }

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -188,7 +188,7 @@ lyd_parse_check_keys(struct lyd_node *node)
     key = lyd_node_children(node, 0);
     while ((skey = lys_getnext(skey, node->schema, NULL, 0)) && (skey->flags & LYS_KEY)) {
         if (!key || (key->schema != skey)) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOKEY, skey->name);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOKEY, skey->name);
             return LY_EVALID;
         }
 
@@ -256,7 +256,7 @@ lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_A
     case LYD_ANYDATA_STRING:
     case LYD_ANYDATA_XML:
     case LYD_ANYDATA_JSON:
-        FREE_STRING(LYD_NODE_CTX(trg), t->value.str);
+        FREE_STRING(LYD_CTX(trg), t->value.str);
         break;
     case LYD_ANYDATA_LYB:
         free(t->value.mem);
@@ -281,7 +281,7 @@ lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_A
     case LYD_ANYDATA_XML:
     case LYD_ANYDATA_JSON:
         if (value->str) {
-            t->value.str = lydict_insert(LYD_NODE_CTX(trg), value->str, 0);
+            t->value.str = lydict_insert(LYD_CTX(trg), value->str, 0);
         }
         break;
     case LYD_ANYDATA_LYB:
@@ -289,7 +289,7 @@ lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_A
             len = lyd_lyb_data_length(value->mem);
             LY_CHECK_RET(len == -1, LY_EINVAL);
             t->value.mem = malloc(len);
-            LY_CHECK_ERR_RET(!t->value.mem, LOGMEM(LYD_NODE_CTX(trg)), LY_EMEM);
+            LY_CHECK_ERR_RET(!t->value.mem, LOGMEM(LYD_CTX(trg)), LY_EMEM);
             memcpy(t->value.mem, value->mem, len);
         }
         break;

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1257,8 +1257,6 @@ struct lysc_must {
 
 struct lysc_type {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1266,8 +1264,6 @@ struct lysc_type {
 
 struct lysc_type_num {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1276,8 +1272,6 @@ struct lysc_type_num {
 
 struct lysc_type_dec {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1287,8 +1281,6 @@ struct lysc_type_dec {
 
 struct lysc_type_str {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1312,8 +1304,6 @@ struct lysc_type_bitenum_item {
 
 struct lysc_type_enum {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1322,8 +1312,6 @@ struct lysc_type_enum {
 
 struct lysc_type_bits {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1333,8 +1321,6 @@ struct lysc_type_bits {
 
 struct lysc_type_leafref {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1346,8 +1332,6 @@ struct lysc_type_leafref {
 
 struct lysc_type_identityref {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1357,8 +1341,6 @@ struct lysc_type_identityref {
 
 struct lysc_type_instanceid {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1367,8 +1349,6 @@ struct lysc_type_instanceid {
 
 struct lysc_type_union {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1377,8 +1357,6 @@ struct lysc_type_union {
 
 struct lysc_type_bin {
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    struct lyd_value *dflt;          /**< type's default value if any */
-    struct lys_module *dflt_mod;     /**< module where the lysc_type::dflt value was defined (needed to correctly map prefixes). */
     struct lysc_type_plugin *plugin; /**< type's plugin with built-in as well as user functions to canonize or validate the value of the type */
     LY_DATA_TYPE basetype;           /**< Base type of the type */
     uint32_t refcount;               /**< reference counter for type sharing */
@@ -1567,7 +1545,6 @@ struct lysc_node_leaf {
 
     const char *units;               /**< units of the leaf's type */
     struct lyd_value *dflt;          /**< default value */
-    struct lys_module *dflt_mod;     /**< module where the lysc_node_leaf::dflt value was defined (needed to correctly map prefixes). */
 };
 
 struct lysc_node_leaflist {
@@ -1595,8 +1572,7 @@ struct lysc_node_leaflist {
 
     const char *units;               /**< units of the leaf's type */
     struct lyd_value **dflts;        /**< list ([sized array](@ref sizedarrays)) of default values */
-    struct lys_module **dflts_mods;  /**< list ([sized array](@ref sizedarrays)) of modules where the lysc_node_leaflist::dflts values were defined
-                                          (needed to correctly map prefixes). */
+
     uint32_t min;                    /**< min-elements constraint */
     uint32_t max;                    /**< max-elements constraint */
 

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -597,13 +597,6 @@ lysc_type_free(struct ly_ctx *ctx, struct lysc_type *type)
     if (--type->refcount) {
         return;
     }
-    FREE_ARRAY(ctx, type->exts, lysc_ext_instance_free);
-    if (type->dflt) {
-        type->plugin->free(ctx, type->dflt);
-        lysc_type_free(ctx, type->dflt->realtype);
-        free(type->dflt);
-        type->dflt = NULL;
-    }
 
     switch(type->basetype) {
     case LY_TYPE_BINARY:
@@ -648,6 +641,8 @@ lysc_type_free(struct ly_ctx *ctx, struct lysc_type *type)
         /* nothing to do */
         break;
     }
+
+    FREE_ARRAY(ctx, type->exts, lysc_ext_instance_free);
     free(type);
 }
 
@@ -736,7 +731,6 @@ lysc_node_leaflist_free(struct ly_ctx *ctx, struct lysc_node_leaflist *node)
         free(node->dflts[u]);
     }
     LY_ARRAY_FREE(node->dflts);
-    LY_ARRAY_FREE(node->dflts_mods);
 }
 
 static void

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -160,9 +160,13 @@ struct lys_yin_parser_ctx {
 void yin_parser_ctx_free(struct lys_yin_parser_ctx *ctx);
 
 struct lysc_incomplete_dflt {
-    struct lyd_value *dflt;
+    union {
+        struct lysc_node_leaf *leaf;
+        struct lysc_node_leaflist *llist;
+    };
+    const char *dflt;
+    const char **dflts;
     struct lys_module *dflt_mod;
-    struct lysc_node *context_node;
 };
 
 /**

--- a/src/validation.c
+++ b/src/validation.c
@@ -98,7 +98,7 @@ lyd_validate_when(struct lyd_node **tree, struct lyd_node *node, struct lysc_whe
             lyd_free_tree(node);
         } else {
             /* invalid data */
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOWHEN, when->cond->expr);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOWHEN, when->cond->expr);
             return LY_EVALID;
         }
     } else {
@@ -904,12 +904,12 @@ lyd_validate_must(const struct lyd_node *node, LYD_VALIDATE_OP op)
         } else if (op == LYD_VALIDATE_OP_REPLY) {
             musts = ((struct lysc_action *)node->schema)->output.musts;
         } else {
-            LOGINT(LYD_NODE_CTX(node));
+            LOGINT(LYD_CTX(node));
             return LY_EINT;
         }
         break;
     default:
-        LOGINT(LYD_NODE_CTX(node));
+        LOGINT(LYD_CTX(node));
         return LY_EINT;
     }
 
@@ -934,7 +934,7 @@ lyd_validate_must(const struct lyd_node *node, LYD_VALIDATE_OP op)
         /* check the result */
         lyxp_set_cast(&xp_set, LYXP_SET_BOOLEAN);
         if (!xp_set.val.bln) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOMUST, musts[u].cond->expr);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOMUST, musts[u].cond->expr);
             return LY_EVALID;
         }
     }
@@ -958,20 +958,20 @@ lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, co
 
         /* opaque data */
         if (!node->schema) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LYVE_DATA, "Opaque node \"%s\" found.",
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LYVE_DATA, "Opaque node \"%s\" found.",
                    ((struct lyd_node_opaq *)node)->name);
             return LY_EVALID;
         }
 
         /* no state/input/output data */
         if ((val_opts & LYD_VALIDATE_NO_STATE) && (node->schema->flags & LYS_CONFIG_R)) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "state", node->schema->name);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "state", node->schema->name);
             return LY_EVALID;
         } else if ((op == LYD_VALIDATE_OP_RPC) && (node->schema->flags & LYS_CONFIG_R)) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "output", node->schema->name);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "output", node->schema->name);
             return LY_EVALID;
         } else if ((op == LYD_VALIDATE_OP_REPLY) && (node->schema->flags & LYS_CONFIG_W)) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "input", node->schema->name);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_INNODE, "input", node->schema->name);
             return LY_EVALID;
         }
 
@@ -980,7 +980,7 @@ lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, co
 
         /* node's schema if-features */
         if ((snode = lysc_node_is_disabled(node->schema, 1))) {
-            LOGVAL(LYD_NODE_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOIFF, snode->name);
+            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOIFF, snode->name);
             return LY_EVALID;
         }
 
@@ -1225,12 +1225,12 @@ lyd_validate_op(struct lyd_node *op_tree, const struct lyd_node *tree, LYD_VALID
     }
     if (op == LYD_VALIDATE_OP_RPC || op == LYD_VALIDATE_OP_REPLY) {
         if (!(op_node->schema->nodetype & (LYS_RPC | LYS_ACTION))) {
-            LOGERR(LYD_NODE_CTX(op_tree), LY_EINVAL, "No RPC/action to validate found.");
+            LOGERR(LYD_CTX(op_tree), LY_EINVAL, "No RPC/action to validate found.");
             return LY_EINVAL;
         }
     } else {
         if (op_node->schema->nodetype != LYS_NOTIF) {
-            LOGERR(LYD_NODE_CTX(op_tree), LY_EINVAL, "No notification to validate found.");
+            LOGERR(LYD_CTX(op_tree), LY_EINVAL, "No notification to validate found.");
             return LY_EINVAL;
         }
     }
@@ -1259,7 +1259,7 @@ lyd_validate_op(struct lyd_node *op_tree, const struct lyd_node *tree, LYD_VALID
     /* perform final validation of the operation/notification */
     lyd_validate_obsolete(op_node);
     if (lysc_node_is_disabled(op_node->schema, 1)) {
-        LOGVAL(LYD_NODE_CTX(op_tree), LY_VLOG_LYD, op_node, LY_VCODE_NOIFF, op_node->schema->name);
+        LOGVAL(LYD_CTX(op_tree), LY_VLOG_LYD, op_node, LY_VCODE_NOIFF, op_node->schema->name);
         ret = LY_EVALID;
         goto cleanup;
     }

--- a/src/validation.c
+++ b/src/validation.c
@@ -172,7 +172,7 @@ lyd_validate_unres(struct lyd_node **tree, struct ly_set *node_when, struct ly_s
             struct lyd_node_term *node = (struct lyd_node_term *)node_types->objs[i];
 
             /* validate and store the value of the node */
-            ret = lyd_value_parse(node, node->value.original, strlen(node->value.original), 0, 1, 0, format,
+            ret = lyd_value_parse(node, node->value.canonical, strlen(node->value.canonical), 0, 1, 0, format,
                                   prefix_data, *tree);
             LY_CHECK_RET(ret);
 
@@ -190,8 +190,8 @@ lyd_validate_unres(struct lyd_node **tree, struct ly_set *node_when, struct ly_s
             struct lyd_meta *meta = (struct lyd_meta *)meta_types->objs[i];
 
             /* validate and store the value of the metadata */
-            ret = lyd_value_parse_meta(meta->parent->schema->module->ctx, meta, meta->value.original,
-                                       strlen(meta->value.original), 0, 1, 0, format, prefix_data, NULL, *tree);
+            ret = lyd_value_parse_meta(meta->parent->schema->module->ctx, meta, meta->value.canonical,
+                                       strlen(meta->value.canonical), 0, 1, 0, format, prefix_data, NULL, *tree);
             LY_CHECK_RET(ret);
 
             /* remove this attr from the set */

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -165,7 +165,6 @@ print_set_debug(struct lyxp_set *set)
 {
     uint32_t i;
     char *str;
-    int dynamic;
     struct lyxp_set_node *item;
     struct lyxp_set_scnode *sitem;
 
@@ -193,18 +192,10 @@ print_set_debug(struct lyxp_set *set)
                 if ((item->node->schema->nodetype == LYS_LIST)
                         && (((struct lyd_node_inner *)item->node)->child->schema->nodetype == LYS_LEAF)) {
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): ELEM %s (1st child val: %s)", i + 1, item->pos,
-                           item->node->schema->name,
-                           (str = (char *)lyd_value2str((struct lyd_node_term *)lyd_node_children(item->node, 0), &dynamic)));
-                    if (dynamic) {
-                        free(str);
-                    }
+                           item->node->schema->name, LYD_CANONICAL(lyd_node_children(item->node, 0)));
                 } else if (((struct lyd_node_inner *)item->node)->schema->nodetype == LYS_LEAFLIST) {
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): ELEM %s (val: %s)", i + 1, item->pos,
-                           item->node->schema->name,
-                           (str = (char *)lyd_value2str((struct lyd_node_term *)item->node, &dynamic)));
-                    if (dynamic) {
-                        free(str);
-                    }
+                           item->node->schema->name, LYD_CANONICAL(item->node));
                 } else {
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): ELEM %s", i + 1, item->pos, item->node->schema->name);
                 }
@@ -214,11 +205,7 @@ print_set_debug(struct lyxp_set *set)
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): TEXT <%s>", i + 1, item->pos,
                            item->node->schema->nodetype == LYS_ANYXML ? "anyxml" : "anydata");
                 } else {
-                    LOGDBG(LY_LDGXPATH, "\t%d (pos %u): TEXT %s", i + 1, item->pos,
-                           (str = (char *)lyd_value2str((struct lyd_node_term *)item->node, &dynamic)));
-                    if (dynamic) {
-                        free(str);
-                    }
+                    LOGDBG(LY_LDGXPATH, "\t%d (pos %u): TEXT %s", i + 1, item->pos, LYD_CANONICAL(item->node));
                 }
                 break;
             case LYXP_NODE_META:
@@ -336,7 +323,6 @@ cast_string_recursive(const struct lyd_node *node, int fake_cont, enum lyxp_node
 {
     char *buf, *line, *ptr = NULL;
     const char *value_str;
-    int dynamic;
     const struct lyd_node *child;
     struct lyd_node *tree;
     struct lyd_node_any *any;
@@ -374,16 +360,10 @@ cast_string_recursive(const struct lyd_node *node, int fake_cont, enum lyxp_node
 
     case LYS_LEAF:
     case LYS_LEAFLIST:
-        value_str = lyd_value2str(((struct lyd_node_term *)node), &dynamic);
+        value_str = LYD_CANONICAL(node);
 
         /* print indent */
-        rc = cast_string_realloc(LYD_NODE_CTX(node), indent * 2 + strlen(value_str) + 1, str, used, size);
-        if (rc != LY_SUCCESS) {
-            if (dynamic) {
-                free((char *)value_str);
-            }
-            return rc;
-        }
+        LY_CHECK_RET(cast_string_realloc(LYD_NODE_CTX(node), indent * 2 + strlen(value_str) + 1, str, used, size));
         memset(*str + (*used - 1), ' ', indent * 2);
         *used += indent * 2;
 
@@ -394,9 +374,6 @@ cast_string_recursive(const struct lyd_node *node, int fake_cont, enum lyxp_node
         } else {
             sprintf(*str + (*used - 1), "%s\n", value_str);
             *used += strlen(value_str) + 1;
-        }
-        if (dynamic) {
-            free((char *)value_str);
         }
 
         break;
@@ -522,8 +499,6 @@ cast_string_elem(struct lyd_node *node, int fake_cont, enum lyxp_node_type root_
 static LY_ERR
 cast_node_set_to_string(struct lyxp_set *set, char **str)
 {
-    int dynamic;
-
     switch (set->val.nodes[0].type) {
     case LYXP_NODE_NONE:
         /* invalid */
@@ -535,12 +510,9 @@ cast_node_set_to_string(struct lyxp_set *set, char **str)
     case LYXP_NODE_TEXT:
         return cast_string_elem(set->val.nodes[0].node, 0, set->root_type, str);
     case LYXP_NODE_META:
-        *str = (char *)lyd_meta2str(set->val.meta[0].meta, &dynamic);
-        if (!dynamic) {
-            *str = strdup(*str);
-            if (!*str) {
-                LOGMEM_RET(set->ctx);
-            }
+        *str = strdup(set->val.meta[0].meta->value.canonical);
+        if (!*str) {
+            LOGMEM_RET(set->ctx);
         }
         return LY_SUCCESS;
     }
@@ -1565,9 +1537,8 @@ set_comp_canonize(struct lyxp_set *trg, const struct lyxp_set *src, const struct
     }
 
     /* ignore errors, the value may not satisfy schema constraints */
-    rc = type->plugin->store(src->ctx, type, str, strlen(str),
-                             LY_TYPE_OPTS_STORE | LY_TYPE_OPTS_INCOMPLETE_DATA | LY_TYPE_OPTS_DYNAMIC, LY_PREF_JSON,
-                             NULL, NULL, NULL, &val, NULL, &err);
+    rc = type->plugin->store(src->ctx, type, str, strlen(str), LY_TYPE_OPTS_INCOMPLETE_DATA | LY_TYPE_OPTS_DYNAMIC,
+                             LY_PREF_JSON, NULL, NULL, NULL, &val, &err);
     ly_err_free(err);
     if (rc) {
         /* invalid value */
@@ -3307,6 +3278,7 @@ warn_equality_value(struct lyxp_expr *exp, struct lyxp_set *set, uint16_t val_ex
     struct lysc_node *scnode;
     struct lysc_type *type;
     char *value;
+    struct lyd_value storage;
     LY_ERR rc;
     struct ly_err_item *err = NULL;
 
@@ -3334,7 +3306,7 @@ warn_equality_value(struct lyxp_expr *exp, struct lyxp_set *set, uint16_t val_ex
         type = ((struct lysc_node_leaf *)scnode)->type;
         if (type->basetype != LY_TYPE_IDENT) {
             rc = type->plugin->store(set->ctx, type, value, strlen(value), LY_TYPE_OPTS_SCHEMA, LY_PREF_SCHEMA,
-                                     (void *)set->local_mod, NULL, NULL, NULL, NULL, &err);
+                                     (void *)set->local_mod, NULL, NULL, &storage, &err);
 
             if (err) {
                 LOGWRN(set->ctx, "Invalid value \"%s\" which does not fit the type (%s).", value, err->msg);
@@ -3346,6 +3318,8 @@ warn_equality_value(struct lyxp_expr *exp, struct lyxp_set *set, uint16_t val_ex
                 LOGWRN(set->ctx, "Previous warning generated by XPath subexpression[%u] \"%.*s\".", exp->tok_pos[equal_exp],
                     (exp->tok_pos[last_equal_exp] - exp->tok_pos[equal_exp]) + exp->tok_len[last_equal_exp],
                     exp->expr + exp->tok_pos[equal_exp]);
+            } else {
+                type->plugin->free(set->ctx, &storage);
             }
         }
         free(value);
@@ -3677,8 +3651,6 @@ xpath_deref(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set 
     struct ly_path *p;
     struct lyd_node *node;
     char *errmsg = NULL;
-    const char *val;
-    int dynamic;
     uint8_t oper;
     LY_ERR rc = LY_SUCCESS;
 
@@ -3732,11 +3704,8 @@ xpath_deref(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set 
             } else {
                 assert(sleaf->type->basetype == LY_TYPE_INST);
                 if (ly_path_eval(leaf->value.target, set->tree, &node)) {
-                    val = lyd_value2str(leaf, &dynamic);
-                    LOGERR(set->ctx, LY_EVALID, "Invalid instance-identifier \"%s\" value - required instance not found.", val);
-                    if (dynamic) {
-                        free((char *)val);
-                    }
+                    LOGERR(set->ctx, LY_EVALID, "Invalid instance-identifier \"%s\" value - required instance not found.",
+                           LYD_CANONICAL(leaf));
                     return LY_EVALID;
                 }
             }
@@ -3810,8 +3779,8 @@ xpath_derived_(struct lyxp_set **args, struct lyxp_set *set, int options, int se
 
             /* store args[1] as ident */
             rc = val->realtype->plugin->store(set->ctx, val->realtype, args[1]->val.str, strlen(args[1]->val.str),
-                                              LY_TYPE_OPTS_STORE, set->format, (void *)set->local_mod,
-                                              (struct lyd_node *)leaf, set->tree, &data, NULL, &err);
+                                              0, set->format, (void *)set->local_mod,
+                                              (struct lyd_node *)leaf, set->tree, &data, &err);
         } else {
             meta = args[0]->val.meta[i].meta;
             val = &meta->value;
@@ -3822,8 +3791,8 @@ xpath_derived_(struct lyxp_set **args, struct lyxp_set *set, int options, int se
 
             /* store args[1] as ident */
             rc = val->realtype->plugin->store(set->ctx, val->realtype, args[1]->val.str, strlen(args[1]->val.str),
-                                              LY_TYPE_OPTS_STORE, set->format, (void *)meta->annotation->module,
-                                              meta->parent, set->tree, &data, NULL, &err);
+                                              0, set->format, (void *)meta->annotation->module,
+                                              meta->parent, set->tree, &data, &err);
         }
 
         if (err) {
@@ -4000,7 +3969,7 @@ xpath_lang(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set *
     struct lysc_node_leaf *sleaf;
     struct lyd_meta *meta = NULL;
     const char *val;
-    int i, dynamic;
+    int i;
     LY_ERR rc = LY_SUCCESS;
 
     if (options & LYXP_SCNODE_ALL) {
@@ -4058,7 +4027,7 @@ xpath_lang(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set *
     if (!meta) {
         set_fill_boolean(set, 0);
     } else {
-        val = lyd_meta2str(meta, &dynamic);
+        val = meta->value.canonical;
         for (i = 0; args[0]->val.str[i]; ++i) {
             if (tolower(args[0]->val.str[i]) != tolower(val[i])) {
                 set_fill_boolean(set, 0);
@@ -4071,9 +4040,6 @@ xpath_lang(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set *
             } else {
                 set_fill_boolean(set, 0);
             }
-        }
-        if (dynamic) {
-            free((char *)val);
         }
     }
 

--- a/tests/utests/data/test_new.c
+++ b/tests/utests/data/test_new.c
@@ -218,7 +218,6 @@ test_path(void **state)
 
     LY_ERR ret;
     struct lyd_node *root, *node, *parent;
-    int dynamic;
 
     /* create 2 nodes */
     ret = lyd_new_path2(NULL, ctx, "/a:c/x[.='val']", "vvv", 0, 0, &root, &node);
@@ -227,24 +226,21 @@ test_path(void **state)
     assert_string_equal(root->schema->name, "c");
     assert_non_null(node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val", lyd_value2str((struct lyd_node_term *)node, &dynamic));
-    assert_int_equal(dynamic, 0);
+    assert_string_equal("val", LYD_CANONICAL(node));
 
     /* append another */
     ret = lyd_new_path2(root, NULL, "/a:c/x", "val2", 0, 0, &parent, &node);
     assert_int_equal(ret, LY_SUCCESS);
     assert_ptr_equal(parent, node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val2", lyd_value2str((struct lyd_node_term *)node, &dynamic));
-    assert_int_equal(dynamic, 0);
+    assert_string_equal("val2", LYD_CANONICAL(node));
 
     /* and a last one */
     ret = lyd_new_path2(root, NULL, "x", "val3", 0, 0, &parent, &node);
     assert_int_equal(ret, LY_SUCCESS);
     assert_ptr_equal(parent, node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val3", lyd_value2str((struct lyd_node_term *)node, &dynamic));
-    assert_int_equal(dynamic, 0);
+    assert_string_equal("val3", LYD_CANONICAL(node));
 
     lyd_free_tree(root);
 
@@ -276,8 +272,7 @@ test_path(void **state)
     assert_int_equal(ret, LY_SUCCESS);
     assert_non_null(root);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val", lyd_value2str((struct lyd_node_term *)node, &dynamic));
-    assert_int_equal(dynamic, 0);
+    assert_string_equal("val", LYD_CANONICAL(node));
 
     ret = lyd_new_path2(root, NULL, "/a:l2[1]/c/x", "val", 0, 0, NULL, &node);
     assert_int_equal(ret, LY_EEXIST);
@@ -290,8 +285,7 @@ test_path(void **state)
     assert_int_equal(ret, LY_SUCCESS);
     assert_non_null(node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val2", lyd_value2str((struct lyd_node_term *)node, &dynamic));
-    assert_int_equal(dynamic, 0);
+    assert_string_equal("val2", LYD_CANONICAL(node));
 
     lyd_free_tree(root);
 

--- a/tests/utests/data/test_new.c
+++ b/tests/utests/data/test_new.c
@@ -226,21 +226,21 @@ test_path(void **state)
     assert_string_equal(root->schema->name, "c");
     assert_non_null(node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val", LYD_CANONICAL(node));
+    assert_string_equal("val", LYD_CANON_VALUE(node));
 
     /* append another */
     ret = lyd_new_path2(root, NULL, "/a:c/x", "val2", 0, 0, &parent, &node);
     assert_int_equal(ret, LY_SUCCESS);
     assert_ptr_equal(parent, node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val2", LYD_CANONICAL(node));
+    assert_string_equal("val2", LYD_CANON_VALUE(node));
 
     /* and a last one */
     ret = lyd_new_path2(root, NULL, "x", "val3", 0, 0, &parent, &node);
     assert_int_equal(ret, LY_SUCCESS);
     assert_ptr_equal(parent, node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val3", LYD_CANONICAL(node));
+    assert_string_equal("val3", LYD_CANON_VALUE(node));
 
     lyd_free_tree(root);
 
@@ -272,7 +272,7 @@ test_path(void **state)
     assert_int_equal(ret, LY_SUCCESS);
     assert_non_null(root);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val", LYD_CANONICAL(node));
+    assert_string_equal("val", LYD_CANON_VALUE(node));
 
     ret = lyd_new_path2(root, NULL, "/a:l2[1]/c/x", "val", 0, 0, NULL, &node);
     assert_int_equal(ret, LY_EEXIST);
@@ -285,7 +285,7 @@ test_path(void **state)
     assert_int_equal(ret, LY_SUCCESS);
     assert_non_null(node);
     assert_string_equal(node->schema->name, "x");
-    assert_string_equal("val2", LYD_CANONICAL(node));
+    assert_string_equal("val2", LYD_CANON_VALUE(node));
 
     lyd_free_tree(root);
 

--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -138,12 +138,12 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("foo value", leaf->value.original);
+    assert_string_equal("foo value", leaf->value.canonical);
 
     assert_int_equal(LYS_LEAF, tree->next->next->schema->nodetype);
     assert_string_equal("foo2", tree->next->next->schema->name);
     leaf = (struct lyd_node_term*)tree->next->next;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_true(leaf->flags & LYD_DEFAULT);
 
     lyd_print_tree(out, tree, LYD_JSON, 0);
@@ -158,7 +158,7 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo2", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_false(leaf->flags & LYD_DEFAULT);
 
     lyd_print_tree(out, tree, LYD_JSON, 0);
@@ -173,7 +173,7 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo2", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_true(leaf->flags & LYD_DEFAULT);
 
     /* TODO default values
@@ -192,13 +192,13 @@ test_leaf(void **state)
     assert_non_null(tree->meta);
     assert_string_equal("hint", tree->meta->name);
     assert_int_equal(LY_TYPE_INT8, tree->meta->value.realtype->basetype);
-    assert_string_equal("1", tree->meta->value.original);
+    assert_string_equal("1", tree->meta->value.canonical);
     assert_int_equal(1, tree->meta->value.int8);
     assert_ptr_equal(tree, tree->meta->parent);
     assert_non_null(tree->meta->next);
     assert_string_equal("hint", tree->meta->next->name);
     assert_int_equal(LY_TYPE_INT8, tree->meta->next->value.realtype->basetype);
-    assert_string_equal("2", tree->meta->next->value.original);
+    assert_string_equal("2", tree->meta->next->value.canonical);
     assert_int_equal(2, tree->meta->next->value.int8);
     assert_ptr_equal(tree, tree->meta->next->parent);
     assert_null(tree->meta->next->next);
@@ -242,13 +242,13 @@ test_leaflist(void **state)
     assert_int_equal(LYS_LEAFLIST, tree->schema->nodetype);
     assert_string_equal("ll1", tree->schema->name);
     ll = (struct lyd_node_term*)tree;
-    assert_string_equal("10", ll->value.original);
+    assert_string_equal("10", ll->value.canonical);
 
     assert_non_null(tree->next);
     assert_int_equal(LYS_LEAFLIST, tree->next->schema->nodetype);
     assert_string_equal("ll1", tree->next->schema->name);
     ll = (struct lyd_node_term*)tree->next;
-    assert_string_equal("11", ll->value.original);
+    assert_string_equal("11", ll->value.canonical);
 
     lyd_print_all(out, tree, LYD_JSON, 0);
     assert_string_equal(printed, data);
@@ -262,16 +262,16 @@ test_leaflist(void **state)
     assert_int_equal(LYS_LEAFLIST, tree->schema->nodetype);
     assert_string_equal("ll1", tree->schema->name);
     ll = (struct lyd_node_term*)tree;
-    assert_string_equal("10", ll->value.original);
+    assert_string_equal("10", ll->value.canonical);
     assert_null(ll->meta);
 
     assert_non_null(tree->next);
     assert_int_equal(LYS_LEAFLIST, tree->next->schema->nodetype);
     assert_string_equal("ll1", tree->next->schema->name);
     ll = (struct lyd_node_term*)tree->next;
-    assert_string_equal("11", ll->value.original);
+    assert_string_equal("11", ll->value.canonical);
     assert_non_null(ll->meta);
-    assert_string_equal("2", ll->meta->value.original);
+    assert_string_equal("2", ll->meta->value.canonical);
     assert_null(ll->meta->next);
 
     lyd_print_all(out, tree, LYD_JSON, 0);
@@ -286,17 +286,17 @@ test_leaflist(void **state)
     assert_int_equal(LYS_LEAFLIST, tree->schema->nodetype);
     assert_string_equal("ll1", tree->schema->name);
     ll = (struct lyd_node_term*)tree;
-    assert_string_equal("1", ll->value.original);
+    assert_string_equal("1", ll->value.canonical);
     assert_non_null(ll->meta);
     assert_string_equal("hint", ll->meta->name);
     assert_int_equal(LY_TYPE_INT8, ll->meta->value.realtype->basetype);
-    assert_string_equal("1", ll->meta->value.original);
+    assert_string_equal("1", ll->meta->value.canonical);
     assert_int_equal(1, ll->meta->value.int8);
     assert_ptr_equal(ll, ll->meta->parent);
     assert_non_null(ll->meta->next);
     assert_string_equal("hint", ll->meta->next->name);
     assert_int_equal(LY_TYPE_INT8, ll->meta->next->value.realtype->basetype);
-    assert_string_equal("10", ll->meta->next->value.original);
+    assert_string_equal("10", ll->meta->next->value.canonical);
     assert_int_equal(10, ll->meta->next->value.int8);
     assert_ptr_equal(ll, ll->meta->next->parent);
     assert_null(ll->meta->next->next);
@@ -305,18 +305,18 @@ test_leaflist(void **state)
     assert_int_equal(LYS_LEAFLIST, tree->next->schema->nodetype);
     assert_string_equal("ll1", tree->next->schema->name);
     ll = (struct lyd_node_term*)tree->next;
-    assert_string_equal("2", ll->value.original);
+    assert_string_equal("2", ll->value.canonical);
     assert_null(ll->meta);
 
     assert_non_null(tree->next->next);
     assert_int_equal(LYS_LEAFLIST, tree->next->next->schema->nodetype);
     assert_string_equal("ll1", tree->next->next->schema->name);
     ll = (struct lyd_node_term*)tree->next->next;
-    assert_string_equal("3", ll->value.original);
+    assert_string_equal("3", ll->value.canonical);
     assert_non_null(ll->meta);
     assert_string_equal("hint", ll->meta->name);
     assert_int_equal(LY_TYPE_INT8, ll->meta->value.realtype->basetype);
-    assert_string_equal("3", ll->meta->value.original);
+    assert_string_equal("3", ll->meta->value.canonical);
     assert_int_equal(3, ll->meta->value.int8);
     assert_ptr_equal(ll, ll->meta->parent);
     assert_null(ll->meta->next);
@@ -467,7 +467,7 @@ test_list(void **state)
     assert_string_equal("cp", tree->schema->name);
     assert_non_null(tree->meta);
     assert_string_equal("hint", tree->meta->name);
-    assert_string_equal("1", tree->meta->value.original);
+    assert_string_equal("1", tree->meta->value.canonical);
     assert_ptr_equal(tree, tree->meta->parent);
     assert_null(tree->meta->next);
 

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -132,12 +132,12 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("foo value", leaf->value.original);
+    assert_string_equal("foo value", leaf->value.canonical);
 
     assert_int_equal(LYS_LEAF, tree->next->next->schema->nodetype);
     assert_string_equal("foo2", tree->next->next->schema->name);
     leaf = (struct lyd_node_term*)tree->next->next;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_true(leaf->flags & LYD_DEFAULT);
 
     lyd_free_all(tree);
@@ -149,7 +149,7 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo2", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_false(leaf->flags & LYD_DEFAULT);
 
     lyd_free_all(tree);
@@ -161,7 +161,7 @@ test_leaf(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("foo2", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("default-val", leaf->value.original);
+    assert_string_equal("default-val", leaf->value.canonical);
     assert_true(leaf->flags & LYD_DEFAULT);
 
     lyd_free_all(tree);

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -277,8 +277,7 @@ test_target(void **state)
     struct lyd_node *tree;
     struct lyxp_expr *exp;
     struct ly_path *path;
-    const char *path_str = "/a:l2[2]/c/d[3]", *val;
-    int dynamic;
+    const char *path_str = "/a:l2[2]/c/d[3]";
     const char *data =
         "<l2 xmlns=\"urn:tests:a\"><c>"
             "<d>a</d>"
@@ -300,12 +299,8 @@ test_target(void **state)
     term = lyd_target(path, tree);
 
     assert_string_equal(term->schema->name, "d");
-    val = lyd_value2str(term, &dynamic);
-    assert_int_equal(dynamic, 0);
-    assert_string_equal(val, "b");
-    val = lyd_value2str((struct lyd_node_term *)term->prev, &dynamic);
-    assert_int_equal(dynamic, 0);
-    assert_string_equal(val, "b");
+    assert_string_equal(LYD_CANONICAL(term), "b");
+    assert_string_equal(LYD_CANONICAL(term->prev), "b");
 
     lyd_free_all(tree);
     ly_path_free(ctx, path);

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -299,8 +299,8 @@ test_target(void **state)
     term = lyd_target(path, tree);
 
     assert_string_equal(term->schema->name, "d");
-    assert_string_equal(LYD_CANONICAL(term), "b");
-    assert_string_equal(LYD_CANONICAL(term->prev), "b");
+    assert_string_equal(LYD_CANON_VALUE(term), "b");
+    assert_string_equal(LYD_CANON_VALUE(term->prev), "b");
 
     lyd_free_all(tree);
     ly_path_free(ctx, path);

--- a/tests/utests/data/test_types.c
+++ b/tests/utests/data/test_types.c
@@ -181,12 +181,12 @@ test_int(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("int8", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("15", leaf->value.canonical_cache);
+    assert_string_equal("15", leaf->value.canonical);
     assert_int_equal(15, leaf->value.int8);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_int_equal(15, value.int8);
     value.realtype->plugin->free(s->ctx, &value);
     memset(&value, 0, sizeof value);
@@ -222,12 +222,12 @@ test_uint(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("uint8", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("150", leaf->value.canonical_cache);
+    assert_string_equal("150", leaf->value.canonical);
     assert_int_equal(150, leaf->value.uint8);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_int_equal(150, value.uint8);
     value.realtype->plugin->free(s->ctx, &value);
     memset(&value, 0, sizeof value);
@@ -263,12 +263,12 @@ test_dec64(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("dec64", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("8.0", leaf->value.canonical_cache);
+    assert_string_equal("8.0", leaf->value.canonical);
     assert_int_equal(80, leaf->value.dec64);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_int_equal(80, value.dec64);
     value.realtype->plugin->free(s->ctx, &value);
     memset(&value, 0, sizeof value);
@@ -278,7 +278,7 @@ test_dec64(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("dec64", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("8.0", leaf->value.canonical_cache);
+    assert_string_equal("8.0", leaf->value.canonical);
     assert_int_equal(80, leaf->value.dec64);
     lyd_free_all(tree);
 
@@ -286,7 +286,7 @@ test_dec64(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("dec64-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("-9.223372036854775808", leaf->value.canonical_cache);
+    assert_string_equal("-9.223372036854775808", leaf->value.canonical);
     assert_int_equal(INT64_C(-9223372036854775807) - INT64_C(1), leaf->value.dec64);
     lyd_free_all(tree);
 
@@ -294,7 +294,7 @@ test_dec64(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("dec64-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("9.223372036854775807", leaf->value.canonical_cache);
+    assert_string_equal("9.223372036854775807", leaf->value.canonical);
     assert_int_equal(INT64_C(9223372036854775807), leaf->value.dec64);
     lyd_free_all(tree);
 
@@ -328,7 +328,7 @@ test_string(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("str", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("teststring", leaf->value.canonical_cache);
+    assert_string_equal("teststring", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* multibyte characters (€ encodes as 3-byte UTF8 character, length restriction is 2-5) */
@@ -336,7 +336,7 @@ test_string(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("str-utf8", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("€€", leaf->value.canonical_cache);
+    assert_string_equal("€€", leaf->value.canonical);
     lyd_free_all(tree);
     TEST_DATA("<str-utf8 xmlns=\"urn:tests:types\">€</str-utf8>", LY_EVALID, "Length \"1\" does not satisfy the length constraint. /types:str-utf8");
     TEST_DATA("<str-utf8 xmlns=\"urn:tests:types\">€€€€€€</str-utf8>", LY_EVALID, "Length \"6\" does not satisfy the length constraint. /types:str-utf8");
@@ -369,14 +369,14 @@ test_bits(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("bits", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("zero two", leaf->value.canonical_cache);
+    assert_string_equal("zero two", leaf->value.canonical);
     assert_int_equal(2, LY_ARRAY_COUNT(leaf->value.bits_items));
     assert_string_equal("zero", leaf->value.bits_items[0]->name);
     assert_string_equal("two", leaf->value.bits_items[1]->name);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_int_equal(2, LY_ARRAY_COUNT(value.bits_items));
     assert_string_equal("zero", value.bits_items[0]->name);
     assert_string_equal("two", value.bits_items[1]->name);
@@ -388,7 +388,7 @@ test_bits(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("bits", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("zero two", leaf->value.canonical_cache);
+    assert_string_equal("zero two", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* disabled feature */
@@ -400,13 +400,13 @@ test_bits(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("bits", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("one", leaf->value.canonical_cache);
+    assert_string_equal("one", leaf->value.canonical);
     assert_int_equal(1, LY_ARRAY_COUNT(leaf->value.bits_items));
     assert_string_equal("one", leaf->value.bits_items[0]->name);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_int_equal(1, LY_ARRAY_COUNT(value.bits_items));
     assert_string_equal("one", value.bits_items[0]->name);
     value.realtype->plugin->free(s->ctx, &value);
@@ -438,12 +438,12 @@ test_enums(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("enums", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("white", leaf->value.canonical_cache);
+    assert_string_equal("white", leaf->value.canonical);
     assert_string_equal("white", leaf->value.enum_item->name);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     assert_string_equal("white", value.enum_item->name);
     value.realtype->plugin->free(s->ctx, &value);
     lyd_free_all(tree);
@@ -458,7 +458,7 @@ test_enums(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("enums", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("yellow", leaf->value.canonical_cache);
+    assert_string_equal("yellow", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* leading/trailing whitespaces are not valid */
@@ -488,16 +488,16 @@ test_binary(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("binary", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("aGVs\nbG8=", leaf->value.canonical_cache);
+    assert_string_equal("aGVs\nbG8=", leaf->value.canonical);
     assert_non_null(tree = tree->next);
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("binary-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("TQ==", leaf->value.canonical_cache);
+    assert_string_equal("TQ==", leaf->value.canonical);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal(leaf->value.canonical_cache, value.canonical_cache);
+    assert_string_equal(leaf->value.canonical, value.canonical);
     value.realtype->plugin->free(s->ctx, &value);
     memset(&value, 0, sizeof value);
     lyd_free_all(tree);
@@ -507,19 +507,19 @@ test_binary(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("binary-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("</binary-norestr>", leaf->value.canonical);
     lyd_free_all(tree);
     TEST_DATA("<binary-norestr xmlns=\"urn:tests:types\"></binary-norestr>", LY_SUCCESS, "");
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("binary-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("", leaf->value.canonical);
     lyd_free_all(tree);
     TEST_DATA("<binary-norestr xmlns=\"urn:tests:types\"/>", LY_SUCCESS, "");
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("binary-norestr", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* invalid base64 character */
@@ -559,7 +559,7 @@ test_boolean(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("bool", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("true", leaf->value.canonical_cache);
+    assert_string_equal("true", leaf->value.canonical);
     assert_int_equal(1, leaf->value.boolean);
     lyd_free_all(tree);
 
@@ -567,7 +567,7 @@ test_boolean(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("bool", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("false", leaf->value.canonical_cache);
+    assert_string_equal("false", leaf->value.canonical);
     assert_int_equal(0, leaf->value.boolean);
     lyd_free_all(tree);
 
@@ -575,7 +575,7 @@ test_boolean(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("tbool", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("false", leaf->value.canonical_cache);
+    assert_string_equal("false", leaf->value.canonical);
     assert_int_equal(0, leaf->value.boolean);
     lyd_free_all(tree);
 
@@ -603,21 +603,21 @@ test_empty(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("empty", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<empty xmlns=\"urn:tests:types\"/>", LY_SUCCESS, "");
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("empty", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<tempty xmlns=\"urn:tests:types\"/>", LY_SUCCESS, "");
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("tempty", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("", leaf->value.canonical_cache);
+    assert_string_equal("", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* invalid value */
@@ -658,13 +658,14 @@ test_identityref(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("ident", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_non_null(leaf->value.canonical);
+    assert_string_equal("types:gigabit-ethernet", leaf->value.canonical);
     assert_string_equal("gigabit-ethernet", leaf->value.ident->name);
     test_printed_value(&leaf->value, "t:gigabit-ethernet", LY_PREF_SCHEMA, s->mod_types);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_null(value.canonical_cache);
+    assert_string_equal("types:gigabit-ethernet", value.canonical);
     assert_string_equal("gigabit-ethernet", value.ident->name);
     value.realtype->plugin->free(s->ctx, &value);
     lyd_free_all(tree);
@@ -673,7 +674,7 @@ test_identityref(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("ident", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("defs:fast-ethernet", leaf->value.canonical);
     test_printed_value(&leaf->value, "d:fast-ethernet", LY_PREF_SCHEMA, s->mod_defs);
     lyd_free_all(tree);
 
@@ -721,7 +722,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:cont/leaftarget", leaf->value.canonical);
     assert_int_equal(2, LY_ARRAY_COUNT(leaf->value.target));
     assert_string_equal("cont", leaf->value.target[0].node->name);
     assert_null(leaf->value.target[0].predicates);
@@ -730,7 +731,7 @@ test_instanceid(void **state)
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_null(value.canonical_cache);
+    assert_string_equal("/types:cont/leaftarget", value.canonical);
     assert_true(LY_ARRAY_COUNT(leaf->value.target) == LY_ARRAY_COUNT(value.target));
     assert_true(leaf->value.target[0].node == value.target[0].node);
     assert_true(leaf->value.target[0].predicates == value.target[0].predicates); /* NULL */
@@ -745,7 +746,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:list[id='b']/id", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<leaflisttarget xmlns=\"urn:tests:types\">1</leaflisttarget><leaflisttarget xmlns=\"urn:tests:types\">2</leaflisttarget>"
@@ -754,7 +755,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:leaflisttarget[.='1']", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list_inst xmlns=\"urn:tests:types\"><id xmlns:b=\"urn:tests:types\">/b:leaflisttarget[.='a']</id><value>x</value></list_inst>"
@@ -765,7 +766,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:list_inst[id=\"/types:leaflisttarget[.='b']\"]/value", leaf->value.canonical);
     assert_int_equal(2, LY_ARRAY_COUNT(leaf->value.target));
     assert_string_equal("list_inst", leaf->value.target[0].node->name);
     assert_int_equal(1, LY_ARRAY_COUNT(leaf->value.target[0].predicates));
@@ -777,7 +778,7 @@ test_instanceid(void **state)
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_null(value.canonical_cache);
+    assert_string_equal("/types:list_inst[id=\"/types:leaflisttarget[.='b']\"]/value", value.canonical);
     assert_true(LY_ARRAY_COUNT(leaf->value.target) == LY_ARRAY_COUNT(value.target));
     assert_true(leaf->value.target[0].node == value.target[0].node);
     assert_true(LY_ARRAY_COUNT(leaf->value.target[0].predicates) == LY_ARRAY_COUNT(value.target[0].predicates));
@@ -792,7 +793,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:list[id='b']/value", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list_inst xmlns=\"urn:tests:types\"><id xmlns:b=\"urn:tests:types\">/b:leaflisttarget[.='a']</id><value>x</value></list_inst>"
@@ -803,7 +804,7 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:list_inst[id=\"/types:leaflisttarget[.='a']\"]/value", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list_ident xmlns=\"urn:tests:types\"><id xmlns:dfs=\"urn:tests:defs\">dfs:ethernet</id><value>x</value></list_ident>"
@@ -813,7 +814,8 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_non_null(leaf->value.canonical);
+    assert_string_equal("/types:list_ident[id='defs:fast-ethernet']/value", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list2 xmlns=\"urn:tests:types\"><id>types:xxx</id><value>x</value></list2>"
@@ -823,7 +825,8 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_non_null(leaf->value.canonical);
+    assert_string_equal("/types:list2[id='a:xxx'][value='y']/value", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list xmlns=\"urn:tests:types\"><id>types:xxx</id><value>x</value></list>"
@@ -833,7 +836,8 @@ test_instanceid(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("inst", tree->schema->name);
     leaf = (const struct lyd_node_term*)tree;
-    assert_null(leaf->value.canonical_cache);
+    assert_non_null(leaf->value.canonical);
+    assert_string_equal("/types:list[id='a:xxx']/value", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list2 xmlns=\"urn:tests:types\"><id>a</id><value>a</value></list2>"
@@ -843,10 +847,11 @@ test_instanceid(void **state)
     leaf = (const struct lyd_node_term*)tree->prev->prev;
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("inst", leaf->schema->name);
-    assert_null(leaf->value.canonical_cache);
+    assert_non_null(leaf->value.canonical);
+    assert_string_equal("/types:list2[id='a'][value='b']/id", leaf->value.canonical);
     assert_non_null(leaf = lyd_target(leaf->value.target, tree));
-    assert_string_equal("a", leaf->value.canonical_cache);
-    assert_string_equal("b", ((struct lyd_node_term*)leaf->next)->value.canonical_cache);
+    assert_string_equal("a", leaf->value.canonical);
+    assert_string_equal("b", ((struct lyd_node_term*)leaf->next)->value.canonical);
     lyd_free_all(tree);
 
     /* invalid value */
@@ -864,10 +869,10 @@ test_instanceid(void **state)
     TEST_DATA("<inst xmlns=\"urn:tests:types\">/cont/leaftarget</inst>", LY_EVALID,
               "Invalid instance-identifier \"/cont/leaftarget\" value - syntax error. /types:inst");
 
-    /* instance-identifier is here in JSON format because it is already in internal representation without original prefixes */
+    /* instance-identifier is here in JSON format because it is already in internal representation without canonical prefixes */
     TEST_DATA( "<cont xmlns=\"urn:tests:types\"/><t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:leaftarget</t:inst>", LY_EVALID, "Invalid instance-identifier \"/types:cont/leaftarget\" value - required instance not found. /types:inst");
 
-    /* instance-identifier is here in JSON format because it is already in internal representation without original prefixes */
+    /* instance-identifier is here in JSON format because it is already in internal representation without canonical prefixes */
     TEST_DATA( "<t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:leaftarget</t:inst>", LY_EVALID, "Invalid instance-identifier \"/types:cont/leaftarget\" value - required instance not found. /types:inst");
 
     TEST_DATA("<leaflisttarget xmlns=\"urn:tests:types\">x</leaflisttarget><t:inst xmlns:t=\"urn:tests:types\">/t:leaflisttarget[1</t:inst>", LY_EVALID,
@@ -899,7 +904,7 @@ test_instanceid(void **state)
               "<t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:listtarget[.='x']</t:inst>", LY_EVALID,
               "Invalid instance-identifier \"/t:cont/t:listtarget[.='x']\" value - semantic error. /types:inst");
 
-    /* instance-identifier is here in JSON format because it is already in internal representation without original prefixes */
+    /* instance-identifier is here in JSON format because it is already in internal representation without canonical prefixes */
     TEST_DATA("<cont xmlns=\"urn:tests:types\"><leaflisttarget>1</leaflisttarget></cont>"
               "<t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:leaflisttarget[.='2']</t:inst>", LY_EVALID,
               "Invalid instance-identifier \"/types:cont/leaflisttarget[.='2']\" value - required instance not found. /types:inst");
@@ -910,7 +915,7 @@ test_instanceid(void **state)
               "<t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:listtarget[t:id='x']</t:inst>", LY_EVALID,
               "Invalid instance-identifier \"/t:cont/t:listtarget[t:id='x']\" value - semantic error. /types:inst");
 
-    /* instance-identifier is here in JSON format because it is already in internal representation without original prefixes */
+    /* instance-identifier is here in JSON format because it is already in internal representation without canonical prefixes */
     TEST_DATA("<cont xmlns=\"urn:tests:types\"><listtarget><id>1</id><value>x</value></listtarget></cont>"
               "<t:inst xmlns:t=\"urn:tests:types\">/t:cont/t:listtarget[t:id='2']</t:inst>", LY_EVALID,
               "Invalid instance-identifier \"/types:cont/listtarget[id='2']\" value - required instance not found. /types:inst");
@@ -994,7 +999,7 @@ test_leafref(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("lref", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("y", leaf->value.canonical_cache);
+    assert_string_equal("y", leaf->value.canonical);
     assert_int_equal(LY_TYPE_STRING, leaf->value.realtype->plugin->type);
     lyd_free_all(tree);
 
@@ -1005,7 +1010,7 @@ test_leafref(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("lref2", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("y", leaf->value.canonical_cache);
+    assert_string_equal("y", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<str-norestr xmlns=\"urn:tests:types\">y</str-norestr>"
@@ -1014,7 +1019,7 @@ test_leafref(void **state)
     leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->next, 0)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr1", leaf->schema->name);
-    assert_string_equal("y", leaf->value.canonical_cache);
+    assert_string_equal("y", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<str-norestr xmlns=\"urn:tests:types\">y</str-norestr>"
@@ -1024,7 +1029,7 @@ test_leafref(void **state)
     leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->prev, 0)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr2", leaf->schema->name);
-    assert_string_equal("y", leaf->value.canonical_cache);
+    assert_string_equal("y", leaf->value.canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<list xmlns=\"urn:tests:types\"><id>x</id><targets>a</targets><targets>b</targets></list>"
@@ -1035,7 +1040,7 @@ test_leafref(void **state)
     leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->prev, 0)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr3", leaf->schema->name);
-    assert_string_equal("c", leaf->value.canonical_cache);
+    assert_string_equal("c", leaf->value.canonical);
     lyd_free_all(tree);
 
     /* invalid value */
@@ -1098,25 +1103,23 @@ test_union(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("12", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("12", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 1);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_INT8, leaf->value.subvalue->value->realtype->basetype);
-    assert_string_equal("12", leaf->value.subvalue->value->canonical_cache);
+    assert_string_equal("12", leaf->value.subvalue->value->canonical);
     assert_int_equal(12, leaf->value.subvalue->value->int8);
 
     test_printed_value(&leaf->value, "12", LY_PREF_SCHEMA, NULL);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal("12", value.original);
-    assert_null(value.canonical_cache);
+    assert_string_equal("12", value.canonical);
     assert_non_null(value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 1);
     assert_int_equal(LY_TYPE_INT8, value.subvalue->value->realtype->basetype);
-    assert_string_equal("12", value.subvalue->value->canonical_cache);
+    assert_string_equal("12", value.subvalue->value->canonical);
     assert_int_equal(12, leaf->value.subvalue->value->int8);
     value.realtype->plugin->free(s->ctx, &value);
     lyd_free_all(tree);
@@ -1126,35 +1129,32 @@ test_union(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("2", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("2", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 1);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_STRING, leaf->value.subvalue->value->realtype->basetype);
-    assert_string_equal("2", leaf->value.subvalue->value->canonical_cache);
+    assert_string_equal("2", leaf->value.subvalue->value->canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<un1 xmlns=\"urn:tests:types\" xmlns:x=\"urn:tests:defs\">x:fast-ethernet</un1>", LY_SUCCESS, "");
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("x:fast-ethernet", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("defs:fast-ethernet", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 2);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_IDENT, leaf->value.subvalue->value->realtype->basetype);
-    assert_null(leaf->value.subvalue->value->canonical_cache); /* identityref does not have canonical form */
+    assert_string_equal("defs:fast-ethernet", leaf->value.subvalue->value->canonical);
 
     test_printed_value(&leaf->value, "d:fast-ethernet", LY_PREF_SCHEMA, s->mod_defs);
     test_printed_value(leaf->value.subvalue->value, "d:fast-ethernet", LY_PREF_SCHEMA, s->mod_defs);
 
     value.realtype = leaf->value.realtype;
     assert_int_equal(LY_SUCCESS, value.realtype->plugin->duplicate(s->ctx, &leaf->value, &value));
-    assert_string_equal("x:fast-ethernet", value.original);
-    assert_null(value.canonical_cache);
-    assert_null(value.subvalue->value->canonical_cache);
+    assert_string_equal("defs:fast-ethernet", value.canonical);
+    assert_string_equal("defs:fast-ethernet", value.subvalue->value->canonical);
     assert_non_null(value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 2);
     assert_int_equal(LY_TYPE_IDENT, value.subvalue->value->realtype->basetype);
@@ -1166,13 +1166,12 @@ test_union(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("d:superfast-ethernet", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("d:superfast-ethernet", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 2);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_STRING, leaf->value.subvalue->value->realtype->basetype);
-    assert_string_equal("d:superfast-ethernet", leaf->value.subvalue->value->canonical_cache);
+    assert_string_equal("d:superfast-ethernet", leaf->value.subvalue->value->canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<leaflisttarget xmlns=\"urn:tests:types\">x</leaflisttarget><leaflisttarget xmlns=\"urn:tests:types\">y</leaflisttarget>"
@@ -1181,13 +1180,12 @@ test_union(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("/a:leaflisttarget[.='y']", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/types:leaflisttarget[.='y']", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 2);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_INST, leaf->value.subvalue->value->realtype->basetype);
-    assert_null(leaf->value.subvalue->value->canonical_cache); /* instance-identifier does not have canonical form */
+    assert_string_equal("/types:leaflisttarget[.='y']", leaf->value.subvalue->value->canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<leaflisttarget xmlns=\"urn:tests:types\">x</leaflisttarget><leaflisttarget xmlns=\"urn:tests:types\">y</leaflisttarget>"
@@ -1196,13 +1194,12 @@ test_union(void **state)
     assert_int_equal(LYS_LEAF, tree->schema->nodetype);
     assert_string_equal("un1", tree->schema->name);
     leaf = (struct lyd_node_term*)tree;
-    assert_string_equal("/a:leaflisttarget[3]", leaf->value.original);
-    assert_null(leaf->value.canonical_cache);
+    assert_string_equal("/a:leaflisttarget[3]", leaf->value.canonical);
     assert_non_null(leaf->value.subvalue->prefix_data);
     assert_int_equal(((struct ly_set *)leaf->value.subvalue->prefix_data)->count, 2);
     assert_int_equal(LY_TYPE_UNION, leaf->value.realtype->basetype);
     assert_int_equal(LY_TYPE_STRING, leaf->value.subvalue->value->realtype->basetype);
-    assert_string_equal("/a:leaflisttarget[3]", leaf->value.subvalue->value->canonical_cache);
+    assert_string_equal("/a:leaflisttarget[3]", leaf->value.subvalue->value->canonical);
     lyd_free_all(tree);
 
     TEST_DATA("<un1 xmlns=\"urn:tests:types\">123456789012345678901</un1>", LY_EVALID, "Invalid union value \"123456789012345678901\" - no matching subtype found. /types:un1");

--- a/tests/utests/schema/test_schema_stmts.c
+++ b/tests/utests/schema/test_schema_stmts.c
@@ -134,12 +134,12 @@ test_identity(void **state)
 
     /* default value from non-implemented module */
     TEST_SCHEMA_ERR(ctx, 0, 0, "ident2", "import base {prefix b;} leaf l {type identityref {base b:i1;} default b:i2;}",
-                    "Invalid leaf's default value \"b:i2\" which does not fit the type (Invalid identityref \"b:i2\" value"
+                    "Invalid default - value does not fit the type (Invalid identityref \"b:i2\" value"
                     " - identity found in non-implemented module \"base\".). /ident2:l");
 
     /* default value in typedef from non-implemented module */
     TEST_SCHEMA_ERR(ctx, 0, 0, "ident2", "import base {prefix b;} typedef t1 {type identityref {base b:i1;} default b:i2;}"
-                    "leaf l {type t1;}", "Invalid type's default value \"b:i2\" which does not fit the type (Invalid"
+                    "leaf l {type t1;}", "Invalid default - value does not fit the type (Invalid"
                     " identityref \"b:i2\" value - identity found in non-implemented module \"base\".). /ident2:l");
 
     /*

--- a/tests/utests/test_xpath.c
+++ b/tests/utests/test_xpath.c
@@ -223,8 +223,6 @@ test_hash(void **state)
     "</c>";
     struct lyd_node *tree, *node;
     struct ly_set *set;
-    int dynamic;
-    const char *val_str;
 
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(ctx, data, LYD_XML, LYD_PARSE_STRICT, LYD_VALIDATE_PRESENT, &tree));
     assert_non_null(tree);
@@ -237,9 +235,7 @@ test_hash(void **state)
     assert_string_equal(node->schema->name, "l1");
     node = lyd_node_children(node, 0);
     assert_string_equal(node->schema->name, "a");
-    val_str = lyd_value2str((struct lyd_node_term *)node, &dynamic);
-    assert_int_equal(0, dynamic);
-    assert_string_equal(val_str, "a3");
+    assert_string_equal(LYD_CANONICAL(node), "a3");
 
     ly_set_free(set, NULL);
 
@@ -251,9 +247,7 @@ test_hash(void **state)
     assert_string_equal(node->schema->name, "ll");
     node = lyd_node_children(node, 0);
     assert_string_equal(node->schema->name, "a");
-    val_str = lyd_value2str((struct lyd_node_term *)node, &dynamic);
-    assert_int_equal(0, dynamic);
-    assert_string_equal(val_str, "val_b");
+    assert_string_equal(LYD_CANONICAL(node), "val_b");
     node = node->next;
     assert_string_equal(node->schema->name, "b");
     assert_null(node->next);
@@ -272,9 +266,7 @@ test_hash(void **state)
 
     node = set->objs[0];
     assert_string_equal(node->schema->name, "ll2");
-    val_str = lyd_value2str((struct lyd_node_term *)node, &dynamic);
-    assert_int_equal(0, dynamic);
-    assert_string_equal(val_str, "three");
+    assert_string_equal(LYD_CANONICAL(node), "three");
 
     ly_set_free(set, NULL);
 

--- a/tests/utests/test_xpath.c
+++ b/tests/utests/test_xpath.c
@@ -235,7 +235,7 @@ test_hash(void **state)
     assert_string_equal(node->schema->name, "l1");
     node = lyd_node_children(node, 0);
     assert_string_equal(node->schema->name, "a");
-    assert_string_equal(LYD_CANONICAL(node), "a3");
+    assert_string_equal(LYD_CANON_VALUE(node), "a3");
 
     ly_set_free(set, NULL);
 
@@ -247,7 +247,7 @@ test_hash(void **state)
     assert_string_equal(node->schema->name, "ll");
     node = lyd_node_children(node, 0);
     assert_string_equal(node->schema->name, "a");
-    assert_string_equal(LYD_CANONICAL(node), "val_b");
+    assert_string_equal(LYD_CANON_VALUE(node), "val_b");
     node = node->next;
     assert_string_equal(node->schema->name, "b");
     assert_null(node->next);
@@ -266,7 +266,7 @@ test_hash(void **state)
 
     node = set->objs[0];
     assert_string_equal(node->schema->name, "ll2");
-    assert_string_equal(LYD_CANONICAL(node), "three");
+    assert_string_equal(LYD_CANON_VALUE(node), "three");
 
     ly_set_free(set, NULL);
 

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -133,6 +133,7 @@ main(int argc, char* argv[])
     ssize_t l;
     struct lysc_type *type;
     struct ly_err_item *err = NULL;
+    struct lyd_value storage;
 
     opterr = 0;
     while ((i = getopt_long(argc, argv, "hf:ivVp:", options, &opt_index)) != -1) {
@@ -272,8 +273,11 @@ main(int argc, char* argv[])
         goto cleanup;
     }
 
-    type = ((struct lysc_node_leaf*)mod->compiled->data)->type;
-    match = type->plugin->store(ctx, type, str, strlen(str), 0, LY_PREF_JSON, NULL, NULL, NULL, NULL, NULL, &err);
+    type = ((struct lysc_node_leaf *)mod->compiled->data)->type;
+    match = type->plugin->store(ctx, type, str, strlen(str), 0, LY_PREF_JSON, NULL, NULL, NULL, &storage, &err);
+    if ((match == LY_SUCCESS) || (match == LY_EINCOMPLETE)) {
+        storage.realtype->plugin->free(ctx, &storage);
+    }
     if (verbose) {
         for (i = 0; i < patterns_count; i++) {
             fprintf(stdout, "pattern  %d: %s\n", i + 1, patterns[i]);


### PR DESCRIPTION
The behavior was changed as if both of these
flags are always set. Also, types now always
include their canonical/JSON string value.

Finally, default value resolution was also
refactored to avoid some code duplication.
This change was most evident in deviations,
which were then significantly refactored.