### PR TITLE
libyang REFACTOR use size-specific int types instead of generic types

### DIFF
--- a/compat/compat.c
+++ b/compat/compat.c
@@ -128,7 +128,7 @@ getline(char **lineptr, size_t *n, FILE *stream)
 {
     static char line[256];
     char *ptr;
-    unsigned int len;
+    ssize_t len;
 
     if (!lineptr || !n) {
         errno = EINVAL;

--- a/src/common.c
+++ b/src/common.c
@@ -164,7 +164,7 @@ ly_realloc(void *ptr, size_t size)
 }
 
 char *
-ly_strnchr(const char *s, int c, unsigned int len)
+ly_strnchr(const char *s, int c, size_t len)
 {
     for ( ; *s != (char)c; ++s, --len) {
         if ((*s == '\0') || (!len)) {
@@ -188,9 +188,8 @@ ly_strncmp(const char *refstr, const char *str, size_t str_len)
 LY_ERR
 ly_getutf8(const char **input, uint32_t *utf8_char, size_t *bytes_read)
 {
-    uint32_t c, len;
-    int aux;
-    int i;
+    uint32_t c, aux;
+    size_t len;
 
     if (bytes_read) {
         (*bytes_read) = 0;
@@ -224,7 +223,7 @@ ly_getutf8(const char **input, uint32_t *utf8_char, size_t *bytes_read)
         len = 3;
 
         c &= 0x0f;
-        for (i = 1; i <= 2; i++) {
+        for (uint64_t i = 1; i <= 2; i++) {
             aux = (*input)[i];
             if ((aux & 0xc0) != 0x80) {
                 return LY_EINVAL;
@@ -241,7 +240,7 @@ ly_getutf8(const char **input, uint32_t *utf8_char, size_t *bytes_read)
         len = 4;
 
         c &= 0x07;
-        for (i = 1; i <= 3; i++) {
+        for (uint64_t i = 1; i <= 3; i++) {
             aux = (*input)[i];
             if ((aux & 0xc0) != 0x80) {
                 return LY_EINVAL;
@@ -574,7 +573,7 @@ ly_parse_instance_predicate(const char **pred, size_t limit, LYD_FORMAT format,
     LY_ERR ret = LY_EVALID;
     const char *in = *pred;
     size_t offset = 1;
-    int expr = 0;
+    uint8_t expr = 0;
     char quot;
 
     assert(in[0] == '\[');

--- a/src/common.h
+++ b/src/common.h
@@ -67,8 +67,8 @@ enum LY_VLOG_ELEM {
 };
 
 extern THREAD_LOCAL enum int_log_opts log_opt;
-extern volatile uint8_t ly_log_level;
-extern volatile uint8_t ly_log_opts;
+extern volatile LY_LOG_LEVEL ly_log_level;
+extern volatile uint32_t ly_log_opts;
 
 /**
  * @brief Set error-app-tag to the last error record in the context.
@@ -105,7 +105,7 @@ void ly_vlog(const struct ly_ctx *ctx, enum LY_VLOG_ELEM elem_type, const void *
 #ifdef NDEBUG
 #  define LOGDBG(dbg_group, str, ...)
 #else
-void ly_log_dbg(int group, const char *format, ...);
+void ly_log_dbg(uint32_t group, const char *format, ...);
 #  define LOGDBG(dbg_group, str, ...) ly_log_dbg(dbg_group, str, ##__VA_ARGS__);
 #endif
 
@@ -326,7 +326,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] len Limit the search to this number of characters in @p s.
  * @return Pointer to first @p c occurence in @p s, NULL if not found in first @p len characters.
  */
-char *ly_strnchr(const char *s, int c, unsigned int len);
+char *ly_strnchr(const char *s, int c, size_t len);
 
 /**
  * @brief Compare NULL-terminated @p refstr with @str_len bytes from @p str.

--- a/src/context.c
+++ b/src/context.c
@@ -70,7 +70,6 @@ ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
 {
     struct stat st;
     char *new_dir = NULL;
-    unsigned int u;
 
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
 
@@ -92,7 +91,7 @@ ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
                          LOGERR(ctx, LY_ESYS, "Given search directory \"%s\" is not a directory.", new_dir); free(new_dir),
                          LY_EINVAL);
         /* avoid path duplication */
-        for (u = 0; u < ctx->search_paths.count; ++u) {
+        for (uint32_t u = 0; u < ctx->search_paths.count; ++u) {
             if (!strcmp(new_dir, ctx->search_paths.objs[u])) {
                 free(new_dir);
                 return LY_EEXIST;
@@ -136,8 +135,6 @@ ly_ctx_get_searchdirs(const struct ly_ctx *ctx)
 API LY_ERR
 ly_ctx_unset_searchdir(struct ly_ctx *ctx, const char *value)
 {
-    unsigned int index;
-
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
 
     if (!ctx->search_paths.count) {
@@ -146,6 +143,8 @@ ly_ctx_unset_searchdir(struct ly_ctx *ctx, const char *value)
 
     if (value) {
         /* remove specific search directory */
+        uint32_t index;
+
         for (index = 0; index < ctx->search_paths.count; ++index) {
             if (!strcmp(value, ctx->search_paths.objs[index])) {
                 break;
@@ -167,7 +166,7 @@ ly_ctx_unset_searchdir(struct ly_ctx *ctx, const char *value)
 }
 
 API LY_ERR
-ly_ctx_unset_searchdir_last(struct ly_ctx *ctx, unsigned int count)
+ly_ctx_unset_searchdir_last(struct ly_ctx *ctx, uint32_t count)
 {
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
 
@@ -190,7 +189,7 @@ ly_ctx_load_module(struct ly_ctx *ctx, const char *name, const char *revision)
 }
 
 API LY_ERR
-ly_ctx_new(const char *search_dir, int options, struct ly_ctx **new_ctx)
+ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
 {
     struct ly_ctx *ctx = NULL;
     struct lys_module *module;
@@ -268,7 +267,7 @@ error:
     return rc;
 }
 
-API int
+API uint16_t
 ly_ctx_get_options(const struct ly_ctx *ctx)
 {
     LY_CHECK_ARG_RET(ctx, ctx, 0);
@@ -276,7 +275,7 @@ ly_ctx_get_options(const struct ly_ctx *ctx)
 }
 
 API LY_ERR
-ly_ctx_set_options(struct ly_ctx *ctx, int option)
+ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option)
 {
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
     LY_CHECK_ERR_RET(option & LY_CTX_NOYANGLIBRARY, LOGARG(ctx, option), LY_EINVAL);
@@ -288,7 +287,7 @@ ly_ctx_set_options(struct ly_ctx *ctx, int option)
 }
 
 API LY_ERR
-ly_ctx_unset_options(struct ly_ctx *ctx, int option)
+ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option)
 {
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
     LY_CHECK_ERR_RET(option & LY_CTX_NOYANGLIBRARY, LOGARG(ctx, option), LY_EINVAL);
@@ -327,7 +326,7 @@ ly_ctx_get_module_imp_clb(const struct ly_ctx *ctx, void **user_data)
 }
 
 API const struct lys_module *
-ly_ctx_get_module_iter(const struct ly_ctx *ctx, unsigned int *index)
+ly_ctx_get_module_iter(const struct ly_ctx *ctx, uint32_t *index)
 {
     LY_CHECK_ARG_RET(ctx, ctx, index, NULL);
 
@@ -352,7 +351,7 @@ ly_ctx_get_module_iter(const struct ly_ctx *ctx, unsigned int *index)
  * @return Module matching the given key, NULL if no such module found.
  */
 static struct lys_module *
-ly_ctx_get_module_by_iter(const struct ly_ctx *ctx, const char *key, size_t key_size, size_t key_offset, unsigned int *index)
+ly_ctx_get_module_by_iter(const struct ly_ctx *ctx, const char *key, size_t key_size, size_t key_offset, uint32_t *index)
 {
     struct lys_module *mod;
     const char *value;
@@ -383,7 +382,7 @@ static struct lys_module *
 ly_ctx_get_module_by(const struct ly_ctx *ctx, const char *key, size_t key_offset, const char *revision)
 {
     struct lys_module *mod;
-    unsigned int index = 0;
+    uint32_t index = 0;
 
     while ((mod = ly_ctx_get_module_by_iter(ctx, key, 0, key_offset, &index))) {
         if (!revision) {
@@ -427,7 +426,7 @@ static struct lys_module *
 ly_ctx_get_module_latest_by(const struct ly_ctx *ctx, const char *key, size_t key_offset)
 {
     struct lys_module *mod;
-    unsigned int index = 0;
+    uint32_t index = 0;
 
     while ((mod = ly_ctx_get_module_by_iter(ctx, key, 0, key_offset, &index))) {
         if (mod->latest_revision) {
@@ -464,7 +463,7 @@ static struct lys_module *
 ly_ctx_get_module_implemented_by(const struct ly_ctx *ctx, const char *key, size_t key_size, size_t key_offset)
 {
     struct lys_module *mod;
-    unsigned int index = 0;
+    uint32_t index = 0;
 
     while ((mod = ly_ctx_get_module_by_iter(ctx, key, key_size, key_offset, &index))) {
         if (mod->implemented) {
@@ -533,7 +532,7 @@ ly_ctx_get_submodule(const struct ly_ctx *ctx, const char *module, const char *s
 }
 
 API const struct lysc_node *
-ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, const char *data_path, int output)
+ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, const char *data_path, uint8_t output)
 {
     const struct lysc_node *snode = NULL;
     struct lyxp_expr *exp = NULL;
@@ -622,7 +621,7 @@ ylib_feature(struct lyd_node *parent, const struct lys_module *cur_mod)
 }
 
 static LY_ERR
-ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, int bis)
+ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, uint8_t bis)
 {
     LY_ARRAY_COUNT_TYPE i;
     struct lys_module *mod;
@@ -647,7 +646,7 @@ ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, int bi
 }
 
 static LY_ERR
-ylib_submodules(struct lyd_node *parent, const struct lys_module *cur_mod, int bis)
+ylib_submodules(struct lyd_node *parent, const struct lys_module *cur_mod, uint8_t bis)
 {
     LY_ERR ret;
     LY_ARRAY_COUNT_TYPE i;
@@ -694,7 +693,8 @@ ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root_p)
 {
     LY_ERR ret;
     uint32_t i;
-    int bis = 0, r;
+    uint8_t bis = 0;
+    int r;
     char id[8], *str;
     const struct lys_module *mod;
     struct lyd_node *root = NULL, *root_bis = NULL, *cont, *set_bis = NULL;

--- a/src/context.h
+++ b/src/context.h
@@ -198,7 +198,7 @@ struct ly_ctx;
  * @param[out] new_ctx Pointer to the created libyang context if LY_SUCCESS returned.
  * @return LY_ERR return value.
  */
-LY_ERR ly_ctx_new(const char *search_dir, int options, struct ly_ctx **new_ctx);
+LY_ERR ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx);
 
 /**
  * @brief Add the search path into libyang context
@@ -234,7 +234,7 @@ LY_ERR ly_ctx_unset_searchdir(struct ly_ctx *ctx, const char *value);
  * Value 0 does not change the search path set.
  * @return LY_ERR return value
  */
-LY_ERR ly_ctx_unset_searchdir_last(struct ly_ctx *ctx, unsigned int count);
+LY_ERR ly_ctx_unset_searchdir_last(struct ly_ctx *ctx, uint32_t count);
 
 /**
  * @brief Get the NULL-terminated list of the search paths in libyang context. Do not modify the result!
@@ -251,7 +251,7 @@ const char * const *ly_ctx_get_searchdirs(const struct ly_ctx *ctx);
  * @param[in] ctx Context to query.
  * @return Combination of all the currently set context's options, see @ref contextoptions.
  */
-int ly_ctx_get_options(const struct ly_ctx *ctx);
+uint16_t ly_ctx_get_options(const struct ly_ctx *ctx);
 
 /**
  * @brief Set some of the context's options, see @ref contextoptions.
@@ -259,7 +259,7 @@ int ly_ctx_get_options(const struct ly_ctx *ctx);
  * @param[in] option Combination of the context's options to be set, see @ref contextoptions.
  * @return LY_ERR value.
  */
-LY_ERR ly_ctx_set_options(struct ly_ctx *ctx, int option);
+LY_ERR ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option);
 
 /**
  * @brief Unset some of the context's options, see @ref contextoptions.
@@ -267,7 +267,7 @@ LY_ERR ly_ctx_set_options(struct ly_ctx *ctx, int option);
  * @param[in] option Combination of the context's options to be unset, see @ref contextoptions.
  * @return LY_ERR value.
  */
-LY_ERR ly_ctx_unset_options(struct ly_ctx *ctx, int option);
+LY_ERR ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option);
 
 /**
  * @brief Get current ID of the modules set. The value is available also
@@ -373,7 +373,7 @@ struct lys_module *ly_ctx_get_module_implemented(const struct ly_ctx *ctx, const
  * to be used in all calls starting with value 0.
  * @return Next context module, NULL if the last was already returned.
  */
-const struct lys_module *ly_ctx_get_module_iter(const struct ly_ctx *ctx, unsigned int *index);
+const struct lys_module *ly_ctx_get_module_iter(const struct ly_ctx *ctx, uint32_t *index);
 
 /**
  * @brief Get YANG module of the given namespace and revision.
@@ -418,7 +418,7 @@ struct lys_module *ly_ctx_get_module_implemented_ns(const struct ly_ctx *ctx, co
  * @return Found schema node or NULL.
  */
 const struct lysc_node *ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node,
-        const char *data_path, int output);
+        const char *data_path, uint8_t output);
 
 /**
  * @brief Reset cached latest revision information of the schemas in the context.

--- a/src/diff.c
+++ b/src/diff.c
@@ -231,7 +231,7 @@ lyd_diff_userord_get(const struct lyd_node *first, const struct lysc_node *schem
  * @return LY_ERR value on other errors.
  */
 static LY_ERR
-lyd_diff_userord_attrs(const struct lyd_node *first, const struct lyd_node *second, int options,
+lyd_diff_userord_attrs(const struct lyd_node *first, const struct lyd_node *second, uint16_t options,
         struct lyd_diff_userord **userord, enum lyd_diff_op *op, const char **orig_default, char **value,
         char **orig_value, char **key, char **orig_key)
 {
@@ -394,7 +394,7 @@ lyd_diff_userord_attrs(const struct lyd_node *first, const struct lyd_node *seco
  * @return LY_ERR value on other errors.
  */
 static LY_ERR
-lyd_diff_attrs(const struct lyd_node *first, const struct lyd_node *second, int options, enum lyd_diff_op *op,
+lyd_diff_attrs(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, enum lyd_diff_op *op,
         const char **orig_default, char **orig_value)
 {
     const struct lysc_node *schema;
@@ -516,7 +516,7 @@ lyd_diff_attrs(const struct lyd_node *first, const struct lyd_node *second, int 
  * @return LY_ERR value.
  */
 static LY_ERR
-lyd_diff_siblings_r(const struct lyd_node *first, const struct lyd_node *second, int options, int nosiblings,
+lyd_diff_siblings_r(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, uint8_t nosiblings,
         struct lyd_node **diff)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -669,7 +669,7 @@ cleanup:
 }
 
 static LY_ERR
-lyd_diff(const struct lyd_node *first, const struct lyd_node *second, int options, int nosiblings, struct lyd_node **diff)
+lyd_diff(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, uint8_t nosiblings, struct lyd_node **diff)
 {
     const struct ly_ctx *ctx;
 
@@ -694,13 +694,13 @@ lyd_diff(const struct lyd_node *first, const struct lyd_node *second, int option
 }
 
 API LY_ERR
-lyd_diff_tree(const struct lyd_node *first, const struct lyd_node *second, int options, struct lyd_node **diff)
+lyd_diff_tree(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, struct lyd_node **diff)
 {
     return lyd_diff(first, second, options, 1, diff);
 }
 
 API LY_ERR
-lyd_diff_siblings(const struct lyd_node *first, const struct lyd_node *second, int options, struct lyd_node **diff)
+lyd_diff_siblings(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, struct lyd_node **diff)
 {
     return lyd_diff(first, second, options, 0, diff);
 }
@@ -1512,7 +1512,7 @@ lyd_diff_reverse_value(struct lyd_node *leaf, const struct lys_module *mod)
     struct lyd_meta *meta;
     const char *val1 = NULL;
     char *val2;
-    int flags;
+    uint32_t flags;
 
     meta = lyd_find_meta(leaf->meta, mod, "orig-value");
     LY_CHECK_ERR_RET(!meta, LOGINT(LYD_CTX(leaf)), LY_EINT);
@@ -1538,7 +1538,7 @@ static LY_ERR
 lyd_diff_reverse_default(struct lyd_node *node, const struct lys_module *mod)
 {
     struct lyd_meta *meta;
-    int flag1, flag2;
+    uint32_t flag1, flag2;
 
     meta = lyd_find_meta(node->meta, mod, "orig-default");
     if (!meta) {

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -47,7 +47,7 @@ uint32_t dict_hash(const char *key, size_t len);
  * @param[in] cb_data User callback data.
  * @return 0 on non-equal, non-zero on equal.
  */
-typedef int (*values_equal_cb)(void *val1_p, void *val2_p, int mod, void *cb_data);
+typedef uint8_t (*values_equal_cb)(void *val1_p, void *val2_p, uint8_t mod, void *cb_data);
 
 /** when the table is at least this much percent full, it is enlarged (double the size) */
 #define LYHT_ENLARGE_PERCENTAGE 75
@@ -128,7 +128,7 @@ void lydict_clean(struct dict_table *dict);
  * @param[in] resize Whether to resize the table on too few/too many records taken.
  * @return Empty hash table, NULL on error.
  */
-struct hash_table *lyht_new(uint32_t size, uint16_t val_size, values_equal_cb val_equal, void *cb_data, int resize);
+struct hash_table *lyht_new(uint32_t size, uint16_t val_size, values_equal_cb val_equal, void *cb_data, uint16_t resize);
 
 /**
  * @brief Set hash table value equal callback.

--- a/src/json.c
+++ b/src/json.c
@@ -87,7 +87,7 @@ skip_ws(struct lyjson_ctx *jsonctx)
  * @brief Set value corresponding to the current context's status
  */
 static void
-lyjson_ctx_set_value(struct lyjson_ctx *jsonctx, const char *value, size_t value_len, int dynamic)
+lyjson_ctx_set_value(struct lyjson_ctx *jsonctx, const char *value, size_t value_len, uint8_t dynamic)
 {
     assert(jsonctx);
 
@@ -323,7 +323,7 @@ lyjson_number(struct lyjson_ctx *jsonctx)
 {
     size_t offset = 0, exponent = 0;
     const char *in = jsonctx->in->current;
-    int minus = 0;
+    uint8_t minus = 0;
 
     if (in[offset] == '-') {
         ++offset;
@@ -376,7 +376,7 @@ invalid_character:
         char *ptr, *dec_point, *num;
         const char *e_ptr = &in[exponent + 1];
         size_t num_len, i;
-        long int dp_position; /* final position of the deciaml point */
+        int64_t dp_position; /* final position of the deciaml point */
 
         errno = 0;
         e_val = strtol(e_ptr, &ptr, 10);
@@ -437,7 +437,9 @@ invalid_character:
             }
         }
         /* copy the value */
-        for (unsigned int dp_placed = dp_position ? 0 : 1, j = minus; j < exponent; j++) {
+        uint8_t dp_placed;
+        size_t j;
+        for (dp_placed = dp_position ? 0 : 1, j = minus; j < exponent; j++) {
             if (in[j] == '.') {
                 continue;
             }
@@ -679,7 +681,7 @@ LY_ERR
 lyjson_ctx_next(struct lyjson_ctx *jsonctx, enum LYJSON_PARSER_STATUS *status)
 {
     LY_ERR ret = LY_SUCCESS;
-    int toplevel = 0;
+    uint8_t toplevel = 0;
     enum LYJSON_PARSER_STATUS prev;
 
     assert(jsonctx);

--- a/src/json.h
+++ b/src/json.h
@@ -60,14 +60,14 @@ struct lyjson_ctx {
 
     const char *value;      /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
     size_t value_len;       /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
-    int dynamic;            /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
+    uint8_t dynamic;        /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
 
     struct {
         enum LYJSON_PARSER_STATUS status;
         uint32_t status_count;
         const char *value;
         size_t value_len;
-        int dynamic;
+        uint8_t dynamic;
         const char *input;
     } backup;
 };

--- a/src/log.c
+++ b/src/log.c
@@ -31,12 +31,12 @@
 #include "tree_data.h"
 #include "tree_schema.h"
 
-volatile uint8_t ly_log_level = LY_LLWRN;
-volatile uint8_t ly_log_opts = LY_LOLOG | LY_LOSTORE_LAST;
+volatile LY_LOG_LEVEL ly_log_level = LY_LLWRN;
+volatile uint32_t ly_log_opts = LY_LOLOG | LY_LOSTORE_LAST;
 static ly_log_clb log_clb;
-static volatile int path_flag = 1;
+static volatile uint8_t path_flag = 1;
 #ifndef NDEBUG
-volatile int ly_log_dbg_groups = 0;
+volatile uint32_t ly_log_dbg_groups = 0;
 #endif
 
 /* how many bytes add when enlarging buffers */
@@ -190,17 +190,17 @@ ly_verb(LY_LOG_LEVEL level)
     return prev;
 }
 
-API int
-ly_log_options(int opts)
+API uint32_t
+ly_log_options(uint32_t opts)
 {
-    uint8_t prev = ly_log_opts;
+    uint32_t prev = ly_log_opts;
 
     ly_log_opts = opts;
     return prev;
 }
 
 API void
-ly_verb_dbg(int dbg_groups)
+ly_verb_dbg(uint32_t dbg_groups)
 {
 #ifndef NDEBUG
     ly_log_dbg_groups = dbg_groups;
@@ -210,7 +210,7 @@ ly_verb_dbg(int dbg_groups)
 }
 
 API void
-ly_set_log_clb(ly_log_clb clb, int path)
+ly_set_log_clb(ly_log_clb clb, uint8_t path)
 {
     log_clb = clb;
     path_flag = path;
@@ -294,7 +294,7 @@ log_vprintf(const struct ly_ctx *ctx, LY_LOG_LEVEL level, LY_ERR no, LY_VECODE v
         const char *format, va_list args)
 {
     char *msg = NULL;
-    int free_strs;
+    uint8_t free_strs;
 
     if (level > ly_log_level) {
         /* do not print or store the message */
@@ -349,7 +349,7 @@ log_vprintf(const struct ly_ctx *ctx, LY_LOG_LEVEL level, LY_ERR no, LY_VECODE v
 #ifndef NDEBUG
 
 void
-ly_log_dbg(int group, const char *format, ...)
+ly_log_dbg(uint32_t group, const char *format, ...)
 {
     char *dbg_format;
     const char *str_group;

--- a/src/log.h
+++ b/src/log.h
@@ -15,6 +15,8 @@
 #ifndef LY_LOG_H_
 #define LY_LOG_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -75,7 +77,7 @@ LY_LOG_LEVEL ly_verb(LY_LOG_LEVEL level);
  * @param[in] opts Bitfield of @ref logopts.
  * @return Previous logger options.
  */
-int ly_log_options(int opts);
+uint32_t ly_log_options(uint32_t opts);
 
 #ifndef NDEBUG
 
@@ -102,7 +104,7 @@ int ly_log_options(int opts);
  * @brief Enable specific debugging messages (independent of log level).
  * @param[in] dbg_groups Bitfield of enabled debug message groups (see @ref dbggroup).
  */
-void ly_verb_dbg(int dbg_groups);
+void ly_verb_dbg(uint32_t dbg_groups);
 
 #endif
 
@@ -129,7 +131,7 @@ typedef void (*ly_log_clb)(LY_LOG_LEVEL level, const char *msg, const char *path
  *            presence) or it can be NULL, so consider it as an optional parameter. If the flag is 0, libyang will
  *            not bother with resolving the path.
  */
-void ly_set_log_clb(ly_log_clb clb, int path);
+void ly_set_log_clb(ly_log_clb clb, uint8_t path);
 
 /**
  * @brief Get logger callback.

--- a/src/parser.c
+++ b/src/parser.c
@@ -288,7 +288,7 @@ lys_parser_fill_filepath(struct ly_ctx *ctx, struct ly_in *in, const char **file
 }
 
 API void
-ly_in_free(struct ly_in *in, int destroy)
+ly_in_free(struct ly_in *in, uint8_t destroy)
 {
     if (!in) {
         return;
@@ -407,7 +407,7 @@ lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *snode)
 
 LY_ERR
 lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-        int *dynamic, int value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
+        uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
 {
     LY_ERR ret;
 
@@ -423,7 +423,7 @@ lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, c
 
 LY_ERR
 lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod,
-        const char *name, size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hints,
+        const char *name, size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hints,
         LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode)
 {
     LY_ERR ret;

--- a/src/parser.h
+++ b/src/parser.h
@@ -167,7 +167,7 @@ size_t ly_in_parsed(const struct ly_in *in);
  * @param[in] destroy Flag to free the input data buffer (for LY_IN_MEMORY) or to
  * close stream/file descriptor (for LY_IN_FD and LY_IN_FILE)
  */
-void ly_in_free(struct ly_in *in, int destroy);
+void ly_in_free(struct ly_in *in, uint8_t destroy);
 
 #ifdef __cplusplus
 }

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -129,8 +129,8 @@ typedef enum {
  * @return LY_SUCCESS in case of successful parsing (and validation).
  * @return LY_ERR value in case of error. Additional error information can be obtained from the context using ly_err* functions.
  */
-LY_ERR lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, int parse_options,
-        int validate_options, struct lyd_node **tree);
+LY_ERR lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, uint32_t parse_options,
+        uint32_t validate_options, struct lyd_node **tree);
 
 /**
  * @brief Parse (and validate) input data as a YANG data tree.
@@ -147,8 +147,8 @@ LY_ERR lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT for
  * @return LY_SUCCESS in case of successful parsing (and validation).
  * @return LY_ERR value in case of error. Additional error information can be obtained from the context using ly_err* functions.
  */
-LY_ERR lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT format, int parse_options,
-        int validate_options, struct lyd_node **tree);
+LY_ERR lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT format, uint32_t parse_options,
+        uint32_t validate_options, struct lyd_node **tree);
 
 /**
  * @brief Parse (and validate) input data as a YANG data tree.
@@ -165,7 +165,7 @@ LY_ERR lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT
  * @return LY_SUCCESS in case of successful parsing (and validation).
  * @return LY_ERR value in case of error. Additional error information can be obtained from the context using ly_err* functions.
  */
-LY_ERR lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, int parse_options, int validate_options,
+LY_ERR lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree);
 
 /**
@@ -183,8 +183,8 @@ LY_ERR lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, in
  * @return LY_SUCCESS in case of successful parsing (and validation).
  * @return LY_ERR value in case of error. Additional error information can be obtained from the context using ly_err* functions.
  */
-LY_ERR lyd_parse_data_path(const struct ly_ctx *ctx, const char *path, LYD_FORMAT format, int parse_options,
-        int validate_options, struct lyd_node **tree);
+LY_ERR lyd_parse_data_path(const struct ly_ctx *ctx, const char *path, LYD_FORMAT format, uint32_t parse_options,
+        uint32_t validate_options, struct lyd_node **tree);
 
 /**
  * @brief Parse (and validate) data from the input handler as a YANG RPC/action invocation.
@@ -256,7 +256,7 @@ LY_ERR lyd_parse_notif(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT fo
  * @return LY_SUCCESS on success.
  * @return LY_ERR error on error.
  */
-LY_ERR lyd_validate_all(struct lyd_node **tree, const struct ly_ctx *ctx, int val_opts, struct lyd_node **diff);
+LY_ERR lyd_validate_all(struct lyd_node **tree, const struct ly_ctx *ctx, uint32_t val_opts, struct lyd_node **diff);
 
 /**
  * @brief Fully validate a data tree of a module.
@@ -268,7 +268,7 @@ LY_ERR lyd_validate_all(struct lyd_node **tree, const struct ly_ctx *ctx, int va
  * @return LY_SUCCESS on success.
  * @return LY_ERR error on error.
  */
-LY_ERR lyd_validate_module(struct lyd_node **tree, const struct lys_module *module, int val_opts, struct lyd_node **diff);
+LY_ERR lyd_validate_module(struct lyd_node **tree, const struct lys_module *module, uint32_t val_opts, struct lyd_node **diff);
 
 /**
  * @brief Validate an RPC/action, notification, or RPC/action reply.

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -171,7 +171,7 @@ LY_ERR lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *s
  * @param[in] value_hints Data parser's hint for the value's type.
  */
 LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-        int *dynamic, int value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
+        uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
 
 /**
  * @brief Wrapper around lyd_create_meta() for data parsers.
@@ -181,7 +181,7 @@ LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *sc
  */
 LY_ERR lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta,
         const struct lys_module *mod, const char *name, size_t name_len, const char *value,
-        size_t value_len, int *dynamic, int value_hints, LY_PREFIX_FORMAT format,
+        size_t value_len, uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format,
         void *prefix_data, const struct lysc_node *ctx_snode);
 
 #endif /* LY_PARSER_INTERNAL_H_ */

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -171,9 +171,9 @@ lyb_read_number(void *num, size_t num_size, size_t bytes, struct lylyb_ctx *lybc
  * @return LY_ERR value.
  */
 static LY_ERR
-lyb_read_string(char **str, int with_length, struct lylyb_ctx *lybctx)
+lyb_read_string(char **str, uint8_t with_length, struct lylyb_ctx *lybctx)
 {
-    int next_chunk = 0;
+    uint8_t next_chunk = 0;
     size_t len = 0, cur_len;
 
     *str = NULL;
@@ -345,7 +345,7 @@ static LY_ERR
 lyb_parse_metadata(struct lyd_lyb_ctx *lybctx, const struct lysc_node *sparent, struct lyd_meta **meta)
 {
     LY_ERR ret = LY_SUCCESS;
-    int dynamic;
+    uint8_t dynamic;
     uint8_t i, count = 0;
     char *meta_name = NULL, *meta_value;
     const struct lys_module *mod;
@@ -464,7 +464,7 @@ lyb_parse_attributes(struct lylyb_ctx *lybctx, struct lyd_attr **attr)
     uint8_t count, i;
     struct lyd_attr *attr2;
     char *prefix = NULL, *module_name = NULL, *name = NULL, *value = NULL;
-    int dynamic = 0;
+    uint8_t dynamic = 0;
     LYD_FORMAT format = 0;
     struct ly_prefix *val_prefs = NULL;
 
@@ -589,7 +589,7 @@ lyb_parse_schema_hash(struct lyd_lyb_ctx *lybctx, const struct lysc_node *sparen
     uint8_t i, j;
     const struct lysc_node *sibling;
     LYB_HASH hash[LYB_HASH_BITS - 1];
-    int getnext_opts;
+    uint32_t getnext_opts;
 
     *snode = NULL;
     /* leave if-feature check for validation */
@@ -688,9 +688,9 @@ lyb_parse_subtree_r(struct lyd_lyb_ctx *lybctx, struct lyd_node_inner *parent, s
     struct ly_prefix *val_prefs = NULL;
     LYD_ANYDATA_VALUETYPE value_type;
     char *value = NULL, *name = NULL, *prefix = NULL, *module_key = NULL;
-    int dynamic = 0;
+    uint8_t dynamic = 0;
     LYD_FORMAT format = 0;
-    int prev_lo;
+    uint32_t prev_lo;
     const struct ly_ctx *ctx = lybctx->lybctx->ctx;
 
     /* register a new subtree */
@@ -986,8 +986,8 @@ lyb_parse_header(struct lylyb_ctx *lybctx)
  * @param[out] lydctx_p Data parser context to finish validation.
  */
 static LY_ERR
-lyd_parse_lyb_(const struct ly_ctx *ctx, struct lyd_node_inner **parent, struct ly_in *in, int parse_options, int validate_options,
-        int data_type, struct lyd_node **tree_p, struct lyd_node **op_p, struct lyd_ctx **lydctx_p)
+lyd_parse_lyb_(const struct ly_ctx *ctx, struct lyd_node_inner **parent, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
+        uint32_t data_type, struct lyd_node **tree_p, struct lyd_node **op_p, struct lyd_ctx **lydctx_p)
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyd_lyb_ctx *lybctx;
@@ -1083,7 +1083,7 @@ cleanup:
 }
 
 LY_ERR
-lyd_parse_lyb_data(const struct ly_ctx *ctx, struct ly_in *in, int parse_options, int validate_options,
+lyd_parse_lyb_data(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree_p, struct lyd_ctx **lydctx_p)
 {
     return lyd_parse_lyb_(ctx, NULL, in, parse_options, validate_options, 0, tree_p, NULL, lydctx_p);

--- a/src/parser_schema.h
+++ b/src/parser_schema.h
@@ -107,7 +107,7 @@ LY_ERR lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format,
  * file suffix.
  * @return LY_ERR value (LY_SUCCESS is returned even if the file is not found, then the *localfile is NULL).
  */
-LY_ERR lys_search_localfile(const char * const *searchpaths, int cwd, const char *name, const char *revision,
+LY_ERR lys_search_localfile(const char * const *searchpaths, uint8_t cwd, const char *name, const char *revision,
         char **localfile, LYS_INFORMAT *format);
 
 /** @} schematree */

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -32,8 +32,8 @@
 static LY_ERR
 lysp_stmt_validate_value(struct lys_parser_ctx *ctx, enum yang_arg val_type, const char *val)
 {
-    int prefix = 0, first = 1;
-    unsigned int c;
+    uint8_t prefix = 0, first = 1;
+    uint32_t c;
     size_t utf8_char_len;
 
     while (*val) {

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -381,7 +381,7 @@ lydxml_subtree_r(struct lyd_xml_ctx *lydctx, struct lyd_node_inner *parent, stru
     uint32_t prev_opts;
     struct lyd_node *node = NULL, *anchor;
     struct ly_prefix *val_prefs;
-    int getnext_opts;
+    uint32_t getnext_opts;
 
     xmlctx = lydctx->xmlctx;
     ctx = xmlctx->ctx;
@@ -616,7 +616,7 @@ error:
 }
 
 LY_ERR
-lyd_parse_xml_data(const struct ly_ctx *ctx, struct ly_in *in, int parse_options, int validate_options,
+lyd_parse_xml_data(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree_p, struct lyd_ctx **lydctx_p)
 {
     LY_ERR ret = LY_SUCCESS;

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -139,9 +139,9 @@ buf_add_char(struct ly_ctx *ctx, struct ly_in *in, size_t len, char **buf, size_
  */
 LY_ERR
 buf_store_char(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg, char **word_p, size_t *word_len,
-        char **word_b, size_t *buf_len, int need_buf, int *prefix)
+        char **word_b, size_t *buf_len, uint8_t need_buf, uint8_t *prefix)
 {
-    unsigned int c;
+    uint32_t c;
     size_t len;
 
     /* check  valid combination of input paremeters - if need_buf specified, word_b must be provided */
@@ -220,7 +220,7 @@ buf_store_char(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg 
  * @return LY_ERR values.
  */
 LY_ERR
-skip_comment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, int comment)
+skip_comment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, uint8_t comment)
 {
     /* internal statuses: 0 - comment ended,
      *                    1 - in line comment,
@@ -295,10 +295,11 @@ read_qstring(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg ar
     /* string: 0 - string ended, 1 - string with ', 2 - string with ", 3 - string with " with last character \,
      *         4 - string finished, now skipping whitespaces looking for +,
      *         5 - string continues after +, skipping whitespaces */
-    unsigned int string, block_indent = 0, current_indent = 0, need_buf = 0;
+    uint8_t string;
+    uint64_t block_indent = 0, current_indent = 0;
+    uint8_t need_buf = 0, prefix = 0;
     const char *c;
-    int prefix = 0;
-    unsigned int trailing_ws = 0; /* current number of stored trailing whitespace characters */
+    uint64_t trailing_ws = 0; /* current number of stored trailing whitespace characters */
 
     if (in->current[0] == '\"') {
         string = 2;
@@ -514,7 +515,7 @@ get_argument(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg ar
         char **word_b, size_t *word_len)
 {
     size_t buf_len = 0;
-    int prefix = 0;
+    uint8_t prefix = 0;
     /* word buffer - dynamically allocated */
     *word_b = NULL;
 
@@ -631,9 +632,8 @@ str_end:
 LY_ERR
 get_keyword(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt *kw, char **word_p, size_t *word_len)
 {
-    int prefix;
+    uint8_t prefix;
     const char *word_start;
-    unsigned int c;
     size_t len;
 
     if (word_p) {
@@ -721,6 +721,8 @@ keyword_start:
 extension:
         while (in->current[0] && (in->current[0] != ' ') && (in->current[0] != '\t') && (in->current[0] != '\n')
                 && (in->current[0] != '{') && (in->current[0] != ';')) {
+            uint32_t c = 0;
+
             LY_CHECK_ERR_RET(ly_getutf8(&in->current, &c, &len),
                              LOGVAL_PARSER(ctx, LY_VCODE_INCHAR, in->current[-len]), LY_EVALID);
             ++ctx->indent;
@@ -816,7 +818,7 @@ parse_ext_substmt(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stm
  * @return LY_ERR values.
  */
 static LY_ERR
-parse_ext(struct lys_yang_parser_ctx *ctx, struct ly_in *in, const char *ext_name, int ext_name_len, LYEXT_SUBSTMT insubstmt,
+parse_ext(struct lys_yang_parser_ctx *ctx, struct ly_in *in, const char *ext_name, size_t ext_name_len, LYEXT_SUBSTMT insubstmt,
         LY_ARRAY_COUNT_TYPE insubstmt_index, struct lysp_ext_instance **exts)
 {
     LY_ERR ret = LY_SUCCESS;

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -276,8 +276,8 @@ mem_err:
 LY_ERR
 yin_validate_value(struct lys_yin_parser_ctx *ctx, enum yang_arg val_type)
 {
-    int prefix = 0;
-    unsigned int c;
+    uint8_t prefix = 0;
+    uint32_t c;
     size_t utf8_char_len, already_read = 0;
     const char *val;
 
@@ -292,10 +292,10 @@ yin_validate_value(struct lys_yin_parser_ctx *ctx, enum yang_arg val_type)
 
         switch (val_type) {
         case Y_IDENTIF_ARG:
-            LY_CHECK_RET(lysp_check_identifierchar((struct lys_parser_ctx *)ctx, c, !already_read, NULL));
+            LY_CHECK_RET(lysp_check_identifierchar((struct lys_parser_ctx *)ctx, c, already_read ? 0 : 1, NULL));
             break;
         case Y_PREF_IDENTIF_ARG:
-            LY_CHECK_RET(lysp_check_identifierchar((struct lys_parser_ctx *)ctx, c, !already_read, &prefix));
+            LY_CHECK_RET(lysp_check_identifierchar((struct lys_parser_ctx *)ctx, c, already_read ? 0 : 1, &prefix));
             break;
         case Y_STR_ARG:
         case Y_MAYBE_STR_ARG:
@@ -378,9 +378,9 @@ yin_parse_attribute(struct lys_yin_parser_ctx *ctx, enum yin_argument arg_type, 
  * @return Pointer to desired record on success, NULL if element is not in the array.
  */
 static struct yin_subelement *
-get_record(enum ly_stmt type, size_t array_size, struct yin_subelement *array)
+get_record(enum ly_stmt type, LY_ARRAY_COUNT_TYPE array_size, struct yin_subelement *array)
 {
-    for (unsigned int u = 0; u < array_size; ++u) {
+    for (LY_ARRAY_COUNT_TYPE u = 0; u < array_size; ++u) {
         if (array[u].type == type) {
             return &array[u];
         }

--- a/src/path.c
+++ b/src/path.c
@@ -697,7 +697,7 @@ ly_path_compile(const struct ly_ctx *ctx, const struct lys_module *cur_mod, cons
     const struct lys_module *mod;
     const struct lysc_node *node2, *cur_node, *op;
     struct ly_path *p = NULL;
-    int getnext_opts;
+    uint32_t getnext_opts;
     const char *name;
     size_t name_len;
 

--- a/src/plugins_exts.c
+++ b/src/plugins_exts.c
@@ -37,9 +37,7 @@ struct lyext_plugins_list lyext_plugins_internal[6] = {
 struct lyext_plugin *
 lyext_get_plugin(struct lysc_ext *ext)
 {
-    unsigned int u;
-
-    for (u = 0; lyext_plugins_internal[u].module; ++u) {
+    for (uint8_t u = 0; lyext_plugins_internal[u].module; ++u) {
         if (!strcmp(ext->name, lyext_plugins_internal[u].name) &&
                 !strcmp(ext->module->name, lyext_plugins_internal[u].module) &&
                 (!lyext_plugins_internal[u].revision || !strcmp(ext->module->revision, lyext_plugins_internal[u].revision))) {

--- a/src/plugins_exts.h
+++ b/src/plugins_exts.h
@@ -41,7 +41,7 @@ extern "C" {
  * @brief Macro to store version of extension plugins API in the plugins.
  * It is matched when the plugin is being loaded by libyang.
  */
-#define LYEXT_VERSION_CHECK int lyext_api_version = LYEXT_API_VERSION;
+#define LYEXT_VERSION_CHECK uint32_t lyext_api_version = LYEXT_API_VERSION;
 
 /**
  * @defgroup extensionscompile YANG Extensions - Compilation Helpers

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -174,7 +174,7 @@ ly_type_compare_simple(const struct lyd_value *val1, const struct lyd_value *val
  */
 static const char *
 ly_type_print_simple(const struct lyd_value *value, LY_PREFIX_FORMAT UNUSED(format),
-        void *UNUSED(prefix_data), int *dynamic)
+        void *UNUSED(prefix_data), uint8_t *dynamic)
 {
     *dynamic = 0;
     return (char *)value->canonical;
@@ -349,7 +349,7 @@ decimal:
 
     if (len + trailing_zeros < value_len) {
         /* consume trailing whitespaces to check that there is nothing after it */
-        unsigned long int u;
+        uint64_t u;
         for (u = len + trailing_zeros; u < value_len && isspace(value[u]); ++u) {}
         if (u != value_len) {
             if (asprintf(&errmsg, "Invalid %lu. character of decimal64 value \"%.*s\".",
@@ -517,7 +517,7 @@ error:
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_int(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_int(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -573,7 +573,7 @@ ly_type_store_int(const struct ly_ctx *ctx, struct lysc_type *type, const char *
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_uint(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_uint(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -627,7 +627,7 @@ ly_type_store_uint(const struct ly_ctx *ctx, struct lysc_type *type, const char 
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_decimal64(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_decimal64(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -656,7 +656,7 @@ ly_type_store_decimal64(const struct ly_ctx *ctx, struct lysc_type *type, const 
              * for (num<0) - extra character for '-' sign */
             count = sprintf(buf, "%0*" PRId64 " ", (d > 0) ? (type_dec->fraction_digits + 1) : (type_dec->fraction_digits + 2), d);
         }
-        for (int i = type_dec->fraction_digits, j = 1; i > 0; i--) {
+        for (uint8_t i = type_dec->fraction_digits, j = 1; i > 0; i--) {
             if (j && i > 1 && buf[count - 2] == '0') {
                 /* we have trailing zero to skip */
                 buf[count - 1] = '\0';
@@ -693,14 +693,14 @@ ly_type_store_decimal64(const struct ly_ctx *ctx, struct lysc_type *type, const 
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_binary(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_binary(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
     size_t start = 0, stop = 0, count = 0, u, termination = 0;
     struct lysc_type_bin *type_bin = (struct lysc_type_bin *)type;
     char *errmsg;
-    int erc = 0;
+    int rc = 0;
 
     LY_CHECK_ARG_RET(ctx, value, LY_EINVAL);
 
@@ -744,7 +744,7 @@ ly_type_store_binary(const struct ly_ctx *ctx, struct lysc_type *type, const cha
                 }
                 if (!termination) {
                     /* error */
-                    erc = asprintf(&errmsg, "Invalid Base64 character (%c).", value[u]);
+                    rc = asprintf(&errmsg, "Invalid Base64 character (%c).", value[u]);
                     goto error;
                 }
             }
@@ -781,7 +781,7 @@ finish:
 
 error:
     if (!*err) {
-        if (erc == -1 || !errmsg) {
+        if (rc == -1 || !errmsg) {
             *err = ly_err_new(LY_LLERR, LY_EMEM, 0, "Memory allocation failed.", NULL, NULL);
         } else {
             *err = ly_err_new(LY_LLERR, LY_EVALID, LYVE_DATA, errmsg, NULL, NULL);
@@ -796,7 +796,7 @@ error:
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_string(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_string(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -836,7 +836,7 @@ ly_type_store_string(const struct ly_ctx *ctx, struct lysc_type *type, const cha
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -850,11 +850,11 @@ ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char 
     LY_ARRAY_COUNT_TYPE u, v;
     char *errmsg = NULL;
     struct lysc_type_bits *type_bits = (struct lysc_type_bits *)type;
-    int iscanonical = 1;
+    uint8_t iscanonical = 1;
     size_t ws_count;
     size_t lws_count; /* leading whitespace count */
     const char *can = NULL;
-    int erc = 0;
+    int rc = 0;
 
     if (options & LY_TYPE_OPTS_SECOND_CALL) {
         return LY_SUCCESS;
@@ -886,7 +886,7 @@ ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char 
                 /* check that the bit is not disabled */
                 LY_ARRAY_FOR(type_bits->bits[u].iffeatures, v) {
                     if (lysc_iffeature_value(&type_bits->bits[u].iffeatures[v]) == LY_ENOT) {
-                        erc = asprintf(&errmsg, "Bit \"%s\" is disabled by its %" LY_PRI_ARRAY_COUNT_TYPE ". if-feature condition.",
+                        rc = asprintf(&errmsg, "Bit \"%s\" is disabled by its %" LY_PRI_ARRAY_COUNT_TYPE ". if-feature condition.",
                                        type_bits->bits[u].name, v + 1);
                         goto error;
                     }
@@ -897,15 +897,15 @@ ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char 
                 }
                 inserted = ly_set_add(items, &type_bits->bits[u], 0);
                 LY_CHECK_ERR_GOTO(inserted == -1, ret = LY_EMEM, error);
-                if ((unsigned int)inserted != items->count - 1) {
-                    erc = asprintf(&errmsg, "Bit \"%s\" used multiple times.", type_bits->bits[u].name);
+                if ((uint32_t)inserted != items->count - 1) {
+                    rc = asprintf(&errmsg, "Bit \"%s\" used multiple times.", type_bits->bits[u].name);
                     goto error;
                 }
                 goto next;
             }
         }
         /* item not found */
-        erc = asprintf(&errmsg, "Invalid bit value \"%.*s\".", (int)item_len, item);
+        rc = asprintf(&errmsg, "Invalid bit value \"%.*s\".", (int)item_len, item);
         goto error;
 next:
         /* remember for canonized form: item + space/termination-byte */
@@ -971,7 +971,7 @@ next:
     return LY_SUCCESS;
 
 error:
-    if (erc == -1) {
+    if (rc == -1) {
         *err = ly_err_new(LY_LLERR, LY_EMEM, 0, "Memory allocation failed.", NULL, NULL);
         ret = LY_EMEM;
     } else if (errmsg) {
@@ -1025,14 +1025,14 @@ ly_type_free_bits(const struct ly_ctx *ctx, struct lyd_value *value)
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_enum(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_enum(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data), const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
     LY_ARRAY_COUNT_TYPE u, v;
     char *errmsg = NULL;
     struct lysc_type_enum *type_enum = (struct lysc_type_enum *)type;
-    int erc = 0;
+    int rc = 0;
 
     if (options & LY_TYPE_OPTS_SECOND_CALL) {
         return LY_SUCCESS;
@@ -1046,7 +1046,7 @@ ly_type_store_enum(const struct ly_ctx *ctx, struct lysc_type *type, const char 
             /* check that the enumeration value is not disabled */
             LY_ARRAY_FOR(type_enum->enums[u].iffeatures, v) {
                 if (lysc_iffeature_value(&type_enum->enums[u].iffeatures[v]) == LY_ENOT) {
-                    erc = asprintf(&errmsg, "Enumeration \"%s\" is disabled by its %" LY_PRI_ARRAY_COUNT_TYPE ". if-feature condition.",
+                    rc = asprintf(&errmsg, "Enumeration \"%s\" is disabled by its %" LY_PRI_ARRAY_COUNT_TYPE ". if-feature condition.",
                                    type_enum->enums[u].name, v + 1);
                     goto error;
                 }
@@ -1055,7 +1055,7 @@ ly_type_store_enum(const struct ly_ctx *ctx, struct lysc_type *type, const char 
         }
     }
     /* enum not found */
-    erc = asprintf(&errmsg, "Invalid enumeration value \"%.*s\".", (int)value_len, value);
+    rc = asprintf(&errmsg, "Invalid enumeration value \"%.*s\".", (int)value_len, value);
     goto error;
 
 match:
@@ -1072,7 +1072,7 @@ match:
     return LY_SUCCESS;
 
 error:
-    if (erc == -1) {
+    if (rc == -1) {
         *err = ly_err_new(LY_LLERR, LY_EMEM, 0, "Memory allocation failed.", NULL, NULL);
         return LY_EMEM;
     } else {
@@ -1088,7 +1088,7 @@ error:
  */
 static LY_ERR
 ly_type_store_boolean(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len,
-        int options, LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data),
+        uint32_t options, LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data),
         const void *UNUSED(context_node), const struct lyd_node *UNUSED(tree),
         struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -1130,7 +1130,7 @@ ly_type_store_boolean(const struct ly_ctx *ctx, struct lysc_type *type, const ch
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_empty(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_empty(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT UNUSED(format), void *UNUSED(prefix_data),
         const void *UNUSED(context_node), const struct lyd_node *UNUSED(tree),
         struct lyd_value *storage, struct ly_err_item **err)
@@ -1186,7 +1186,7 @@ ly_type_identity_isderived(struct lysc_ident *base, struct lysc_ident *der)
 }
 
 static const char *ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        int *dynamic);
+        uint8_t *dynamic);
 
 /**
  * @brief Validate, canonize and store value of the YANG built-in identiytref type.
@@ -1194,7 +1194,7 @@ static const char *ly_type_print_identityref(const struct lyd_value *value, LY_P
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT format, void *prefix_data, const void *UNUSED(context_node),
         const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -1205,7 +1205,8 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
     const struct lys_module *mod;
     LY_ARRAY_COUNT_TYPE u;
     struct lysc_ident *ident = NULL, *identities;
-    int erc = 0, dyn;
+    int rc = 0;
+    uint8_t dyn;
 
     if (options & LY_TYPE_OPTS_SECOND_CALL) {
         return LY_SUCCESS;
@@ -1229,7 +1230,7 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
 
     mod = ly_resolve_prefix(ctx, prefix, prefix_len, format, prefix_data);
     if (!mod) {
-        erc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - unable to map prefix to YANG schema.", (int)value_len, value);
+        rc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - unable to map prefix to YANG schema.", (int)value_len, value);
         goto error;
     }
     if (mod->compiled) {
@@ -1246,11 +1247,11 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
     }
     if (u == LY_ARRAY_COUNT(identities)) {
         /* no match */
-        erc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity not found.", (int)value_len, value);
+        rc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity not found.", (int)value_len, value);
         goto error;
     } else if (!mod->compiled) {
         /* non-implemented module */
-        erc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity found in non-implemented module \"%s\".",
+        rc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity found in non-implemented module \"%s\".",
                         (int)value_len, value, mod->name);
         goto error;
     }
@@ -1264,7 +1265,7 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
     }
     if (u == LY_ARRAY_COUNT(type_ident->bases)) {
         /* no match */
-        erc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity not accepted by the type specification.",
+        rc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - identity not accepted by the type specification.",
                         (int)value_len, value);
         goto error;
     }
@@ -1283,7 +1284,7 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
     return LY_SUCCESS;
 
 error:
-    if (erc == -1 || !errmsg) {
+    if (rc == -1 || !errmsg) {
         *err = ly_err_new(LY_LLERR, LY_EMEM, 0, "Memory allocation failed.", NULL, NULL);
         return LY_EMEM;
     } else {
@@ -1312,7 +1313,7 @@ ly_type_compare_identityref(const struct lyd_value *val1, const struct lyd_value
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, int *dynamic)
+ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
 {
     char *result = NULL;
 
@@ -1325,7 +1326,7 @@ ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format
 }
 
 static const char *ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        int *dynamic);
+        uint8_t *dynamic);
 
 /**
  * @brief Validate and store value of the YANG built-in instance-identifier type.
@@ -1333,7 +1334,7 @@ static const char *ly_type_print_instanceid(const struct lyd_value *value, LY_PR
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node, const struct lyd_node *tree,
         struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -1344,7 +1345,9 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
     struct ly_set predicates = {0};
     struct lyxp_expr *exp = NULL;
     const struct lysc_node *ctx_scnode;
-    int erc = 0, prefix_opt = 0, dyn;
+    int rc = 0;
+    uint32_t prefix_opt = 0;
+    uint8_t dyn;
 
     /* init */
     *err = NULL;
@@ -1373,9 +1376,9 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
         if (ly_path_eval(storage->target, tree, NULL)) {
             /* in error message we print the JSON format of the instance-identifier - in case of XML, it is not possible
              * to get the exactly same string as original, JSON is less demanding and still well readable/understandable. */
-            int dynamic = 0;
+            uint8_t dynamic = 0;
             const char *id = storage->realtype->plugin->print(storage, LY_PREF_JSON, NULL, &dynamic);
-            erc = asprintf(&errmsg, "Invalid instance-identifier \"%s\" value - required instance not found.", id);
+            rc = asprintf(&errmsg, "Invalid instance-identifier \"%s\" value - required instance not found.", id);
             if (dynamic) {
                 free((char *)id);
             }
@@ -1391,7 +1394,7 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
     ret = ly_path_parse(ctx, ctx_scnode, value, value_len, LY_PATH_BEGIN_ABSOLUTE, LY_PATH_LREF_FALSE,
                         prefix_opt, LY_PATH_PRED_SIMPLE, &exp);
     if (ret) {
-        erc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - syntax error.", (int)value_len, value);
+        rc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - syntax error.", (int)value_len, value);
         goto error;
     }
 
@@ -1399,7 +1402,7 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
     ret = ly_path_compile(ctx, ctx_scnode->module, NULL, exp, LY_PATH_LREF_FALSE, lysc_is_output(ctx_scnode) ?
                           LY_PATH_OPER_OUTPUT : LY_PATH_OPER_INPUT, LY_PATH_TARGET_SINGLE, format, prefix_data, &path);
     if (ret) {
-        erc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - semantic error.", (int)value_len, value);
+        rc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - semantic error.", (int)value_len, value);
         goto error;
     }
 
@@ -1407,7 +1410,7 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
     if (!(options & LY_TYPE_OPTS_INCOMPLETE_DATA) && !(options & LY_TYPE_OPTS_SCHEMA) && type_inst->require_instance) {
         ret = ly_path_eval(path, tree, NULL);
         if (ret) {
-            erc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - instance not found.", (int)value_len, value);
+            rc = asprintf(&errmsg, "Invalid instance-identifier \"%.*s\" value - instance not found.", (int)value_len, value);
             goto error;
         }
     }
@@ -1447,7 +1450,7 @@ error:
     ly_path_free(ctx, path);
 
     if (!*err) {
-        if (erc == -1) {
+        if (rc == -1) {
             *err = ly_err_new(LY_LLERR, LY_EMEM, 0, "Memory allocation failed.", NULL, NULL);
             ret = LY_EMEM;
         } else {
@@ -1520,7 +1523,7 @@ ly_type_compare_instanceid(const struct lyd_value *val1, const struct lyd_value 
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, int *dynamic)
+ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
 {
     LY_ARRAY_COUNT_TYPE u, v;
     char *result = NULL;
@@ -1547,7 +1550,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LIST:
                 {
                     /* key-predicate */
-                    int d = 0;
+                    uint8_t d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1563,7 +1566,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LEAFLIST:
                 {
                     /* leaf-list-predicate */
-                    int d = 0;
+                    uint8_t d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1600,7 +1603,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LIST:
                 {
                     /* key-predicate */
-                    int d = 0;
+                    uint8_t d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1615,7 +1618,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LEAFLIST:
                 {
                     /* leaf-list-predicate */
-                    int d = 0;
+                    uint8_t d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1673,7 +1676,7 @@ ly_type_find_leafref(const struct lysc_type_leafref *lref, const struct lyd_node
     LY_ERR ret;
     struct lyxp_set set = {0};
     const char *val_str;
-    int dynamic;
+    uint8_t dynamic;
     uint32_t i;
 
     /* find all target data instances */
@@ -1733,7 +1736,7 @@ error:
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_leafref(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_leafref(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node, const struct lyd_node *tree,
         struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -1810,7 +1813,7 @@ ly_type_compare_leafref(const struct lyd_value *val1, const struct lyd_value *va
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_leafref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, int *dynamic)
+ly_type_print_leafref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
 {
     return value->realtype->plugin->print(value, format, prefix_data, dynamic);
 }
@@ -1843,7 +1846,7 @@ ly_type_free_leafref(const struct ly_ctx *ctx, struct lyd_value *value)
  * @brief Answer if the type is suitable for the parser's hit (if any) in the specified format
  */
 LY_ERR
-type_check_parser_hint(LY_PREFIX_FORMAT format, int hint, LY_DATA_TYPE type)
+type_check_parser_hint(LY_PREFIX_FORMAT format, uint32_t hint, LY_DATA_TYPE type)
 {
     if (format == LY_PREF_JSON && hint) {
         switch (type) {
@@ -1929,7 +1932,6 @@ static void *
 ly_type_union_store_prefix_data(const struct ly_ctx *ctx, const char *value, size_t value_len, LY_PREFIX_FORMAT format,
         void *prefix_data)
 {
-    unsigned int c;
     const char *start, *stop;
     const struct lys_module *mod;
     struct lyxml_ns *ns;
@@ -1955,6 +1957,8 @@ ly_type_union_store_prefix_data(const struct ly_ctx *ctx, const char *value, siz
     /* add all used prefixes */
     for (stop = start = value; (size_t)(stop - value) < value_len; start = stop) {
         size_t bytes;
+        uint32_t c;
+
         ly_getutf8(&stop, &c, &bytes);
         if (is_xmlqnamestartchar(c)) {
             for (ly_getutf8(&stop, &c, &bytes);
@@ -2062,7 +2066,7 @@ error:
  * Implementation of the ly_type_store_clb.
  */
 static LY_ERR
-ly_type_store_union(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, int options,
+ly_type_store_union(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len, uint32_t options,
         LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node, const struct lyd_node *tree,
         struct lyd_value *storage, struct ly_err_item **err)
 {
@@ -2071,7 +2075,7 @@ ly_type_store_union(const struct ly_ctx *ctx, struct lysc_type *type, const char
     struct lysc_type_union *type_u = (struct lysc_type_union *)type;
     struct lyd_value_subvalue *subvalue;
     char *errmsg = NULL;
-    int prev_lo;
+    uint32_t prev_lo;
 
     if (options & LY_TYPE_OPTS_SECOND_CALL) {
         subvalue = storage->subvalue;
@@ -2187,7 +2191,7 @@ ly_type_compare_union(const struct lyd_value *val1, const struct lyd_value *val2
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_union(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, int *dynamic)
+ly_type_print_union(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
 {
     return value->subvalue->value->realtype->plugin->print(value->subvalue->value, format, prefix_data, dynamic);
 }

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -201,7 +201,7 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_PREFIX_FORMAT format,
  * @return LY_ERR value if an error occurred and the value could not be canonized following the type's rules.
  */
 typedef LY_ERR (*ly_type_store_clb)(const struct ly_ctx *ctx, struct lysc_type *type, const char *value, size_t value_len,
-        int options, LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node,
+        uint32_t options, LY_PREFIX_FORMAT format, void *prefix_data, const void *context_node,
         const struct lyd_node *tree, struct lyd_value *storage, struct ly_err_item **err);
 
 /**
@@ -234,7 +234,7 @@ typedef LY_ERR (*ly_type_compare_clb)(const struct lyd_value *val1, const struct
  * @return NULL in case of error.
  */
 typedef const char *(*ly_type_print_clb)(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        int *dynamic);
+        uint8_t *dynamic);
 
 /**
  * @brief Callback to duplicate data in data structure. Note that callback is even responsible for duplicating lyd_value::canonized.

--- a/src/printer.h
+++ b/src/printer.h
@@ -237,7 +237,7 @@ size_t ly_out_printed(const struct ly_out *out);
  * @param[in] destroy Flag to free allocated buffer (for LY_OUT_MEMORY) or to
  * close stream/file descriptor (for LY_OUT_FD, LY_OUT_FDSTREAM and LY_OUT_FILE)
  */
-void ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), int destroy);
+void ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), uint8_t destroy);
 
 #ifdef __cplusplus
 }

--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -25,7 +25,7 @@
 #include "tree_schema.h"
 
 static LY_ERR
-lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret = LY_SUCCESS;
 
@@ -49,7 +49,7 @@ lyd_print_(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, i
 }
 
 API LY_ERR
-lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_CHECK_ARG_RET(NULL, out, !(options & LYD_PRINT_WITHSIBLINGS), LY_EINVAL);
 
@@ -71,7 +71,7 @@ lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format
 }
 
 API LY_ERR
-lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_CHECK_ARG_RET(NULL, out, !(options & LYD_PRINT_WITHSIBLINGS), LY_EINVAL);
 
@@ -85,7 +85,7 @@ lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT forma
 }
 
 API LY_ERR
-lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret;
     struct ly_out *out;
@@ -102,7 +102,7 @@ lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, int o
 }
 
 API LY_ERR
-lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret;
     struct ly_out *out;
@@ -116,7 +116,7 @@ lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, int options
 }
 
 API LY_ERR
-lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret;
     struct ly_out *out;
@@ -130,7 +130,7 @@ lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, int opti
 }
 
 API LY_ERR
-lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret;
     struct ly_out *out;
@@ -144,7 +144,7 @@ lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format,
 }
 
 API LY_ERR
-lyd_print_clb(ly_write_clb writeclb, void *user_data, const struct lyd_node *root, LYD_FORMAT format, int options)
+lyd_print_clb(ly_write_clb writeclb, void *user_data, const struct lyd_node *root, LYD_FORMAT format, uint32_t options)
 {
     LY_ERR ret;
     struct ly_out *out;

--- a/src/printer_data.h
+++ b/src/printer_data.h
@@ -66,7 +66,7 @@ struct ly_out;
  * @param[in] options [Data printer flags](@ref dataprinterflags) except ::LYD_PRINT_WITHSIBLINGS.
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print the selected data subtree.
@@ -77,7 +77,7 @@ LY_ERR lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT
  * @param[in] options [Data printer flags](@ref dataprinterflags) except ::LYD_PRINT_WITHSIBLINGS.
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print data tree in the specified format.
@@ -88,7 +88,7 @@ LY_ERR lyd_print_tree(struct ly_out *out, const struct lyd_node *root, LYD_FORMA
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print data tree in the specified format.
@@ -99,7 +99,7 @@ LY_ERR lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print data tree in the specified format.
@@ -110,7 +110,7 @@ LY_ERR lyd_print_fd(int fd, const struct lyd_node *root, LYD_FORMAT format, int 
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print data tree in the specified format.
@@ -121,7 +121,7 @@ LY_ERR lyd_print_file(FILE *f, const struct lyd_node *root, LYD_FORMAT format, i
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 /**
  * @brief Print data tree in the specified format.
@@ -133,7 +133,7 @@ LY_ERR lyd_print_path(const char *path, const struct lyd_node *root, LYD_FORMAT 
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lyd_print_clb(ly_write_clb writeclb, void *user_data, const struct lyd_node *root, LYD_FORMAT format, int options);
+LY_ERR lyd_print_clb(ly_write_clb writeclb, void *user_data, const struct lyd_node *root, LYD_FORMAT format, uint32_t options);
 
 #ifdef __cplusplus
 }

--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -65,7 +65,7 @@ struct ly_out {
 struct ext_substmt_info_s {
     const char *name;      /**< name of the statement */
     const char *arg;       /**< name of YIN's attribute to present the statement */
-    int flags;             /**< various flags to clarify printing of the statement */
+    uint8_t flags;         /**< various flags to clarify printing of the statement */
 #define SUBST_FLAG_YIN 0x1 /**< has YIN element */
 #define SUBST_FLAG_ID 0x2  /**< the value is identifier -> no quotes */
 };
@@ -82,7 +82,7 @@ extern struct ext_substmt_info_s ext_substmt_info[];
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yang_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, int options);
+LY_ERR yang_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, uint32_t options);
 
 /**
  * @brief Helper macros for data printers
@@ -102,7 +102,7 @@ LY_ERR yang_print_parsed_module(struct ly_out *out, const struct lys_module *mod
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yang_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, int options);
+LY_ERR yang_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, uint32_t options);
 
 /**
  * @brief YANG printer of the compiled schemas.
@@ -116,7 +116,7 @@ LY_ERR yang_print_parsed_submodule(struct ly_out *out, const struct lys_module *
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yang_print_compiled(struct ly_out *out, const struct lys_module *module, int options);
+LY_ERR yang_print_compiled(struct ly_out *out, const struct lys_module *module, uint32_t options);
 
 /**
  * @brief YANG printer of the compiled schema node
@@ -130,7 +130,7 @@ LY_ERR yang_print_compiled(struct ly_out *out, const struct lys_module *module, 
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yang_print_compiled_node(struct ly_out *out, const struct lysc_node *node, int options);
+LY_ERR yang_print_compiled_node(struct ly_out *out, const struct lysc_node *node, uint32_t options);
 
 /**
  * @brief YIN printer of the parsed module. Full YIN printer.
@@ -141,7 +141,7 @@ LY_ERR yang_print_compiled_node(struct ly_out *out, const struct lysc_node *node
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yin_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, int options);
+LY_ERR yin_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, uint32_t options);
 
 /**
  * @brief YIN printer of the parsed submodule. Full YIN printer.
@@ -152,7 +152,7 @@ LY_ERR yin_print_parsed_module(struct ly_out *out, const struct lys_module *modu
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, int options);
+LY_ERR yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, uint32_t options);
 
 /**
  * @brief XML printer of YANG data.
@@ -162,7 +162,7 @@ LY_ERR yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *m
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR xml_print_data(struct ly_out *out, const struct lyd_node *root, int options);
+LY_ERR xml_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options);
 
 /**
  * @brief JSON printer of YANG data.
@@ -172,7 +172,7 @@ LY_ERR xml_print_data(struct ly_out *out, const struct lyd_node *root, int optio
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR json_print_data(struct ly_out *out, const struct lyd_node *root, int options);
+LY_ERR json_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options);
 
 /**
  * @brief LYB printer of YANG data.
@@ -182,16 +182,16 @@ LY_ERR json_print_data(struct ly_out *out, const struct lyd_node *root, int opti
  * @param[in] options [Data printer flags](@ref dataprinterflags).
  * @return LY_ERR value, number of the printed bytes is updated in lyout::printed.
  */
-LY_ERR lyb_print_data(struct ly_out *out, const struct lyd_node *root, int options);
+LY_ERR lyb_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options);
 
 /**
  * @brief Check whether a node value equals to its default one.
  *
  * @param[in] node Term node to test.
  * @return 0 if no,
- * @return non-zero if yes.
+ * @return 1 if yes.
  */
-int ly_is_default(const struct lyd_node *node);
+uint8_t ly_is_default(const struct lyd_node *node);
 
 /**
  * @brief Check whether the node should even be printed.
@@ -199,9 +199,9 @@ int ly_is_default(const struct lyd_node *node);
  * @param[in] node Node to check.
  * @param[in] options Printer options.
  * @return 0 if no.
- * @return non-zero if yes.
+ * @return 1 if yes.
  */
-int ly_should_print(const struct lyd_node *node, int options);
+uint8_t ly_should_print(const struct lyd_node *node, uint32_t options);
 
 /**
  * @brief Generic printer of the given format string into the specified output.

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -32,12 +32,12 @@
  * @brief JSON printer context.
  */
 struct jsonpr_ctx {
-    struct ly_out *out;  /**< output specification */
-    unsigned int level; /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
-    int options;        /**< [Data printer flags](@ref dataprinterflags) */
-    const struct ly_ctx *ctx; /**< libyang context */
+    struct ly_out *out;         /**< output specification */
+    uint16_t level;             /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
+    uint32_t options;           /**< [Data printer flags](@ref dataprinterflags) */
+    const struct ly_ctx *ctx;   /**< libyang context */
 
-    unsigned int level_printed; /* level where some dara were already printed */
+    uint16_t level_printed;     /* level where some data were already printed */
     struct ly_set open; /* currently open array(s) */
     const struct lyd_node *print_sibling_metadata;
 };
@@ -218,7 +218,7 @@ json_nscmp(const struct lyd_node *node1, const struct lyd_node *node2)
 static LY_ERR
 json_print_string(struct ly_out *out, const char *text)
 {
-    unsigned int i, n;
+    uint64_t i, n;
 
     if (!text) {
         return LY_SUCCESS;
@@ -258,7 +258,7 @@ json_print_string(struct ly_out *out, const char *text)
  * @return LY_ERR value.
  */
 static LY_ERR
-json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, int is_attr)
+json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, uint8_t is_attr)
 {
     PRINT_COMMA;
     if (LEVEL == 1 || json_nscmp(node, (const struct lyd_node *)node->parent)) {
@@ -285,7 +285,8 @@ json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, int is_at
  * @return LY_ERR value.
  */
 static LY_ERR
-json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FORMAT format, const struct ly_prefix *prefix, const char *name, int is_attr)
+json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FORMAT format,
+        const struct ly_prefix *prefix, const char *name, uint8_t is_attr)
 {
     const char *module_name = NULL;
 
@@ -332,7 +333,7 @@ json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FO
 static LY_ERR
 json_print_value(struct jsonpr_ctx *ctx, const struct lyd_value *val)
 {
-    int dynamic = 0;
+    uint8_t dynamic = 0;
     const char *value = val->realtype->plugin->print(val, LY_PREF_JSON, NULL, &dynamic);
 
     /* leafref is not supported */
@@ -447,7 +448,7 @@ json_print_metadata(struct jsonpr_ctx *ctx, const struct lyd_node *node, const s
  * @return LY_ERR value.
  */
 static LY_ERR
-json_print_attributes(struct jsonpr_ctx *ctx, const struct lyd_node *node, int inner)
+json_print_attributes(struct jsonpr_ctx *ctx, const struct lyd_node *node, uint8_t inner)
 {
     const struct lys_module *wdmod = NULL;
 
@@ -519,7 +520,7 @@ json_print_anydata(struct jsonpr_ctx *ctx, struct lyd_node_any *any)
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyd_node *iter;
-    int prev_opts, prev_lo;
+    uint32_t prev_opts, prev_lo;
 
     if (!any->value.tree) {
         /* no content */
@@ -527,7 +528,7 @@ json_print_anydata(struct jsonpr_ctx *ctx, struct lyd_node_any *any)
     }
 
     if (any->value_type == LYD_ANYDATA_LYB) {
-        int parser_options = LYD_PARSE_ONLY | LYD_PARSE_OPAQ | LYD_PARSE_STRICT;
+        uint32_t parser_options = LYD_PARSE_ONLY | LYD_PARSE_OPAQ | LYD_PARSE_STRICT;
 
         /* turn logging off */
         prev_lo = ly_log_options(0);
@@ -588,7 +589,7 @@ json_print_inner(struct jsonpr_ctx *ctx, const struct lyd_node *node)
 {
     struct lyd_node *child;
     struct lyd_node *children = lyd_node_children(node, 0);
-    int has_content = 0;
+    uint8_t has_content = 0;
 
     if (node->meta || children) {
         has_content = 1;
@@ -748,7 +749,7 @@ json_print_metadata_leaflist(struct jsonpr_ctx *ctx)
 static LY_ERR
 json_print_opaq(struct jsonpr_ctx *ctx, const struct lyd_node_opaq *node)
 {
-    int first = 1, last = 1;
+    uint8_t first = 1, last = 1;
 
     if (node->hint & LYD_NODE_OPAQ_ISLIST) {
         const struct lyd_node_opaq *prev = (const struct lyd_node_opaq *)node->prev;
@@ -851,7 +852,7 @@ json_print_node(struct jsonpr_ctx *ctx, const struct lyd_node *node)
 }
 
 LY_ERR
-json_print_data(struct ly_out *out, const struct lyd_node *root, int options)
+json_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options)
 {
     const struct lyd_node *node;
     struct jsonpr_ctx ctx = {0};

--- a/src/printer_schema.c
+++ b/src/printer_schema.c
@@ -25,8 +25,8 @@
 #include "tree_schema.h"
 
 API LY_ERR
-lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, int UNUSED(line_length),
-        int options)
+lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, size_t UNUSED(line_length),
+        uint32_t options)
 {
     LY_ERR ret;
 
@@ -82,7 +82,7 @@ lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFOR
 
 API LY_ERR
 lys_print_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodule,
-        LYS_OUTFORMAT format, int UNUSED(line_length), int options)
+        LYS_OUTFORMAT format, size_t UNUSED(line_length), uint32_t options)
 {
     LY_ERR ret;
 
@@ -116,7 +116,7 @@ lys_print_submodule(struct ly_out *out, const struct lys_module *module, const s
 }
 
 static LY_ERR
-lys_print_(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     LY_ERR ret;
 
@@ -129,7 +129,7 @@ lys_print_(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT fo
 }
 
 API LY_ERR
-lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     struct ly_out *out;
 
@@ -143,7 +143,7 @@ lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format
 }
 
 API LY_ERR
-lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     struct ly_out *out;
 
@@ -154,7 +154,7 @@ lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int 
 }
 
 API LY_ERR
-lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     struct ly_out *out;
 
@@ -165,7 +165,7 @@ lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, i
 }
 
 API LY_ERR
-lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     struct ly_out *out;
 
@@ -176,7 +176,7 @@ lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT 
 }
 
 API LY_ERR
-lys_print_clb(ly_write_clb writeclb, void *user_data, const struct lys_module *module, LYS_OUTFORMAT format, int options)
+lys_print_clb(ly_write_clb writeclb, void *user_data, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options)
 {
     struct ly_out *out;
 
@@ -187,7 +187,7 @@ lys_print_clb(ly_write_clb writeclb, void *user_data, const struct lys_module *m
 }
 
 API LY_ERR
-lys_print_node(struct ly_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, int UNUSED(line_length), int options)
+lys_print_node(struct ly_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, size_t UNUSED(line_length), uint32_t options)
 {
     LY_ERR ret;
 

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -71,7 +71,7 @@ typedef enum {
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, int line_length, int options);
+LY_ERR lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFORMAT format, size_t line_length, uint32_t options);
 
 /**
  * @brief Schema submodule printer.
@@ -85,7 +85,7 @@ LY_ERR lys_print_module(struct ly_out *out, const struct lys_module *module, LYS
  * @return LY_ERR value.
  */
 LY_ERR lys_print_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodule,
-        LYS_OUTFORMAT format, int line_length, int options);
+        LYS_OUTFORMAT format, size_t line_length, uint32_t options);
 
 /**
  * @brief Print schema tree in the specified format into a memory block.
@@ -100,7 +100,7 @@ LY_ERR lys_print_submodule(struct ly_out *out, const struct lys_module *module, 
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, int options);
+LY_ERR lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options);
 
 /**
  * @brief Print schema tree in the specified format into a file descriptor.
@@ -114,7 +114,7 @@ LY_ERR lys_print_mem(char **strp, const struct lys_module *module, LYS_OUTFORMAT
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, int options);
+LY_ERR lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options);
 
 /**
  * @brief Print schema tree in the specified format into a file stream.
@@ -128,7 +128,7 @@ LY_ERR lys_print_fd(int fd, const struct lys_module *module, LYS_OUTFORMAT forma
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, int options);
+LY_ERR lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options);
 
 /**
  * @brief Print schema tree in the specified format into a file.
@@ -142,7 +142,7 @@ LY_ERR lys_print_file(FILE *f, const struct lys_module *module, LYS_OUTFORMAT fo
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, int options);
+LY_ERR lys_print_path(const char *path, const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options);
 
 /**
  * @brief Print schema tree in the specified format using a provided callback.
@@ -158,7 +158,7 @@ LY_ERR lys_print_path(const char *path, const struct lys_module *module, LYS_OUT
  * @return LY_ERR value.
  */
 LY_ERR lys_print_clb(ly_write_clb writeclb, void *user_data,
-        const struct lys_module *module, LYS_OUTFORMAT format, int options);
+        const struct lys_module *module, LYS_OUTFORMAT format, uint32_t options);
 
 /**
  * @brief Schema node printer.
@@ -170,7 +170,7 @@ LY_ERR lys_print_clb(ly_write_clb writeclb, void *user_data,
  * @param[in] options Schema output options (see @ref schemaprinterflags).
  * @return LY_ERR value.
  */
-LY_ERR lys_print_node(struct ly_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, int line_length, int options);
+LY_ERR lys_print_node(struct ly_out *out, const struct lysc_node *node, LYS_OUTFORMAT format, size_t line_length, uint32_t options);
 
 /** @} schematree */
 

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -36,12 +36,12 @@
  * @brief XML printer context.
  */
 struct xmlpr_ctx {
-    struct ly_out *out;  /**< output specification */
-    unsigned int level; /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
-    int options;        /**< [Data printer flags](@ref dataprinterflags) */
+    struct ly_out *out;       /**< output specification */
+    uint16_t level;           /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
+    uint32_t options;         /**< [Data printer flags](@ref dataprinterflags) */
     const struct ly_ctx *ctx; /**< libyang context */
-    struct ly_set prefix;   /**< printed namespace prefixes */
-    struct ly_set ns;   /**< printed namespaces */
+    struct ly_set prefix;     /**< printed namespace prefixes */
+    struct ly_set ns;         /**< printed namespaces */
 };
 
 #define LYXML_PREFIX_REQUIRED 0x01  /**< The prefix is not just a suggestion but a requirement. */
@@ -57,11 +57,11 @@ struct xmlpr_ctx {
  * @return Printed prefix of the namespace to use.
  */
 static const char *
-xml_print_ns(struct xmlpr_ctx *ctx, const char *ns, const char *new_prefix, int prefix_opts)
+xml_print_ns(struct xmlpr_ctx *ctx, const char *ns, const char *new_prefix, uint32_t prefix_opts)
 {
-    int i;
+    int64_t i;
 
-    for (i = ctx->ns.count - 1; i > -1; --i) {
+    for (i = (int64_t)ctx->ns.count - 1; i > -1; --i) {
         if (!new_prefix) {
             /* find default namespace */
             if (!ctx->prefix.objs[i]) {
@@ -104,7 +104,7 @@ xml_print_ns(struct xmlpr_ctx *ctx, const char *ns, const char *new_prefix, int 
 }
 
 static const char *
-xml_print_ns_opaq(struct xmlpr_ctx *ctx, LYD_FORMAT format, const struct ly_prefix *prefix, int prefix_opts)
+xml_print_ns_opaq(struct xmlpr_ctx *ctx, LYD_FORMAT format, const struct ly_prefix *prefix, uint32_t prefix_opts)
 {
 
     switch (format) {
@@ -141,12 +141,11 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
     const char **prefs, **nss;
     const char *xml_expr = NULL, *mod_name;
     uint32_t ns_count, i;
-    int rpc_filter = 0;
+    uint8_t rpc_filter = 0;
     char *p;
     size_t len;
 #endif
-    int dynamic;
-    unsigned int u;
+    uint8_t dynamic;
 
     /* with-defaults */
     if (node->schema->nodetype & LYD_NODE_TERM) {
@@ -170,7 +169,7 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
         const char *value = meta->value.realtype->plugin->print(&meta->value, LY_PREF_XML, &ns_list, &dynamic);
 
         /* print namespaces connected with the value's prefixes */
-        for (u = 0; u < ns_list.count; ++u) {
+        for (uint32_t u = 0; u < ns_list.count; ++u) {
             mod = (const struct lys_module *)ns_list.objs[u];
             xml_print_ns(ctx, mod->ns, mod->prefix, 1);
         }
@@ -290,15 +289,14 @@ static void
 xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
 {
     struct ly_set ns_list = {0};
-    unsigned int u;
-    int dynamic;
+    uint8_t dynamic;
     const char *value;
 
     xml_print_node_open(ctx, (struct lyd_node *)node);
     value = ((struct lysc_node_leaf *)node->schema)->type->plugin->print(&node->value, LY_PREF_XML, &ns_list, &dynamic);
 
     /* print namespaces connected with the values's prefixes */
-    for (u = 0; u < ns_list.count; ++u) {
+    for (uint32_t u = 0; u < ns_list.count; ++u) {
         const struct lys_module *mod = (const struct lys_module *)ns_list.objs[u];
         ly_print_(ctx->out, " xmlns:%s=\"%s\"", mod->prefix, mod->ns);
     }
@@ -356,7 +354,7 @@ xml_print_anydata(struct xmlpr_ctx *ctx, const struct lyd_node_any *node)
 {
     struct lyd_node_any *any = (struct lyd_node_any *)node;
     struct lyd_node *iter;
-    int prev_opts, prev_lo;
+    uint32_t prev_opts, prev_lo;
     LY_ERR ret;
 
     xml_print_node_open(ctx, (struct lyd_node *)node);
@@ -535,7 +533,7 @@ xml_print_node(struct xmlpr_ctx *ctx, const struct lyd_node *node)
 }
 
 LY_ERR
-xml_print_data(struct ly_out *out, const struct lyd_node *root, int options)
+xml_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options)
 {
     const struct lyd_node *node;
     struct xmlpr_ctx ctx = {0};

--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -33,17 +33,17 @@
  * @brief YIN printer context.
  */
 struct ypr_ctx {
-    struct ly_out *out;               /**< output specification */
-    unsigned int level;              /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
+    struct ly_out *out;              /**< output specification */
+    uint16_t level;                  /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
+    uint32_t options;                /**< Schema output options (see @ref schemaprinterflags). */
     const struct lys_module *module; /**< schema to print */
-    int options;                     /**< Schema output options (see @ref schemaprinterflags). */
 };
 
 static void yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
-        struct lysp_ext_instance *ext, int *flag, LY_ARRAY_COUNT_TYPE count);
+        struct lysp_ext_instance *ext, int8_t *flag, LY_ARRAY_COUNT_TYPE count);
 
 static void
-ypr_open(struct ypr_ctx *ctx, const char *elem_name, const char *attr_name, const char *attr_value, int flag)
+ypr_open(struct ypr_ctx *ctx, const char *elem_name, const char *attr_name, const char *attr_value, int8_t flag)
 {
     ly_print_(ctx->out, "%*s<%s", INDENT, elem_name);
 
@@ -57,7 +57,7 @@ ypr_open(struct ypr_ctx *ctx, const char *elem_name, const char *attr_name, cons
 }
 
 static void
-ypr_close(struct ypr_ctx *ctx, const char *elem_name, int flag)
+ypr_close(struct ypr_ctx *ctx, const char *elem_name, int8_t flag)
 {
     if (flag) {
         ly_print_(ctx->out, "%*s</%s>\n", INDENT, elem_name);
@@ -72,7 +72,7 @@ ypr_close(struct ypr_ctx *ctx, const char *elem_name, int flag)
  * 1 or NULL - parent already closed, do nothing
  */
 static void
-ypr_close_parent(struct ypr_ctx *ctx, int *par_close_flag)
+ypr_close_parent(struct ypr_ctx *ctx, int8_t *par_close_flag)
 {
     if (par_close_flag && !(*par_close_flag)) {
         (*par_close_flag) = 1;
@@ -92,7 +92,7 @@ static void
 ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, const char *text, void *ext)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int extflag = 0;
+    int8_t extflag = 0;
 
     if (!text) {
         /* nothing to print */
@@ -124,10 +124,10 @@ ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, c
 }
 
 static void
-ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned int attr_value)
+ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned long int attr_value)
 {
     char *str;
-    if (asprintf(&str, "%u", attr_value) == -1) {
+    if (asprintf(&str, "%lu", attr_value) == -1) {
         LOGMEM(ctx->module->ctx);
         return;
     }
@@ -136,11 +136,11 @@ ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, 
 }
 
 static void
-ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed int attr_value)
+ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed long int attr_value)
 {
     char *str;
 
-    if (asprintf(&str, "%d", attr_value) == -1) {
+    if (asprintf(&str, "%ld", attr_value) == -1) {
         LOGMEM(ctx->module->ctx);
         return;
     }
@@ -165,7 +165,7 @@ yprp_revision(struct ypr_ctx *ctx, const struct lysp_revision *rev)
 }
 
 static void
-ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
+ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     if (flags & LYS_MAND_MASK) {
         ypr_close_parent(ctx, flag);
@@ -174,7 +174,7 @@ ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
 }
 
 static void
-ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
+ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     if (flags & LYS_CONFIG_MASK) {
         ypr_close_parent(ctx, flag);
@@ -183,7 +183,7 @@ ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
 }
 
 static void
-ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
+ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     const char *status = NULL;
 
@@ -202,7 +202,7 @@ ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, int *flag)
 }
 
 static void
-ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, int *flag)
+ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, int8_t *flag)
 {
     if (dsc) {
         ypr_close_parent(ctx, flag);
@@ -211,7 +211,7 @@ ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, int *flag)
 }
 
 static void
-ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, int *flag)
+ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, int8_t *flag)
 {
     if (ref) {
         ypr_close_parent(ctx, flag);
@@ -220,10 +220,10 @@ ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, int *flag)
 }
 
 static void
-yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance *exts, int *flag)
+yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance *exts, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int extflag;
+    int8_t extflag;
 
     LY_ARRAY_FOR(iff, u) {
         ypr_close_parent(ctx, flag);
@@ -247,7 +247,7 @@ yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance 
 static void
 yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 {
-    int flag = 0, flag2 = 0;
+    int8_t flag = 0, flag2 = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     ypr_open(ctx, "extension", "name", ext->name, flag);
@@ -290,7 +290,7 @@ yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 static void
 yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 {
-    int flag = 0;
+    int8_t flag = 0;
 
     ypr_open(ctx, "feature", "name", feat->name, flag);
     LEVEL++;
@@ -306,7 +306,7 @@ yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 static void
 yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
 {
-    int flag = 0;
+    int8_t flag = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     ypr_open(ctx, "identity", "name", ident->name, flag);
@@ -329,10 +329,10 @@ yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
 }
 
 static void
-yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, const char *attr, int *flag)
+yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, const char *attr, int8_t *flag)
 {
     (void)flag;
-    int inner_flag = 0;
+    int8_t inner_flag = 0;
 
     if (!restr) {
         return;
@@ -365,9 +365,9 @@ yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name
 }
 
 static void
-yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int *flag)
+yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int8_t *flag)
 {
-    int inner_flag = 0;
+    int8_t inner_flag = 0;
     (void)flag;
 
     if (!when) {
@@ -387,10 +387,10 @@ yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int *flag)
 }
 
 static void
-yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, int *flag)
+yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int inner_flag;
+    int8_t inner_flag;
     (void)flag;
 
     LY_ARRAY_FOR(items, u) {
@@ -428,7 +428,7 @@ static void
 yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
 
     if (!ctx || !type) {
         return;
@@ -507,7 +507,7 @@ static void
 yprp_grouping(struct ypr_ctx *ctx, const struct lysp_grp *grp)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *data;
 
     ypr_open(ctx, "grouping", "name", grp->name, flag);
@@ -543,7 +543,7 @@ yprp_grouping(struct ypr_ctx *ctx, const struct lysp_grp *grp)
 }
 
 static void
-yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, int *flag)
+yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node *data;
@@ -580,7 +580,7 @@ static void
 yprp_notification(struct ypr_ctx *ctx, const struct lysp_notif *notif)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *data;
 
     ypr_open(ctx, "notification", "name", notif->name, flag);
@@ -620,7 +620,7 @@ static void
 yprp_action(struct ypr_ctx *ctx, const struct lysp_action *action)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
 
     ypr_open(ctx, action->parent ? "action" : "rpc", "name", action->name, flag);
 
@@ -649,7 +649,7 @@ yprp_action(struct ypr_ctx *ctx, const struct lysp_action *action)
 }
 
 static void
-yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int *flag)
+yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
 {
     ypr_open(ctx, lys_nodetype2str(node->nodetype), "name", node->name, *flag);
     LEVEL++;
@@ -660,7 +660,7 @@ yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int *flag)
 }
 
 static void
-yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, int *flag)
+yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
 {
     ypr_config(ctx, node->flags, node->exts, flag);
     if (node->nodetype & (LYS_CHOICE | LYS_LEAF | LYS_ANYDATA)) {
@@ -675,7 +675,7 @@ static void
 yprp_container(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *child;
     struct lysp_node_container *cont = (struct lysp_node_container *)node;
 
@@ -724,7 +724,7 @@ yprp_container(struct ypr_ctx *ctx, const struct lysp_node *node)
 static void
 yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *child;
     struct lysp_node_case *cas = (struct lysp_node_case *)node;
 
@@ -743,7 +743,7 @@ yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
 static void
 yprp_choice(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *child;
     struct lysp_node_choice *choice = (struct lysp_node_choice *)node;
 
@@ -771,7 +771,7 @@ yprp_leaf(struct ypr_ctx *ctx, const struct lysp_node *node)
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node_leaf *leaf = (struct lysp_node_leaf *)node;
 
-    int flag = 1;
+    int8_t flag = 1;
     yprp_node_common1(ctx, node, &flag);
 
     yprp_type(ctx, &leaf->type);
@@ -792,7 +792,7 @@ yprp_leaflist(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node_leaflist *llist = (struct lysp_node_leaflist *)node;
-    int flag = 1;
+    int8_t flag = 1;
 
     yprp_node_common1(ctx, node, &flag);
 
@@ -834,7 +834,7 @@ static void
 yprp_list(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node *child;
     struct lysp_node_list *list = (struct lysp_node_list *)node;
 
@@ -908,7 +908,7 @@ static void
 yprp_refine(struct ypr_ctx *ctx, struct lysp_refine *refine)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
 
     ypr_open(ctx, "refine", "target-node", refine->nodeid, flag);
     LEVEL++;
@@ -990,7 +990,7 @@ static void
 yprp_uses(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node_uses *uses = (struct lysp_node_uses *)node;
 
     yprp_node_common1(ctx, node, &flag);
@@ -1014,7 +1014,7 @@ static void
 yprp_anydata(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    int flag = 0;
+    int8_t flag = 0;
     struct lysp_node_anydata *any = (struct lysp_node_anydata *)node;
 
     yprp_node_common1(ctx, node, &flag);
@@ -1170,14 +1170,14 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
 }
 
 static void
-ypr_xmlns(struct ypr_ctx *ctx, const struct lys_module *module, unsigned int indent)
+ypr_xmlns(struct ypr_ctx *ctx, const struct lys_module *module, uint16_t indent)
 {
     ly_print_(ctx->out, "%*sxmlns=\"%s\"", indent + INDENT, YIN_NS_URI);
     ly_print_(ctx->out, "\n%*sxmlns:%s=\"%s\"", indent + INDENT, module->prefix, module->ns);
 }
 
 static void
-ypr_import_xmlns(struct ypr_ctx *ctx, const struct lysp_module *modp, unsigned int indent)
+ypr_import_xmlns(struct ypr_ctx *ctx, const struct lysp_module *modp, uint16_t indent)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -1268,7 +1268,7 @@ static void
 yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
 {
     struct lysp_stmt *childstmt;
-    int flag = stmt->child ? 1 : -1;
+    int8_t flag = stmt->child ? 1 : -1;
 
     /* TODO:
              the extension instance substatements in extension instances (LY_STMT_EXTENSION_INSTANCE)
@@ -1298,13 +1298,14 @@ yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
  */
 static void
 yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
-        struct lysp_ext_instance *ext, int *flag, LY_ARRAY_COUNT_TYPE count)
+        struct lysp_ext_instance *ext, int8_t *flag, LY_ARRAY_COUNT_TYPE count)
 {
     LY_ARRAY_COUNT_TYPE u;
     char *str;
     struct lysp_stmt *stmt;
     const char *argument;
     const char *ext_argument;
+    int8_t inner_flag = 0;
 
     if (!count && ext) {
         count = LY_ARRAY_COUNT(ext);
@@ -1325,7 +1326,7 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
         }
 
         ypr_close_parent(ctx, flag);
-        int inner_flag = 0;
+        inner_flag = 0;
         argument = NULL;
         ext_argument = NULL;
 
@@ -1451,7 +1452,7 @@ yin_print_parsed_body(struct ypr_ctx *ctx, const struct lysp_module *modp)
 }
 
 LY_ERR
-yin_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, int options)
+yin_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
@@ -1513,7 +1514,7 @@ yprp_belongsto(struct ypr_ctx *ctx, const struct lysp_submodule *submodp)
 }
 
 LY_ERR
-yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, int options)
+yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;

--- a/src/set.c
+++ b/src/set.c
@@ -118,7 +118,7 @@ ly_set_dup(const struct ly_set *set, void *(*duplicator)(void *obj))
 }
 
 API int
-ly_set_add(struct ly_set *set, void *object, int options)
+ly_set_add(struct ly_set *set, void *object, uint32_t options)
 {
     uint32_t i;
     void **new;
@@ -148,7 +148,7 @@ ly_set_add(struct ly_set *set, void *object, int options)
 }
 
 API int
-ly_set_merge(struct ly_set *trg, struct ly_set *src, int options, void *(*duplicator)(void *obj))
+ly_set_merge(struct ly_set *trg, struct ly_set *src, uint32_t options, void *(*duplicator)(void *obj))
 {
     uint32_t u, c, ret = 0;
     int i;

--- a/src/set.h
+++ b/src/set.h
@@ -91,7 +91,7 @@ struct ly_set *ly_set_dup(const struct ly_set *set, void *(*duplicator)(void *ob
  * - #LY_SET_OPT_USEASLIST - do not check for duplicities
  * @return -1 on failure, index of the \p node in the set on success
  */
-int ly_set_add(struct ly_set *set, void *object, int options);
+int ly_set_add(struct ly_set *set, void *object, uint32_t options);
 
 /**
  * @brief Add all objects from \p src to \p trg.
@@ -107,7 +107,7 @@ int ly_set_add(struct ly_set *set, void *object, int options);
  * objects as the \p src set.
  * @return -1 on failure, number of objects added into \p trg on success.
  */
-int ly_set_merge(struct ly_set *trg, struct ly_set *src, int options, void *(*duplicator)(void *obj));
+int ly_set_merge(struct ly_set *trg, struct ly_set *src, uint32_t options, void *(*duplicator)(void *obj));
 
 /**
  * @brief Learn whether the set contains the specified object.

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -54,14 +54,14 @@ static LY_ERR lyd_find_sibling_schema(const struct lyd_node *siblings, const str
         struct lyd_node **match);
 
 LY_ERR
-lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, int *dynamic, int second, int value_hint,
-        LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree)
+lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, uint8_t *dynamic, uint8_t second,
+        uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree)
 {
     LY_ERR ret = LY_SUCCESS;
     struct ly_err_item *err = NULL;
     struct ly_ctx *ctx;
     struct lysc_type *type;
-    int options = value_hint | (second ? LY_TYPE_OPTS_SECOND_CALL : 0) |
+    uint32_t options = value_hint | (second ? LY_TYPE_OPTS_SECOND_CALL : 0) |
             (dynamic && *dynamic ? LY_TYPE_OPTS_DYNAMIC : 0) | (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
     assert(node);
 
@@ -91,14 +91,14 @@ error:
 
 /* similar to lyd_value_parse except can be used just to store the value, hence also does not support a second call */
 LY_ERR
-lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len, int *dynamic,
+lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic,
         LY_PREFIX_FORMAT format, void *prefix_data)
 {
     LY_ERR ret = LY_SUCCESS;
     struct ly_err_item *err = NULL;
     struct ly_ctx *ctx;
     struct lysc_type *type;
-    int options = LY_TYPE_OPTS_INCOMPLETE_DATA | (dynamic && *dynamic ? LY_TYPE_OPTS_DYNAMIC : 0);
+    uint32_t options = LY_TYPE_OPTS_INCOMPLETE_DATA | (dynamic && *dynamic ? LY_TYPE_OPTS_DYNAMIC : 0);
 
     assert(val && schema && (schema->nodetype & LYD_NODE_TERM));
 
@@ -122,14 +122,14 @@ lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const cha
 }
 
 LY_ERR
-lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len, int *dynamic,
-        int second, int value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode,
+lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len, uint8_t *dynamic,
+        uint8_t second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode,
         const struct lyd_node *tree)
 {
     LY_ERR ret = LY_SUCCESS;
     struct ly_err_item *err = NULL;
     struct lyext_metadata *ant;
-    int options = value_hint | (second ? LY_TYPE_OPTS_SECOND_CALL : 0) |
+    uint32_t options = value_hint | (second ? LY_TYPE_OPTS_SECOND_CALL : 0) |
             (dynamic && *dynamic ? LY_TYPE_OPTS_DYNAMIC : 0) | (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
 
     assert(ctx && meta && ((tree && meta->parent) || ctx_snode));
@@ -205,7 +205,7 @@ lyd_value_validate(const struct ly_ctx *ctx, const struct lyd_node_term *node, c
     struct ly_err_item *err = NULL;
     struct lysc_type *type;
     struct lyd_value val = {0};
-    int options = (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
+    uint32_t options = (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
 
     LY_CHECK_ARG_RET(ctx, node, value, LY_EINVAL);
 
@@ -241,7 +241,7 @@ lyd_value_compare(const struct lyd_node_term *node, const char *value, size_t va
     struct ly_ctx *ctx;
     struct lysc_type *type;
     struct lyd_value data = {0};
-    int options = (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
+    uint32_t options = (tree ? 0 : LY_TYPE_OPTS_INCOMPLETE_DATA);
 
     LY_CHECK_ARG_RET(node ? node->schema->module->ctx : NULL, node, value, LY_EINVAL);
 
@@ -298,7 +298,7 @@ lyd_parse_get_format(const struct ly_in *in, LYD_FORMAT format)
 }
 
 API LY_ERR
-lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, int parse_options, int validate_options,
+lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -392,7 +392,7 @@ cleanup:
 }
 
 API LY_ERR
-lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT format, int parse_options, int validate_options,
+lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT format, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree)
 {
     LY_ERR ret;
@@ -406,7 +406,7 @@ lyd_parse_data_mem(const struct ly_ctx *ctx, const char *data, LYD_FORMAT format
 }
 
 API LY_ERR
-lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, int parse_options, int validate_options,
+lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree)
 {
     LY_ERR ret;
@@ -420,8 +420,8 @@ lyd_parse_data_fd(const struct ly_ctx *ctx, int fd, LYD_FORMAT format, int parse
 }
 
 API LY_ERR
-lyd_parse_data_path(const struct ly_ctx *ctx, const char *path, LYD_FORMAT format, int parse_options,
-        int validate_options, struct lyd_node **tree)
+lyd_parse_data_path(const struct ly_ctx *ctx, const char *path, LYD_FORMAT format, uint32_t parse_options,
+        uint32_t validate_options, struct lyd_node **tree)
 {
     LY_ERR ret;
     struct ly_in *in;
@@ -533,7 +533,7 @@ lyd_parse_notif(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, s
 }
 
 LY_ERR
-lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, int *dynamic, int value_hint,
+lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
 {
     LY_ERR ret;
@@ -693,7 +693,7 @@ lyd_create_any(const struct lysc_node *schema, const void *value, LYD_ANYDATA_VA
 
 LY_ERR
 lyd_create_opaq(const struct ly_ctx *ctx, const char *name, size_t name_len, const char *value, size_t value_len,
-        int *dynamic, int value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix, size_t pref_len,
+        uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix, size_t pref_len,
         const char *module_key, size_t module_key_len, struct lyd_node **node)
 {
     struct lyd_node_opaq *opaq;
@@ -1087,7 +1087,7 @@ lyd_change_term(struct lyd_node *term, const char *val_str)
     struct lyd_node_term *t;
     struct lyd_node *parent;
     struct lyd_value val = {0};
-    int dflt_change, val_change;
+    uint8_t dflt_change, val_change;
 
     LY_CHECK_ARG_RET(NULL, term, term->schema, term->schema->nodetype & LYD_NODE_TERM, LY_EINVAL);
 
@@ -1163,7 +1163,7 @@ lyd_change_meta(struct lyd_meta *meta, const char *val_str)
     LY_ERR ret = LY_SUCCESS;
     struct lyd_meta *m2;
     struct lyd_value val;
-    int val_change;
+    uint8_t val_change;
 
     LY_CHECK_ARG_RET(NULL, meta, LY_EINVAL);
 
@@ -1197,7 +1197,7 @@ cleanup:
 }
 
 API LY_ERR
-lyd_new_path(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const char *value, int options,
+lyd_new_path(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const char *value, uint32_t options,
         struct lyd_node **node)
 {
     return lyd_new_path2(parent, ctx, path, value, 0, options, node, NULL);
@@ -1205,7 +1205,7 @@ lyd_new_path(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path
 
 API LY_ERR
 lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const void *value,
-        LYD_ANYDATA_VALUETYPE value_type, int options, struct lyd_node **new_parent, struct lyd_node **new_node)
+        LYD_ANYDATA_VALUETYPE value_type, uint32_t options, struct lyd_node **new_parent, struct lyd_node **new_node)
 {
     LY_ERR ret = LY_SUCCESS, r;
     struct lyxp_expr *exp = NULL;
@@ -1381,7 +1381,7 @@ cleanup:
 
 LY_ERR
 lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struct lysc_node *sparent,
-        const struct lys_module *mod, struct ly_set *node_types, struct ly_set *node_when, int impl_opts,
+        const struct lys_module *mod, struct ly_set *node_types, struct ly_set *node_when, uint32_t impl_opts,
         struct lyd_node **diff)
 {
     LY_ERR ret;
@@ -1491,7 +1491,7 @@ lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struc
 }
 
 API LY_ERR
-lyd_new_implicit_tree(struct lyd_node *tree, int implicit_options, struct lyd_node **diff)
+lyd_new_implicit_tree(struct lyd_node *tree, uint32_t implicit_options, struct lyd_node **diff)
 {
     struct lyd_node *node;
     LY_ERR ret = LY_SUCCESS;
@@ -1521,7 +1521,7 @@ cleanup:
 }
 
 API LY_ERR
-lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, int implicit_options, struct lyd_node **diff)
+lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, uint32_t implicit_options, struct lyd_node **diff)
 {
     const struct lys_module *mod;
     struct lyd_node *d = NULL;
@@ -1560,7 +1560,7 @@ cleanup:
 }
 
 API LY_ERR
-lyd_new_implicit_module(struct lyd_node **tree, const struct lys_module *module, int implicit_options, struct lyd_node **diff)
+lyd_new_implicit_module(struct lyd_node **tree, const struct lys_module *module, uint32_t implicit_options, struct lyd_node **diff)
 {
     struct lyd_node *root, *d = NULL;
     LY_ERR ret = LY_SUCCESS;
@@ -1601,7 +1601,7 @@ lyd_insert_get_next_anchor(const struct lyd_node *first_sibling, const struct ly
 {
     const struct lysc_node *schema, *sparent;
     struct lyd_node *match = NULL;
-    int found;
+    uint8_t found;
 
     assert(new_node);
 
@@ -2118,7 +2118,7 @@ lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta)
 
 LY_ERR
 lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
-        size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hint, LY_PREFIX_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LY_PREFIX_FORMAT format,
         void *prefix_data, const struct lysc_node *ctx_snode)
 {
     LY_ERR ret;
@@ -2196,7 +2196,7 @@ lyd_insert_attr(struct lyd_node *parent, struct lyd_attr *attr)
 
 LY_ERR
 lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const struct ly_ctx *ctx, const char *name,
-        size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hint, LYD_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format,
         struct ly_prefix *val_prefs, const char *prefix, size_t prefix_len, const char *module_key, size_t module_key_len)
 {
     struct lyd_attr *at, *last;
@@ -2256,7 +2256,7 @@ lyd_target(const struct ly_path *path, const struct lyd_node *tree)
 }
 
 API LY_ERR
-lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, int options)
+lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, uint32_t options)
 {
     const struct lyd_node *iter1, *iter2;
     struct lyd_node_term *term1, *term2;
@@ -2427,7 +2427,7 @@ all_children_compare:
 }
 
 API LY_ERR
-lyd_compare_siblings(const struct lyd_node *node1, const struct lyd_node *node2, int options)
+lyd_compare_siblings(const struct lyd_node *node1, const struct lyd_node *node2, uint32_t options)
 {
     for ( ; node1 && node2; node1 = node1->next, node2 = node2->next) {
         LY_CHECK_RET(lyd_compare_single(node1, node2, options));
@@ -2474,7 +2474,7 @@ lyd_compare_meta(const struct lyd_meta *meta1, const struct lyd_meta *meta2)
  * @return LY_ERR value
  */
 static LY_ERR
-lyd_dup_r(const struct lyd_node *node, struct lyd_node *parent, struct lyd_node **first, int options,
+lyd_dup_r(const struct lyd_node *node, struct lyd_node *parent, struct lyd_node **first, uint32_t options,
         struct lyd_node **dup_p)
 {
     LY_ERR ret;
@@ -2614,7 +2614,7 @@ lyd_dup_get_local_parent(const struct lyd_node *node, const struct lyd_node_inne
         struct lyd_node_inner **local_parent)
 {
     const struct lyd_node_inner *orig_parent, *iter;
-    int repeat = 1;
+    uint8_t repeat = 1;
 
     *dup_parent = NULL;
     *local_parent = NULL;
@@ -2660,7 +2660,7 @@ lyd_dup_get_local_parent(const struct lyd_node *node, const struct lyd_node_inne
 }
 
 static LY_ERR
-lyd_dup(const struct lyd_node *node, struct lyd_node_inner *parent, int options, int nosiblings, struct lyd_node **dup)
+lyd_dup(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, uint8_t  nosiblings, struct lyd_node **dup)
 {
     LY_ERR rc;
     const struct lyd_node *orig;          /* original node to be duplicated */
@@ -2706,13 +2706,13 @@ error:
 }
 
 API LY_ERR
-lyd_dup_single(const struct lyd_node *node, struct lyd_node_inner *parent, int options, struct lyd_node **dup)
+lyd_dup_single(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, struct lyd_node **dup)
 {
     return lyd_dup(node, parent, options, 1, dup);
 }
 
 API LY_ERR
-lyd_dup_siblings(const struct lyd_node *node, struct lyd_node_inner *parent, int options, struct lyd_node **dup)
+lyd_dup_siblings(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, struct lyd_node **dup)
 {
     return lyd_dup(node, parent, options, 0, dup);
 }
@@ -2759,7 +2759,7 @@ lyd_dup_meta_single(const struct lyd_meta *meta, struct lyd_node *node, struct l
  */
 static LY_ERR
 lyd_merge_sibling_r(struct lyd_node **first_trg, struct lyd_node *parent_trg, const struct lyd_node **sibling_src_p,
-        int options)
+        uint16_t options)
 {
     LY_ERR ret;
     const struct lyd_node *child_src, *tmp, *sibling_src;
@@ -2828,10 +2828,10 @@ lyd_merge_sibling_r(struct lyd_node **first_trg, struct lyd_node *parent_trg, co
 }
 
 static LY_ERR
-lyd_merge(struct lyd_node **target, const struct lyd_node *source, int options, int nosiblings)
+lyd_merge(struct lyd_node **target, const struct lyd_node *source, uint16_t options, uint8_t nosiblings)
 {
     const struct lyd_node *sibling_src, *tmp;
-    int first;
+    uint8_t first;
 
     LY_CHECK_ARG_RET(NULL, target, LY_EINVAL);
 
@@ -2867,19 +2867,19 @@ lyd_merge(struct lyd_node **target, const struct lyd_node *source, int options, 
 }
 
 API LY_ERR
-lyd_merge_tree(struct lyd_node **target, const struct lyd_node *source, int options)
+lyd_merge_tree(struct lyd_node **target, const struct lyd_node *source, uint16_t options)
 {
     return lyd_merge(target, source, options, 1);
 }
 
 API LY_ERR
-lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *source, int options)
+lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *source, uint16_t options)
 {
     return lyd_merge(target, source, options, 0);
 }
 
 static LY_ERR
-lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, int is_static)
+lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, uint8_t is_static)
 {
     /* ending \0 */
     ++reqlen;
@@ -2901,7 +2901,7 @@ lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, int is_static
 }
 
 LY_ERR
-lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, int is_static)
+lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
 {
     const struct lyd_node *key;
     size_t len;
@@ -2934,7 +2934,7 @@ lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *bufl
  * @return LY_ERR
  */
 static LY_ERR
-lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, int is_static)
+lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
 {
     size_t len;
     const char *val;
@@ -2964,11 +2964,11 @@ lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *
  * @return LY_ERR
  */
 static LY_ERR
-lyd_path_position_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, int is_static)
+lyd_path_position_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
 {
     const struct lyd_node *first, *iter;
     size_t len;
-    int pos;
+    uint64_t pos;
     char *val = NULL;
     LY_ERR rc;
 
@@ -2983,7 +2983,7 @@ lyd_path_position_predicate(const struct lyd_node *node, char **buffer, size_t *
             ++pos;
         }
     }
-    if (asprintf(&val, "%d", pos) == -1) {
+    if (asprintf(&val, "%" PRIu64, pos) == -1) {
         return LY_EMEM;
     }
 
@@ -3003,7 +3003,8 @@ cleanup:
 API char *
 lyd_path(const struct lyd_node *node, LYD_PATH_TYPE pathtype, char *buffer, size_t buflen)
 {
-    int is_static = 0, i, depth;
+    uint8_t is_static = 0;
+    uint32_t i, depth;
     size_t bufused = 0, len;
     const struct lyd_node *iter;
     const struct lys_module *mod;
@@ -3191,8 +3192,8 @@ lyd_find_sibling_first(const struct lyd_node *siblings, const struct lyd_node *t
     return LY_SUCCESS;
 }
 
-static int
-lyd_hash_table_schema_val_equal(void *val1_p, void *val2_p, int UNUSED(mod), void *UNUSED(cb_data))
+static uint8_t
+lyd_hash_table_schema_val_equal(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *UNUSED(cb_data))
 {
     struct lysc_node *val1;
     struct lyd_node *val2;

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -89,7 +89,7 @@ struct lysc_node;
  * @param ELEM Iterator intended for use in the block.
  */
 #define LYD_TREE_DFS_BEGIN(START, ELEM) \
-    { int LYD_TREE_DFS_continue = 0; struct lyd_node *LYD_TREE_DFS_next; \
+    { uint8_t LYD_TREE_DFS_continue = 0; struct lyd_node *LYD_TREE_DFS_next; \
     for ((ELEM) = (LYD_TREE_DFS_next) = (struct lyd_node *)(START); \
          (ELEM); \
          (ELEM) = (LYD_TREE_DFS_next), LYD_TREE_DFS_continue = 0)
@@ -195,7 +195,7 @@ struct lyd_value_subvalue {
                                       whether a value is valid for the specific format or not on later validations
                                       (instance-identifier in XML looks different than in JSON). */
     void *prefix_data;           /**< Format-specific data for prefix resolution (see ::ly_resolve_prefix) */
-    int parser_hint;             /**< Hint options from the parser */
+    uint32_t parser_hint;        /**< Hint options from the parser */
 };
 
 /**
@@ -285,7 +285,7 @@ struct lyd_attr {
     const char *value;
 
     LYD_FORMAT format;              /**< format of the prefixes, only LYD_XML and LYD_JSON values can appear at this place */
-    int hint;                       /**< additional information about from the data source, see the [hints list](@ref lydopaqhints) */
+    uint32_t hint;                  /**< additional information about from the data source, see the [hints list](@ref lydopaqhints) */
     struct ly_prefix prefix;        /**< name prefix, it is stored because they are a real pain to generate properly */
 
 };
@@ -470,7 +470,7 @@ struct lyd_node_opaq {
     struct ly_prefix prefix;        /**< name prefix */
     struct ly_prefix *val_prefs;    /**< list of prefixes in the value ([sized array](@ref sizedarrays)) */
     const char *value;              /**< original value */
-    int hint;                       /**< additional information about from the data source, see the [hints list](@ref lydopaqhints) */
+    uint32_t hint;                  /**< additional information about from the data source, see the [hints list](@ref lydopaqhints) */
     const struct ly_ctx *ctx;       /**< libyang context */
 };
 
@@ -491,7 +491,7 @@ struct lyd_node_opaq {
  * @param[in] options Bitmask of options, see @ref
  * @return Pointer to the first child node (if any) of the \p node.
  */
-struct lyd_node *lyd_node_children(const struct lyd_node *node, int options);
+struct lyd_node *lyd_node_children(const struct lyd_node *node, uint32_t options);
 
 /**
  * @brief Get the owner module of the data node. It is the module of the top-level schema node. Generally,
@@ -673,7 +673,7 @@ LY_ERR lyd_new_attr(struct lyd_node *parent, const char *module_name, const char
  * @return LY_ERR value.
  */
 LY_ERR lyd_new_path(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const char *value,
-        int options, struct lyd_node **node);
+        uint32_t options, struct lyd_node **node);
 
 /**
  * @brief Create a new node in the data tree based on a path. All node types can be created.
@@ -692,7 +692,7 @@ LY_ERR lyd_new_path(struct lyd_node *parent, const struct ly_ctx *ctx, const cha
  * @return LY_ERR value.
  */
 LY_ERR lyd_new_path_any(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const void *value,
-        LYD_ANYDATA_VALUETYPE value_type, int options, struct lyd_node **node);
+        LYD_ANYDATA_VALUETYPE value_type, uint32_t options, struct lyd_node **node);
 
 /**
  * @brief Create a new node in the data tree based on a path. All node types can be created.
@@ -712,7 +712,7 @@ LY_ERR lyd_new_path_any(struct lyd_node *parent, const struct ly_ctx *ctx, const
  * @return LY_ERR value.
  */
 LY_ERR lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *path, const void *value,
-        LYD_ANYDATA_VALUETYPE value_type, int options, struct lyd_node **new_parent, struct lyd_node **new_node);
+        LYD_ANYDATA_VALUETYPE value_type, uint32_t options, struct lyd_node **new_parent, struct lyd_node **new_node);
 
 /**
  * @defgroup implicitoptions Implicit node creation options
@@ -741,7 +741,7 @@ LY_ERR lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const ch
  * @param[out] diff Optional diff with any created nodes.
  * @return LY_ERR value.
  */
-LY_ERR lyd_new_implicit_tree(struct lyd_node *tree, int implicit_options, struct lyd_node **diff);
+LY_ERR lyd_new_implicit_tree(struct lyd_node *tree, uint32_t implicit_options, struct lyd_node **diff);
 
 /**
  * @brief Add any missing implicit nodes.
@@ -752,7 +752,7 @@ LY_ERR lyd_new_implicit_tree(struct lyd_node *tree, int implicit_options, struct
  * @param[out] diff Optional diff with any created nodes.
  * @return LY_ERR value.
  */
-LY_ERR lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, int implicit_options, struct lyd_node **diff);
+LY_ERR lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, uint32_t implicit_options, struct lyd_node **diff);
 
 /**
  * @brief Add any missing implicit nodes of one module.
@@ -763,7 +763,7 @@ LY_ERR lyd_new_implicit_all(struct lyd_node **tree, const struct ly_ctx *ctx, in
  * @param[out] diff Optional diff with any created nodes.
  * @return LY_ERR value.
  */
-LY_ERR lyd_new_implicit_module(struct lyd_node **tree, const struct lys_module *module, int implicit_options,
+LY_ERR lyd_new_implicit_module(struct lyd_node **tree, const struct lys_module *module, uint32_t implicit_options,
         struct lyd_node **diff);
 
 /**
@@ -969,7 +969,7 @@ LY_ERR lyd_value_compare(const struct lyd_node_term *node, const char *value, si
  * @return LY_SUCCESS if the nodes are equivalent.
  * @return LY_ENOT if the nodes are not equivalent.
  */
-LY_ERR lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, int options);
+LY_ERR lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *node2, uint32_t options);
 
 /**
  * @brief Compare 2 lists of siblings if they are equivalent.
@@ -980,7 +980,7 @@ LY_ERR lyd_compare_single(const struct lyd_node *node1, const struct lyd_node *n
  * @return LY_SUCCESS if all the siblings are equivalent.
  * @return LY_ENOT if the siblings are not equivalent.
  */
-LY_ERR lyd_compare_siblings(const struct lyd_node *node1, const struct lyd_node *node2, int options);
+LY_ERR lyd_compare_siblings(const struct lyd_node *node1, const struct lyd_node *node2, uint32_t options);
 
 /**
  * @brief Compare 2 metadata.
@@ -1026,7 +1026,7 @@ LY_ERR lyd_compare_meta(const struct lyd_meta *meta1, const struct lyd_meta *met
  * node(s) (when LYD_DUP_WITH_PARENTS used), the first duplicated node is still returned.
  * @return LY_ERR value.
  */
-LY_ERR lyd_dup_single(const struct lyd_node *node, struct lyd_node_inner *parent, int options, struct lyd_node **dup);
+LY_ERR lyd_dup_single(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, struct lyd_node **dup);
 
 /**
  * @brief Create a copy of the specified data tree \p node with any following siblings. Schema references are kept the same.
@@ -1040,7 +1040,7 @@ LY_ERR lyd_dup_single(const struct lyd_node *node, struct lyd_node_inner *parent
  * node(s) (when LYD_DUP_WITH_PARENTS used), the first duplicated node is still returned.
  * @return LY_ERR value.
  */
-LY_ERR lyd_dup_siblings(const struct lyd_node *node, struct lyd_node_inner *parent, int options, struct lyd_node **dup);
+LY_ERR lyd_dup_siblings(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, struct lyd_node **dup);
 
 /**
  * @brief Create a copy of the metadata.
@@ -1079,7 +1079,7 @@ LY_ERR lyd_dup_meta_single(const struct lyd_meta *meta, struct lyd_node *parent,
  * @return LY_SUCCESS on success,
  * @return LY_ERR value on error.
  */
-LY_ERR lyd_merge_tree(struct lyd_node **target, const struct lyd_node *source, int options);
+LY_ERR lyd_merge_tree(struct lyd_node **target, const struct lyd_node *source, uint16_t options);
 
 /**
  * @brief Merge the source data tree with any following siblings into the target data tree. Merge may not be
@@ -1092,7 +1092,7 @@ LY_ERR lyd_merge_tree(struct lyd_node **target, const struct lyd_node *source, i
  * @return LY_SUCCESS on success,
  * @return LY_ERR value on error.
  */
-LY_ERR lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *source, int options);
+LY_ERR lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *source, uint16_t options);
 
 /**
  * @defgroup diffoptions Data diff options.
@@ -1136,7 +1136,7 @@ LY_ERR lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *sourc
  * @return LY_SUCCESS on success,
  * @return LY_ERR on error.
  */
-LY_ERR lyd_diff_tree(const struct lyd_node *first, const struct lyd_node *second, int options, struct lyd_node **diff);
+LY_ERR lyd_diff_tree(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, struct lyd_node **diff);
 
 /**
  * @brief Learn the differences between 2 data trees including all the following siblings.
@@ -1148,7 +1148,7 @@ LY_ERR lyd_diff_tree(const struct lyd_node *first, const struct lyd_node *second
  * @return LY_SUCCESS on success,
  * @return LY_ERR on error.
  */
-LY_ERR lyd_diff_siblings(const struct lyd_node *first, const struct lyd_node *second, int options, struct lyd_node **diff);
+LY_ERR lyd_diff_siblings(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, struct lyd_node **diff);
 
 /**
  * @brief Callback for diff nodes.

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -23,7 +23,7 @@
 #include "plugins_types.h"
 
 static void
-lyd_free_meta(struct lyd_meta *meta, int siblings)
+lyd_free_meta(struct lyd_meta *meta, uint8_t siblings)
 {
     struct lyd_meta *iter;
 
@@ -77,7 +77,7 @@ lyd_free_meta_siblings(struct lyd_meta *meta)
 }
 
 static void
-ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, int siblings)
+ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, uint8_t siblings)
 {
     struct lyd_attr *iter;
     LY_ARRAY_COUNT_TYPE u;
@@ -157,7 +157,7 @@ ly_free_val_prefs(const struct ly_ctx *ctx, struct ly_prefix *val_prefs)
  * @param[in] top Recursion flag to unlink the root of the subtree being freed.
  */
 static void
-lyd_free_subtree(struct lyd_node *node, int top)
+lyd_free_subtree(struct lyd_node *node, uint8_t top)
 {
     struct lyd_node *iter, *next;
     struct lyd_node *children;
@@ -222,7 +222,7 @@ lyd_free_tree(struct lyd_node *node)
 }
 
 static void
-lyd_free_(struct lyd_node *node, int top)
+lyd_free_(struct lyd_node *node, uint8_t top)
 {
     struct lyd_node *iter, *next;
 

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -83,8 +83,8 @@ lyd_hash(struct lyd_node *node)
     return LY_SUCCESS;
 }
 
-static int
-lyd_hash_table_val_equal(void *val1_p, void *val2_p, int mod, void *UNUSED(cb_data))
+static uint8_t
+lyd_hash_table_val_equal(void *val1_p, void *val2_p, uint8_t mod, void *UNUSED(cb_data))
 {
     struct lyd_node *val1, *val2;
 
@@ -120,7 +120,7 @@ lyd_hash_table_val_equal(void *val1_p, void *val2_p, int mod, void *UNUSED(cb_da
  * @return LY_ERR value.
  */
 static LY_ERR
-lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, int empty_ht)
+lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, uint8_t empty_ht)
 {
     uint32_t hash;
 

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -83,7 +83,7 @@ lyd_node_children_p(struct lyd_node *node)
 }
 
 API struct lyd_node *
-lyd_node_children(const struct lyd_node *node, int options)
+lyd_node_children(const struct lyd_node *node, uint32_t options)
 {
     struct lyd_node **children, *child;
 
@@ -199,7 +199,7 @@ lyd_parse_check_keys(struct lyd_node *node)
 }
 
 void
-lyd_parse_set_data_flags(struct lyd_node *node, struct ly_set *when_check, struct lyd_meta **meta, int options)
+lyd_parse_set_data_flags(struct lyd_node *node, struct ly_set *when_check, struct lyd_meta **meta, uint32_t options)
 {
     struct lyd_meta *meta2, *prev_meta = NULL;
 
@@ -242,7 +242,6 @@ API LY_ERR
 lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_ANYDATA_VALUETYPE value_type)
 {
     struct lyd_node_any *t;
-    int len;
 
     assert(trg->schema->nodetype & LYS_ANYDATA);
 
@@ -286,7 +285,7 @@ lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_A
         break;
     case LYD_ANYDATA_LYB:
         if (value->mem) {
-            len = lyd_lyb_data_length(value->mem);
+            int len = lyd_lyb_data_length(value->mem);
             LY_CHECK_RET(len == -1, LY_EINVAL);
             t->value.mem = malloc(len);
             LY_CHECK_ERR_RET(!t->value.mem, LOGMEM(LYD_CTX(trg)), LY_EMEM);
@@ -302,7 +301,6 @@ LYB_HASH
 lyb_hash(struct lysc_node *sibling, uint8_t collision_id)
 {
     const struct lys_module *mod;
-    int ext_len;
     uint32_t full_hash;
     LYB_HASH hash;
 
@@ -315,6 +313,8 @@ lyb_hash(struct lysc_node *sibling, uint8_t collision_id)
     full_hash = dict_hash_multi(0, mod->name, strlen(mod->name));
     full_hash = dict_hash_multi(full_hash, sibling->name, strlen(sibling->name));
     if (collision_id) {
+        size_t ext_len;
+
         if (collision_id > strlen(mod->name)) {
             /* fine, we will not hash more bytes, just use more bits from the hash than previously */
             ext_len = strlen(mod->name);
@@ -339,7 +339,7 @@ lyb_hash(struct lysc_node *sibling, uint8_t collision_id)
     return hash;
 }
 
-int
+uint8_t
 lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models)
 {
     LY_ARRAY_COUNT_TYPE u;

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -48,8 +48,9 @@ LYB_HASH lyb_hash(struct lysc_node *sibling, uint8_t collision_id);
  * @param[in] models Modules in a sized array.
  * @return non-zero if the module was found,
  * @return 0 if not found.
+ * @return 1 if found.
  */
-int lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models);
+uint8_t lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models);
 
 /**
  * @brief Check whether a node to be deleted is the first top-level sibling.
@@ -102,7 +103,7 @@ struct lyd_node *lys_getnext_data(const struct lyd_node *last, const struct lyd_
  * @return LY_EINCOMPLETE in case data tree is needed to finish the validation.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, int *dynamic, int value_hint,
+LY_ERR lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
 
 /**
@@ -181,7 +182,7 @@ LY_ERR lyd_create_any(const struct lysc_node *schema, const void *value, LYD_ANY
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_opaq(const struct ly_ctx *ctx, const char *name, size_t name_len, const char *value, size_t value_len,
-        int *dynamic, int value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix,
+        uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix,
         size_t pref_len, const char *module_key, size_t module_key_len, struct lyd_node **node);
 
 /**
@@ -199,7 +200,7 @@ LY_ERR lyd_create_opaq(const struct ly_ctx *ctx, const char *name, size_t name_l
  */
 LY_ERR lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struct lysc_node *sparent,
         const struct lys_module *mod, struct ly_set *node_types, struct ly_set *node_when,
-        int impl_opts, struct lyd_node **diff);
+        uint32_t impl_opts, struct lyd_node **diff);
 
 /**
  * @brief Find the next node, before which to insert the new node.
@@ -248,7 +249,7 @@ void lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
-        size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hint,
+        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode);
 
 /**
@@ -281,7 +282,7 @@ void lyd_insert_attr(struct lyd_node *parent, struct lyd_attr *attr);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const struct ly_ctx *ctx, const char *name,
-        size_t name_len, const char *value, size_t value_len, int *dynamic, int value_hint, LYD_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format,
         struct ly_prefix *val_prefs, const char *prefix, size_t prefix_len, const char *module_key, size_t module_key_len);
 
 /**
@@ -315,12 +316,12 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @return LY_EINCOMPLETE in case the @p trees is not provided and it was needed to finish the validation.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, int *dynamic, int second, int value_hint,
-        LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree);
+LY_ERR lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, uint8_t *dynamic, uint8_t second,
+        uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree);
 
 /* similar to lyd_value_parse except can be used just to store the value, hence does also not support a second call */
 LY_ERR lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len,
-        int *dynamic, LY_PREFIX_FORMAT format, void *prefix_data);
+        uint8_t *dynamic, LY_PREFIX_FORMAT format, void *prefix_data);
 
 /**
  * @brief Validate, canonize and store the given @p value into the metadata according to the annotation type's rules.
@@ -343,7 +344,7 @@ LY_ERR lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, co
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len,
-        int *dynamic, int second, int value_hint, LY_PREFIX_FORMAT format, void *prefix_data,
+        uint8_t *dynamic, uint8_t second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data,
         const struct lysc_node *ctx_snode, const struct lyd_node *tree);
 
 /* generic function lys_value_validate */
@@ -361,7 +362,7 @@ LY_ERR _lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *nod
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_xml_data(const struct ly_ctx *ctx, struct ly_in *in, int parse_options, int validate_options,
+LY_ERR lyd_parse_xml_data(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree_p, struct lyd_ctx **lydctx_p);
 
 /**
@@ -418,7 +419,7 @@ LY_ERR lyd_parse_xml_reply(const struct lyd_node *request, struct ly_in *in, str
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_json_data(const struct ly_ctx *ctx, struct ly_in *in, int parse_options, int validate_options,
+LY_ERR lyd_parse_json_data(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree_p, struct lyd_ctx **lydctx_p);
 
 /**
@@ -474,7 +475,7 @@ LY_ERR lyd_parse_json_reply(const struct lyd_node *request, struct ly_in *in, st
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_lyb_data(const struct ly_ctx *ctx, struct ly_in *in, int parse_options, int validate_options,
+LY_ERR lyd_parse_lyb_data(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_options, uint32_t validate_options,
         struct lyd_node **tree_p, struct lyd_ctx **lydctx_p);
 
 /**
@@ -583,7 +584,7 @@ LY_ERR lyd_parse_check_keys(struct lyd_node *node);
  * @param[in,out] meta Node metadata, may be removed from.
  * @param[in] options Parse options.
  */
-void lyd_parse_set_data_flags(struct lyd_node *node, struct ly_set *when_check, struct lyd_meta **meta, int options);
+void lyd_parse_set_data_flags(struct lyd_node *node, struct ly_set *when_check, struct lyd_meta **meta, uint32_t options);
 
 /**
  * @brief Free value prefixes.
@@ -603,6 +604,6 @@ void ly_free_val_prefs(const struct ly_ctx *ctx, struct ly_prefix *val_prefs);
  * @param[in] is_static Whether buffer is static or can be reallocated.
  * @return LY_ERR
  */
-LY_ERR lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, int is_static);
+LY_ERR lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static);
 
 #endif /* LY_TREE_DATA_INTERNAL_H_ */

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -40,11 +40,11 @@
 #include "xpath.h"
 
 API const struct lysc_node *
-lys_getnext(const struct lysc_node *last, const struct lysc_node *parent, const struct lysc_module *module, int options)
+lys_getnext(const struct lysc_node *last, const struct lysc_node *parent, const struct lysc_module *module, uint32_t options)
 {
     const struct lysc_node *next = NULL;
     struct lysc_node **snode;
-    int action_flag = 0, notif_flag = 0;
+    uint8_t action_flag = 0, notif_flag = 0;
     const struct lysc_action *actions;
     const struct lysc_notif *notifs;
     LY_ARRAY_COUNT_TYPE u;
@@ -196,7 +196,6 @@ lys_find_node(struct ly_ctx *ctx, const struct lysc_node *context_node, const ch
     const char *id = qpath;
     const char *prefix, *name;
     size_t prefix_len, name_len;
-    unsigned int u;
     const struct lysc_node *node = context_node;
     struct lys_module *mod = NULL;
 
@@ -224,7 +223,7 @@ lys_find_node(struct ly_ctx *ctx, const struct lysc_node *context_node, const ch
             if (context_node) {
                 mod = lys_module_find_prefix(context_node->module, prefix, prefix_len);
             } else {
-                for (u = 0; u < ctx->list.count; ++u) {
+                for (uint32_t u = 0; u < ctx->list.count; ++u) {
                     if (!ly_strncmp(((struct lys_module *)ctx->list.objs[u])->name, prefix, prefix_len)) {
                         struct lys_module *m = (struct lys_module *)ctx->list.objs[u];
                         if (mod) {
@@ -259,7 +258,7 @@ lys_find_node(struct ly_ctx *ctx, const struct lysc_node *context_node, const ch
 
 API const struct lysc_node *
 lys_find_child(const struct lysc_node *parent, const struct lys_module *module, const char *name, size_t name_len,
-        uint16_t nodetype, int options)
+        uint16_t nodetype, uint32_t options)
 {
     const struct lysc_node *node = NULL;
 
@@ -290,7 +289,7 @@ lys_find_child(const struct lysc_node *parent, const struct lys_module *module, 
 }
 
 API LY_ERR
-lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, int options, struct ly_set **set)
+lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set)
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyxp_set xp_set;
@@ -334,7 +333,7 @@ cleanup:
 }
 
 API LY_ERR
-lys_find_xpath(const struct lysc_node *ctx_node, const char *xpath, int options, struct ly_set **set)
+lys_find_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set)
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyxp_set xp_set;
@@ -467,12 +466,10 @@ lysc_feature_value(const struct lysc_feature *feature)
 }
 
 uint8_t
-lysc_iff_getop(uint8_t *list, int pos)
+lysc_iff_getop(uint8_t *list, size_t pos)
 {
     uint8_t *item;
     uint8_t mask = 3, result;
-
-    assert(pos >= 0);
 
     item = &list[pos / 4];
     result = (*item) & (mask << 2 * (pos % 4));
@@ -480,7 +477,7 @@ lysc_iff_getop(uint8_t *list, int pos)
 }
 
 static LY_ERR
-lysc_iffeature_value_(const struct lysc_iffeature *iff, int *index_e, int *index_f)
+lysc_iffeature_value_(const struct lysc_iffeature *iff, size_t *index_e, size_t *index_f)
 {
     uint8_t op;
     LY_ERR a, b;
@@ -520,7 +517,7 @@ lysc_iffeature_value_(const struct lysc_iffeature *iff, int *index_e, int *index
 API LY_ERR
 lysc_iffeature_value(const struct lysc_iffeature *iff)
 {
-    int index_e = 0, index_f = 0;
+    size_t index_e = 0, index_f = 0;
 
     LY_CHECK_ARG_RET(NULL, iff, -1);
 
@@ -545,9 +542,9 @@ lysc_iffeature_value(const struct lysc_iffeature *iff)
  * @return LY_ERR value.
  */
 static LY_ERR
-lys_feature_change(const struct lys_module *mod, const char *name, int value, int skip_checks)
+lys_feature_change(const struct lys_module *mod, const char *name, uint8_t value, uint8_t skip_checks)
 {
-    int all = 0;
+    uint8_t all = 0;
     LY_ARRAY_COUNT_TYPE u, disabled_count;
     uint32_t changed_count;
     struct lysc_feature *f, **df;
@@ -764,7 +761,7 @@ lys_feature_value(const struct lys_module *module, const char *feature)
 }
 
 API const struct lysc_node *
-lysc_node_is_disabled(const struct lysc_node *node, int recursive)
+lysc_node_is_disabled(const struct lysc_node *node, uint8_t recursive)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -962,10 +959,9 @@ error:
 }
 
 LY_ERR
-lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, int implement,
-        LY_ERR (*custom_check)(const struct ly_ctx *ctx, struct lysp_module *mod,
-                                            struct lysp_submodule *submod, void *data), void *check_data,
-        struct lys_module **module)
+lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, uint8_t implement,
+        LY_ERR (*custom_check)(const struct ly_ctx *ctx, struct lysp_module *mod, struct lysp_submodule *submod, void *data),
+        void *check_data, struct lys_module **module)
 {
     struct lys_module *mod = NULL, *latest, *mod_dup;
     LY_ERR ret;
@@ -1230,11 +1226,12 @@ lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format, const 
 }
 
 API LY_ERR
-lys_search_localfile(const char * const *searchpaths, int cwd, const char *name, const char *revision,
+lys_search_localfile(const char * const *searchpaths, uint8_t cwd, const char *name, const char *revision,
         char **localfile, LYS_INFORMAT *format)
 {
+    LY_ERR ret = LY_EMEM;
     size_t len, flen, match_len = 0, dir_len;
-    int i, implicit_cwd = 0, ret = EXIT_FAILURE;
+    uint8_t implicit_cwd = 0;
     char *wd, *wn = NULL;
     DIR *dir = NULL;
     struct dirent *file;
@@ -1249,8 +1246,7 @@ lys_search_localfile(const char * const *searchpaths, int cwd, const char *name,
      * and the current working directory */
     dirs = ly_set_new();
     if (!dirs) {
-        LOGMEM(NULL);
-        return EXIT_FAILURE;
+        LOGMEM_RET(NULL);
     }
 
     len = strlen(name);
@@ -1269,7 +1265,7 @@ lys_search_localfile(const char * const *searchpaths, int cwd, const char *name,
         }
     }
     if (searchpaths) {
-        for (i = 0; searchpaths[i]; i++) {
+        for (uint64_t i = 0; searchpaths[i]; i++) {
             /* check for duplicities with the implicit current working directory */
             if (implicit_cwd && !strcmp(dirs->objs[0], searchpaths[i])) {
                 implicit_cwd = 0;
@@ -1407,7 +1403,7 @@ success:
     if (format) {
         (*format) = match_format;
     }
-    ret = EXIT_SUCCESS;
+    ret = LY_SUCCESS;
 
 cleanup:
     free(wn);

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -69,7 +69,7 @@ struct ly_set;
  * @param ELEM Iterator intended for use in the block.
  */
 #define LYSC_TREE_DFS_BEGIN(START, ELEM) \
-    { int LYSC_TREE_DFS_continue = 0; struct lysc_node *LYSC_TREE_DFS_next; \
+    { uint8_t LYSC_TREE_DFS_continue = 0; struct lysc_node *LYSC_TREE_DFS_next; \
     for ((ELEM) = (LYSC_TREE_DFS_next) = (struct lysc_node*)(START); \
          (ELEM); \
          (ELEM) = (LYSC_TREE_DFS_next), LYSC_TREE_DFS_continue = 0)
@@ -1725,8 +1725,9 @@ const struct lysc_node *lysc_node_children(const struct lysc_node *node, uint16_
  * @param[in] node Node to examine.
  * @return non-zero if it is,
  * @return 0 if not.
+ * @return 1 if the @p node is user-ordered
  */
-int lysc_is_userordered(const struct lysc_node *schema);
+uint8_t lysc_is_userordered(const struct lysc_node *schema);
 
 /**
  * @brief Set a schema private pointer to a user pointer.
@@ -1774,7 +1775,7 @@ LY_ERR lysc_feature_value(const struct lysc_feature *feature);
  * @return LY_SUCCESS on success, @p set is returned.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, int options, struct ly_set **set);
+LY_ERR lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set);
 
 /**
  * @brief Evaluate an \p xpath expression on schema nodes.
@@ -1787,7 +1788,7 @@ LY_ERR lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, in
  * @return LY_SUCCESS on success, @p set is returned.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lys_find_xpath(const struct lysc_node *ctx_node, const char *xpath, int options, struct ly_set **set);
+LY_ERR lys_find_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set);
 
 /**
  * @brief Types of the different schema paths.
@@ -1945,7 +1946,7 @@ LY_ERR lys_feature_value(const struct lys_module *module, const char *feature);
  * @return Next schema tree node that can be instantiated in a data tree, NULL in case there is no such element.
  */
 const struct lysc_node *lys_getnext(const struct lysc_node *last, const struct lysc_node *parent,
-        const struct lysc_module *module, int options);
+        const struct lysc_module *module, uint32_t options);
 
 /**
  * @defgroup sgetnextflags lys_getnext() flags
@@ -1974,7 +1975,7 @@ const struct lysc_node *lys_getnext(const struct lysc_node *last, const struct l
  * @return Found node if any.
  */
 const struct lysc_node *lys_find_child(const struct lysc_node *parent, const struct lys_module *module,
-        const char *name, size_t name_len, uint16_t nodetype, int options);
+        const char *name, size_t name_len, uint16_t nodetype, uint32_t options);
 
 /**
  * @brief Get schema node specified by the schema path.
@@ -2015,7 +2016,7 @@ LY_ERR lys_set_implemented(struct lys_module *mod);
  * @return NULL if enabled,
  * @return pointer to the node with the unsatisfied (disabled) if-feature expression.
  */
-const struct lysc_node *lysc_node_is_disabled(const struct lysc_node *node, int recursive);
+const struct lysc_node *lysc_node_is_disabled(const struct lysc_node *node, uint8_t recursive);
 
 /**
  * @brief Set a schema private pointer to a user pointer.

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -880,7 +880,7 @@ lys_module_free(struct lys_module *module, void (*private_destructor)(const stru
 API void
 lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substmts)
 {
-    for (unsigned int u = 0; substmts[u].stmt; ++u) {
+    for (LY_ARRAY_COUNT_TYPE u = 0; substmts[u].stmt; ++u) {
         if (!substmts[u].storage) {
             continue;
         }

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -36,7 +36,7 @@
 
 LY_ERR
 lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t nodeid_len, const struct lysc_node *context_node,
-        const struct lys_module *context_module, int nodetype, int implement,
+        const struct lys_module *context_module, uint16_t nodetype, uint8_t implement,
         const struct lysc_node **target, uint16_t *result_flag)
 {
     LY_ERR ret = LY_EVALID;
@@ -44,8 +44,8 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
     size_t name_len, prefix_len;
     const struct lys_module *mod;
     const char *nodeid_type;
-    int getnext_extra_flag = 0;
-    int current_nodetype = 0;
+    uint32_t getnext_extra_flag = 0;
+    uint16_t current_nodetype = 0;
 
     assert(nodeid);
     assert(target);
@@ -193,9 +193,8 @@ lysc_check_status(struct lysc_ctx *ctx,
 }
 
 LY_ERR
-lysp_check_date(struct lys_parser_ctx *ctx, const char *date, int date_len, const char *stmt)
+lysp_check_date(struct lys_parser_ctx *ctx, const char *date, uint8_t date_len, const char *stmt)
 {
-    int i;
     struct tm tm, tm_;
     char *r;
 
@@ -203,7 +202,7 @@ lysp_check_date(struct lys_parser_ctx *ctx, const char *date, int date_len, cons
     LY_CHECK_ERR_RET(date_len != LY_REV_SIZE - 1, LOGARG(ctx ? PARSER_CTX(ctx) : NULL, date_len), LY_EINVAL);
 
     /* check format */
-    for (i = 0; i < date_len; i++) {
+    for (uint8_t i = 0; i < date_len; i++) {
         if (i == 4 || i == 7) {
             if (date[i] != '-') {
                 goto error;
@@ -524,10 +523,10 @@ lysp_check_typedef(struct lys_parser_ctx *ctx, struct lysp_node *node, const str
     return LY_SUCCESS;
 }
 
-static int
-lysp_id_cmp(void *val1, void *val2, int UNUSED(mod), void *UNUSED(cb_data))
+static uint8_t
+lysp_id_cmp(void *val1, void *val2, uint8_t UNUSED(mod), void *UNUSED(cb_data))
 {
-    return !strcmp(val1, val2);
+    return strcmp(val1, val2) == 0 ? 1 : 0;
 }
 
 LY_ERR
@@ -745,8 +744,8 @@ lysp_load_module_check(const struct ly_ctx *ctx, struct lysp_module *mod, struct
 }
 
 LY_ERR
-lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement,
-        struct lys_parser_ctx *main_ctx, const char *main_name, int required, void **result)
+lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement,
+        struct lys_parser_ctx *main_ctx, const char *main_name, uint8_t required, void **result)
 {
     struct ly_in *in;
     char *filepath = NULL;
@@ -804,7 +803,7 @@ cleanup:
 }
 
 LY_ERR
-lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, int implement, int require_parsed,
+lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement, uint8_t require_parsed,
         struct lys_module **mod)
 {
     const char *module_data = NULL;
@@ -930,7 +929,7 @@ search_file:
 }
 
 LY_ERR
-lysp_check_stringchar(struct lys_parser_ctx *ctx, unsigned int c)
+lysp_check_stringchar(struct lys_parser_ctx *ctx, uint32_t c)
 {
     if (!is_yangutf8char(c)) {
         LOGVAL_PARSER(ctx, LY_VCODE_INCHAR, c);
@@ -940,11 +939,11 @@ lysp_check_stringchar(struct lys_parser_ctx *ctx, unsigned int c)
 }
 
 LY_ERR
-lysp_check_identifierchar(struct lys_parser_ctx *ctx, unsigned int c, int first, int *prefix)
+lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, uint8_t first, uint8_t *prefix)
 {
     if (first || (prefix && (*prefix) == 1)) {
         if (!is_yangidentstartchar(c)) {
-            LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier first character '%c'.", c);
+            LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier first character '%c' (0x%04x).", (char)c, c);
             return LY_EVALID;
         }
         if (prefix) {
@@ -957,7 +956,7 @@ lysp_check_identifierchar(struct lys_parser_ctx *ctx, unsigned int c, int first,
     } else if (c == ':' && prefix && (*prefix) == 0) {
         (*prefix) = 1;
     } else if (!is_yangidentchar(c)) {
-        LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier character '%c'.", c);
+        LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier character '%c' (0x%04x).", (char)c, c);
         return LY_EVALID;
     }
 
@@ -1403,9 +1402,7 @@ lysc_node_children(const struct lysc_node *node, uint16_t flags)
 struct lys_module *
 lysp_find_module(struct ly_ctx *ctx, const struct lysp_module *mod)
 {
-    unsigned int u;
-
-    for (u = 0; u < ctx->list.count; ++u) {
+    for (uint32_t u = 0; u < ctx->list.count; ++u) {
         if (((struct lys_module *)ctx->list.objs[u])->parsed == mod) {
             return ((struct lys_module *)ctx->list.objs[u]);
         }
@@ -1651,7 +1648,7 @@ lysc_data_parent(const struct lysc_node *schema)
     return parent;
 }
 
-int
+uint8_t
 lysc_is_output(const struct lysc_node *schema)
 {
     const struct lysc_node *parent;
@@ -1665,7 +1662,7 @@ lysc_is_output(const struct lysc_node *schema)
     return 0;
 }
 
-API int
+API uint8_t
 lysc_is_userordered(const struct lysc_node *schema)
 {
     if (!schema || !(schema->nodetype & (LYS_LEAFLIST | LYS_LIST)) || !(schema->flags & LYS_ORDBY_USER)) {

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -184,8 +184,8 @@ struct lysc_ctx {
     struct ly_set leafrefs;     /**< when/must to check */
     struct ly_set dflts;        /**< set of incomplete default values */
     struct ly_set tpdf_chain;
-    uint16_t path_len;
-    int options;                /**< various @ref scflags. */
+    uint32_t path_len;
+    uint32_t options;           /**< various @ref scflags. */
 #define LYSC_CTX_BUFSIZE 4078
     char path[LYSC_CTX_BUFSIZE];
 };
@@ -197,7 +197,7 @@ struct lysc_ctx {
  * @param[in] c UTF8 code point of a character to check.
  * @return LY_ERR values.
  */
-LY_ERR lysp_check_stringchar(struct lys_parser_ctx *ctx, unsigned int c);
+LY_ERR lysp_check_stringchar(struct lys_parser_ctx *ctx, uint32_t c);
 
 /**
  * @brief Check that \p c is valid UTF8 code point for YANG identifier.
@@ -213,7 +213,7 @@ LY_ERR lysp_check_stringchar(struct lys_parser_ctx *ctx, unsigned int c);
  * If the identifier cannot be prefixed, NULL is expected.
  * @return LY_ERR values.
  */
-LY_ERR lysp_check_identifierchar(struct lys_parser_ctx *ctx, unsigned int c, int first, int *prefix);
+LY_ERR lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, uint8_t first, uint8_t *prefix);
 
 /**
  * @brief Check the currently present prefixes in the module for collision with the new one.
@@ -235,7 +235,7 @@ LY_ERR lysp_check_prefix(struct lys_parser_ctx *ctx, struct lysp_import *imports
  * @param[in] stmt Statement name for error message.
  * @return LY_ERR value.
  */
-LY_ERR lysp_check_date(struct lys_parser_ctx *ctx, const char *date, int date_len, const char *stmt);
+LY_ERR lysp_check_date(struct lys_parser_ctx *ctx, const char *date, uint8_t date_len, const char *stmt);
 
 /**
  * @brief Check names of typedefs in the parsed module to detect collisions.
@@ -304,7 +304,7 @@ LY_ERR lysp_check_enum_name(struct lys_parser_ctx *ctx, const char *name, size_t
  * @param[out] mod Parsed module structure.
  * @return LY_ERR value.
  */
-LY_ERR lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, int implement, int require_parsed, struct lys_module **mod);
+LY_ERR lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement, uint8_t require_parsed, struct lys_module **mod);
 
 /**
  * @brief Parse included submodule into the simply parsed YANG module.
@@ -325,7 +325,7 @@ LY_ERR lysp_load_submodule(struct lys_parser_ctx *pctx, struct lysp_include *inc
  * @param[in] options Various options to modify compiler behavior, see [compile flags](@ref scflags).
  * @return LY_ERR value - LY_SUCCESS or LY_EVALID.
  */
-LY_ERR lys_compile(struct lys_module **mod, int options);
+LY_ERR lys_compile(struct lys_module **mod, uint32_t options);
 
 /**
  * @brief Get address of a node's actions list if any.
@@ -443,7 +443,7 @@ LY_ERR lysc_check_status(struct lysc_ctx *ctx,
  * @return LY_ERR values - LY_ENOTFOUND, LY_EVALID, LY_EDENIED or LY_SUCCESS.
  */
 LY_ERR lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t nodeid_len, const struct lysc_node *context_node,
-        const struct lys_module *context_module, int nodetype, int implement,
+        const struct lys_module *context_module, uint16_t nodetype, uint8_t implement,
         const struct lysc_node **target, uint16_t *result_flag);
 
 /**
@@ -496,7 +496,7 @@ typedef LY_ERR (*lys_custom_check)(const struct ly_ctx *ctx, struct lysp_module 
  * @param[out] module Parsed module.
  * @return LY_ERR value.
  */
-LY_ERR lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, int implement,
+LY_ERR lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, uint8_t implement,
         lys_custom_check custom_check, void *check_data, struct lys_module **module);
 
 /**
@@ -545,8 +545,8 @@ void lys_parser_fill_filepath(struct ly_ctx *ctx, struct ly_in *in, const char *
  * If it is a module, it is already in the context!
  * @return LY_ERR value, in case of LY_SUCCESS, the \arg result is always provided.
  */
-LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, int implement,
-        struct lys_parser_ctx *main_ctx, const char *main_name, int required, void **result);
+LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement,
+        struct lys_parser_ctx *main_ctx, const char *main_name, uint8_t required, void **result);
 
 /**
  * @brief Compile information from the identity statement
@@ -595,7 +595,7 @@ LY_ERR lys_feature_precompile(struct lysc_ctx *ctx_sc, struct ly_ctx *ctx, struc
  * @param[in] list The 2bits array with the compiled if-feature expression.
  * @param[in] pos Position (0-based) to specify from which position get the operator.
  */
-uint8_t lysc_iff_getop(uint8_t *list, int pos);
+uint8_t lysc_iff_getop(uint8_t *list, size_t pos);
 
 /**
  * @brief Checks pattern syntax.
@@ -781,12 +781,12 @@ char *lysc_path_until(const struct lysc_node *node, const struct lysc_node *pare
 const struct lysc_node *lysc_data_parent(const struct lysc_node *schema);
 
 /**
- * @brief Learn whether a node is in an operation output.
+ * @brief Learn whether a node is inside an operation output.
  *
  * @param[in] schema Schema node to examine.
- * @return non-zero is the node is in output,
  * @return 0 if it is not.
+ * @return 1 if the node is under an operation output
  */
-int lysc_is_output(const struct lysc_node *schema);
+uint8_t lysc_is_output(const struct lysc_node *schema);
 
 #endif /* LY_TREE_SCHEMA_INTERNAL_H_ */

--- a/src/validation.c
+++ b/src/validation.c
@@ -126,7 +126,7 @@ lyd_validate_unres(struct lyd_node **tree, struct ly_set *node_when, struct ly_s
                 /* evaluate all when expressions that affect this node's existence */
                 struct lyd_node *node = (struct lyd_node *)node_when->objs[i];
                 const struct lysc_node *schema = node->schema;
-                int unres_when = 0;
+                uint8_t unres_when = 0;
 
                 do {
                     LY_ARRAY_COUNT_TYPE u;
@@ -213,7 +213,7 @@ static LY_ERR
 lyd_validate_duplicates(const struct lyd_node *first, const struct lyd_node *node)
 {
     struct lyd_node **match_p;
-    int fail = 0;
+    uint8_t fail = 0;
 
     if ((node->schema->nodetype & (LYS_LIST | LYS_LEAFLIST)) && (node->schema->flags & LYS_CONFIG_R)) {
         /* duplicate instances allowed */
@@ -263,7 +263,7 @@ lyd_validate_cases(struct lyd_node **first, const struct lysc_node_choice *choic
 {
     const struct lysc_node *scase, *iter, *old_case = NULL, *new_case = NULL;
     struct lyd_node *match, *to_del;
-    int found;
+    uint8_t found;
 
     LY_LIST_FOR((struct lysc_node *)choic->cases, scase) {
         found = 0;
@@ -565,8 +565,8 @@ lyd_val_uniq_find_leaf(const struct lysc_node_leaf *uniq_leaf, const struct lyd_
  *
  * @param[in] cb_data 0 to compare all uniques, n to compare only n-th unique.
  */
-static int
-lyd_val_uniq_list_equal(void *val1_p, void *val2_p, int UNUSED(mod), void *cb_data)
+static uint8_t
+lyd_val_uniq_list_equal(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *cb_data)
 {
     struct ly_ctx *ctx;
     struct lysc_node_list *slist;
@@ -677,7 +677,7 @@ lyd_validate_unique(const struct lyd_node *first, const struct lysc_node *snode,
     LY_ARRAY_COUNT_TYPE u, v, x = 0;
     LY_ERR ret = LY_SUCCESS;
     uint32_t hash, i, size = 0;
-    int dynamic;
+    uint8_t dynamic;
     const char *str;
     struct hash_table **uniqtables = NULL;
     struct lyd_value *val;
@@ -792,12 +792,12 @@ cleanup:
  */
 static LY_ERR
 lyd_validate_siblings_schema_r(const struct lyd_node *first, const struct lysc_node *sparent,
-        const struct lysc_module *mod, int val_opts, LYD_VALIDATE_OP op)
+        const struct lysc_module *mod, uint32_t val_opts, LYD_VALIDATE_OP op)
 {
     const struct lysc_node *snode = NULL;
     struct lysc_node_list *slist;
     struct lysc_node_leaflist *sllist;
-    int getnext_opts;
+    uint32_t getnext_opts;
 
     getnext_opts = LYS_GETNEXT_WITHCHOICE | LYS_GETNEXT_WITHCASE | (op == LYD_VALIDATE_OP_REPLY ? LYS_GETNEXT_OUTPUT : 0);
 
@@ -943,7 +943,7 @@ lyd_validate_must(const struct lyd_node *node, LYD_VALIDATE_OP op)
 }
 
 LY_ERR
-lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, const struct lys_module *mod, int val_opts,
+lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, const struct lys_module *mod, uint32_t val_opts,
         LYD_VALIDATE_OP op)
 {
     struct lyd_node *next = NULL, *node;
@@ -1026,7 +1026,7 @@ lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, co
  */
 static LY_ERR
 lyd_validate_subtree(struct lyd_node *root, struct ly_set *type_check, struct ly_set *type_meta_check,
-        struct ly_set *when_check, int val_opts, struct lyd_node **diff)
+        struct ly_set *when_check, uint32_t val_opts, struct lyd_node **diff)
 {
     const struct lyd_meta *meta;
     struct lyd_node *node;
@@ -1076,7 +1076,7 @@ lyd_validate_subtree(struct lyd_node *root, struct ly_set *type_check, struct ly
  * @return LY_ERR value.
  */
 static LY_ERR
-lyd_validate(struct lyd_node **tree, const struct lys_module *module, const struct ly_ctx *ctx, int val_opts,
+lyd_validate(struct lyd_node **tree, const struct lys_module *module, const struct ly_ctx *ctx, uint32_t val_opts,
         struct lyd_node **diff)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -1139,13 +1139,13 @@ cleanup:
 }
 
 API LY_ERR
-lyd_validate_all(struct lyd_node **tree, const struct ly_ctx *ctx, int val_opts, struct lyd_node **diff)
+lyd_validate_all(struct lyd_node **tree, const struct ly_ctx *ctx, uint32_t val_opts, struct lyd_node **diff)
 {
     return lyd_validate(tree, NULL, ctx, val_opts, diff);
 }
 
 API LY_ERR
-lyd_validate_module(struct lyd_node **tree, const struct lys_module *module, int val_opts, struct lyd_node **diff)
+lyd_validate_module(struct lyd_node **tree, const struct lys_module *module, uint32_t val_opts, struct lyd_node **diff)
 {
     return lyd_validate(tree, module, NULL, val_opts, diff);
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -74,6 +74,6 @@ LY_ERR lyd_validate_new(struct lyd_node **first, const struct lysc_node *sparent
  * @return LY_ERR value.
  */
 LY_ERR lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, const struct lys_module *mod,
-        int val_opts, LYD_VALIDATE_OP op);
+        uint32_t val_opts, LYD_VALIDATE_OP op);
 
 #endif /* LY_VALIDATION_H_ */

--- a/src/xml.h
+++ b/src/xml.h
@@ -92,11 +92,11 @@ struct lyxml_ctx {
     };
     union {
         const char *name;   /* LYXML_ELEMENT, LYXML_ATTRIBUTE - elem/attr name */
-        int ws_only;        /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is empty/white-space only */
+        uint8_t ws_only;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is empty/white-space only */
     };
     union {
         size_t name_len;    /* LYXML_ELEMENT, LYXML_ATTRIBUTE - elem/attr name length */
-        int dynamic;        /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is dynamically allocated */
+        uint8_t dynamic;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is dynamically allocated */
     };
 
     struct ly_set elements; /* list of not-yet-closed elements */
@@ -153,7 +153,7 @@ const struct lyxml_ns *lyxml_ns_get(const struct ly_set *ns_set, const char *pre
  * @param[in] attribute Flag for attribute's value where a double quotes must be replaced.
  * @return LY_ERR values.
  */
-LY_ERR lyxml_dump_text(struct ly_out *out, const char *text, int attribute);
+LY_ERR lyxml_dump_text(struct ly_out *out, const char *text, uint8_t attribute);
 
 /**
  * @brief Remove the allocated working memory of the context.

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -238,7 +238,7 @@ struct lyxp_set {
         } *meta;
         char *str;
         long double num;
-        int bln;
+        uint8_t bln; /* boolean */
     } val;
 
     /* this is valid only for type LYXP_SET_NODE_SET and LYXP_SET_SCNODE_SET */
@@ -292,7 +292,7 @@ const char *lyxp_print_token(enum lyxp_token tok);
  */
 LY_ERR lyxp_eval(struct lyxp_expr *exp, LY_PREFIX_FORMAT format, const struct lys_module *local_mod,
         const struct lyd_node *ctx_node, enum lyxp_node_type ctx_node_type, const struct lyd_node *tree,
-        struct lyxp_set *set, int options);
+        struct lyxp_set *set, uint32_t options);
 
 #define LYXP_SCHEMA 0x01        /**< Apply data node access restrictions defined for 'when' and 'must' evaluation. */
 
@@ -312,7 +312,7 @@ LY_ERR lyxp_eval(struct lyxp_expr *exp, LY_PREFIX_FORMAT format, const struct ly
  */
 LY_ERR lyxp_atomize(struct lyxp_expr *exp, LY_PREFIX_FORMAT format, const struct lys_module *local_mod,
         const struct lysc_node *ctx_scnode, enum lyxp_node_type ctx_scnode_type, struct lyxp_set *set,
-        int options);
+        uint32_t options);
 
 /* used only internally */
 #define LYXP_SCNODE_ALL 0x0E
@@ -377,7 +377,7 @@ void lyxp_set_scnode_merge(struct lyxp_set *set1, struct lyxp_set *set2);
  * information about expressions and their operators (fill repeat).
  * @return Filled expression structure or NULL on error.
  */
-struct lyxp_expr *lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr, size_t expr_len, int reparse);
+struct lyxp_expr *lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr, size_t expr_len, uint8_t reparse);
 
 /**
  * @brief Duplicate parsed XPath expression.

--- a/tests/utests/data/test_types.c
+++ b/tests/utests/data/test_types.c
@@ -633,7 +633,7 @@ test_printed_value(const struct lyd_value *value, const char *expected_value, LY
                    const struct lys_module *mod)
 {
     const char *str;
-    int dynamic;
+    uint8_t dynamic;
 
     assert_non_null(str = value->realtype->plugin->print(value, format, (void *)mod, &dynamic));
     assert_string_equal(expected_value, str);

--- a/tests/utests/schema/test_parser_yang.c
+++ b/tests/utests/schema/test_parser_yang.c
@@ -38,11 +38,11 @@ void lysp_when_free(struct ly_ctx *ctx, struct lysp_when *when);
 
 LY_ERR buf_add_char(struct ly_ctx *ctx, struct ly_in *in, size_t len, char **buf, size_t *buf_len, size_t *buf_used);
 LY_ERR buf_store_char(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg, char **word_p,
-                      size_t *word_len, char **word_b, size_t *buf_len, int need_buf, int *prefix);
+                      size_t *word_len, char **word_b, size_t *buf_len, uint8_t need_buf, uint8_t *prefix);
 LY_ERR get_keyword(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt *kw, char **word_p, size_t *word_len);
 LY_ERR get_argument(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg,
                     uint16_t *flags, char **word_p, char **word_b, size_t *word_len);
-LY_ERR skip_comment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, int comment);
+LY_ERR skip_comment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, uint8_t comment);
 
 LY_ERR parse_action(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_action **actions);
 LY_ERR parse_any(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt kw, struct lysp_node *parent, struct lysp_node **siblings);
@@ -143,7 +143,7 @@ test_helpers(void **state)
     ctx.ctx = NULL;
     ctx.pos_type = LY_VLOG_LINE;
     ctx.line = 1;
-    int prefix = 0;
+    uint8_t prefix = 0;
 
     /* storing into buffer */
     in.current = "abcd";
@@ -190,9 +190,9 @@ test_helpers(void **state)
 
     /* checking identifiers */
     assert_int_equal(LY_EVALID, lysp_check_identifierchar((struct lys_parser_ctx *)&ctx, ':', 0, NULL));
-    logbuf_assert("Invalid identifier character ':'. Line number 1.");
+    logbuf_assert("Invalid identifier character ':' (0x003a). Line number 1.");
     assert_int_equal(LY_EVALID, lysp_check_identifierchar((struct lys_parser_ctx *)&ctx, '#', 1, NULL));
-    logbuf_assert("Invalid identifier first character '#'. Line number 1.");
+    logbuf_assert("Invalid identifier first character '#' (0x0023). Line number 1.");
 
     assert_int_equal(LY_SUCCESS, lysp_check_identifierchar((struct lys_parser_ctx *)&ctx, 'a', 1, &prefix));
     assert_int_equal(0, prefix);
@@ -204,7 +204,7 @@ test_helpers(void **state)
     assert_int_equal(2, prefix);
     /* second colon is invalid */
     assert_int_equal(LY_EVALID, lysp_check_identifierchar((struct lys_parser_ctx *)&ctx, ':', 0, &prefix));
-    logbuf_assert("Invalid identifier character ':'. Line number 1.");
+    logbuf_assert("Invalid identifier character ':' (0x003a). Line number 1.");
 }
 
 static void

--- a/tests/utests/schema/test_parser_yin.c
+++ b/tests/utests/schema/test_parser_yin.c
@@ -754,7 +754,7 @@ test_validate_value(void **state)
     st->yin_ctx->xmlctx->value = "#invalid";
     st->yin_ctx->xmlctx->value_len = 8;
     assert_int_equal(yin_validate_value(st->yin_ctx, Y_IDENTIF_ARG), LY_EVALID);
-    logbuf_assert("Invalid identifier character '#'. Line number 1.");
+    logbuf_assert("Invalid identifier character '#' (0x0023). Line number 1.");
 
     st->yin_ctx->xmlctx->value = "";
     st->yin_ctx->xmlctx->value_len = 0;

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -30,7 +30,7 @@ void lysc_feature_free(struct ly_ctx *ctx, struct lysc_feature *feat);
 void yang_parser_ctx_free(struct lys_yang_parser_ctx *ctx);
 
 LY_ERR lys_path_token(const char **path, const char **prefix, size_t *prefix_len, const char **name, size_t *name_len,
-                      int *parent_times, int *has_predicate);
+                      int32_t *parent_times, uint8_t *has_predicate);
 
 #define BUFSIZE 1024
 char logbuf[BUFSIZE] = {0};
@@ -204,7 +204,7 @@ test_node_leaflist(void **state)
     struct lysc_node_leaflist *ll;
     struct lysc_node_leaf *l;
     const char *dflt;
-    int dynamic;
+    uint8_t dynamic;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIRS, &ctx));
 
@@ -1276,10 +1276,10 @@ test_type_bits(void **state)
     logbuf_assert("Duplicate identifier \"one\" of bit statement. Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(ctx, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
                                    "bit '11';}}}", LYS_IN_YANG, &mod));
-    logbuf_assert("Invalid identifier first character '1'. Line number 1.");
+    logbuf_assert("Invalid identifier first character '1' (0x0031). Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(ctx, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
                                    "bit 'x1$1';}}}", LYS_IN_YANG, &mod));
-    logbuf_assert("Invalid identifier character '$'. Line number 1.");
+    logbuf_assert("Invalid identifier character '$' (0x0024). Line number 1.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(ctx, "module bb {namespace urn:bb;prefix bb; leaf l {type bits;}}", LYS_IN_YANG, &mod));
     logbuf_assert("Missing bit substatement for bits type. /bb:l");
@@ -1519,7 +1519,8 @@ test_type_leafref(void **state)
     struct lysc_type *type;
     const char *path, *name, *prefix;
     size_t prefix_len, name_len;
-    int parent_times, has_predicate;
+    int32_t parent_times;
+    uint8_t has_predicate;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIRS, &ctx));
 
@@ -2016,7 +2017,7 @@ test_type_dflt(void **state)
     const struct lys_module *mod;
     struct lysc_type *type;
     struct lysc_node_leaf *leaf;
-    int dynamic;
+    uint8_t dynamic;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIRS, &ctx));
 
@@ -2357,7 +2358,7 @@ test_refine(void **state)
     struct lysc_node *parent, *child;
     struct lysc_node_leaf *leaf;
     struct lysc_node_leaflist *llist;
-    int dynamic;
+    uint8_t dynamic;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIRS, &ctx));
 
@@ -2667,7 +2668,7 @@ test_deviation(void **state)
     const struct lysc_node_leaflist *llist;
     const struct lysc_node_leaf *leaf;
     const char *str;
-    int dynamic;
+    uint8_t dynamic;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_DISABLE_SEARCHDIRS, &ctx));
 

--- a/tests/utests/test_context.c
+++ b/tests/utests/test_context.c
@@ -183,7 +183,7 @@ test_options(void **state)
 
     struct ly_ctx *ctx;
 
-    assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0xffffffff, &ctx));
+    assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0xffff, &ctx));
 
     /* invalid arguments */
     assert_int_equal(0, ly_ctx_get_options(NULL));

--- a/tests/utests/test_hash_table.c
+++ b/tests/utests/test_hash_table.c
@@ -119,8 +119,8 @@ test_dict_hit(void **state)
 #endif
 }
 
-static int
-ht_equal_clb(void *val1, void *val2, int mod, void *cb_data)
+static uint8_t
+ht_equal_clb(void *val1, void *val2, uint8_t mod, void *cb_data)
 {
     int *v1, *v2;
     (void)mod;


### PR DESCRIPTION
Align parameters' types with the values in (internal) structures.