### PR TITLE
Unify return types

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -97,7 +97,7 @@ ly_ctx_set_searchdir(struct ly_ctx *ctx, const char *search_dir)
                 return LY_EEXIST;
             }
         }
-        if (ly_set_add(&ctx->search_paths, new_dir, LY_SET_OPT_USEASLIST) == -1) {
+        if (ly_set_add(&ctx->search_paths, new_dir, LY_SET_OPT_USEASLIST, NULL)) {
             free(new_dir);
             return LY_EMEM;
         }

--- a/src/json.c
+++ b/src/json.c
@@ -24,7 +24,7 @@
 #include "parser_internal.h"
 
 #define JSON_PUSH_STATUS_RET(CTX, STATUS) \
-    LY_CHECK_ERR_RET(ly_set_add(&CTX->status, (void*)STATUS, LY_SET_OPT_USEASLIST) == -1, LOGMEM(CTX->ctx), LY_EMEM)
+    LY_CHECK_RET(ly_set_add(&CTX->status, (void*)STATUS, LY_SET_OPT_USEASLIST, NULL))
 
 #define JSON_POP_STATUS_RET(CTX) \
     assert(CTX->status.count); CTX->status.count--;

--- a/src/parser.c
+++ b/src/parser.c
@@ -414,7 +414,7 @@ lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, c
     ret = lyd_create_term(schema, value, value_len, dynamic, value_hints, format, prefix_data, node);
     if (ret == LY_EINCOMPLETE) {
         if (!(lydctx->parse_options & LYD_PARSE_ONLY)) {
-            ly_set_add(&lydctx->unres_node_type, *node, LY_SET_OPT_USEASLIST);
+            LY_CHECK_RET(ly_set_add(&lydctx->unres_node_type, *node, LY_SET_OPT_USEASLIST, NULL));
         }
         ret = LY_SUCCESS;
     }
@@ -430,7 +430,7 @@ lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct l
     ret = lyd_create_meta(parent, meta, mod, name, name_len, value, value_len, dynamic, value_hints, format, prefix_data,
                           ctx_snode);
     if (ret == LY_EINCOMPLETE) {
-        ly_set_add(&lydctx->unres_meta_type, *meta, LY_SET_OPT_USEASLIST);
+        LY_CHECK_RET(ly_set_add(&lydctx->unres_meta_type, *meta, LY_SET_OPT_USEASLIST, NULL));
         ret = LY_SUCCESS;
     }
     return ret;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -362,7 +362,8 @@ lydjson_check_list(struct lyjson_ctx *jsonctx, const struct lysc_node *list)
     /* get all keys into a set (keys do not have if-features or anything) */
     snode = NULL;
     while ((snode = lys_getnext(snode, list, NULL, LYS_GETNEXT_NOSTATECHECK)) && (snode->flags & LYS_KEY)) {
-        ly_set_add(&key_set, (void *)snode, LY_SET_OPT_USEASLIST);
+        ret = ly_set_add(&key_set, (void *)snode, LY_SET_OPT_USEASLIST, NULL);
+        LY_CHECK_GOTO(ret, cleanup);
     }
 
     if (status != LYJSON_OBJECT_EMPTY) {

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -215,7 +215,8 @@ lydxml_check_list(struct lyxml_ctx *xmlctx, const struct lysc_node *list)
     /* get all keys into a set (keys do not have if-features or anything) */
     snode = NULL;
     while ((snode = lys_getnext(snode, list, NULL, LYS_GETNEXT_NOSTATECHECK)) && (snode->flags & LYS_KEY)) {
-        ly_set_add(&key_set, (void *)snode, LY_SET_OPT_USEASLIST);
+        ret = ly_set_add(&key_set, (void *)snode, LY_SET_OPT_USEASLIST, NULL);
+        LY_CHECK_GOTO(ret, cleanup);
     }
 
     while (xmlctx->status == LYXML_ELEMENT) {

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -2582,7 +2582,7 @@ checks:
 
     /* store data for collision check */
     if (parent && !(parent->nodetype & (LYS_GROUPING | LYS_RPC | LYS_ACTION | LYS_INOUT | LYS_NOTIF))) {
-        LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, parent, 0) == -1, LY_EMEM);
+        LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, parent, 0, NULL));
     }
 
     return ret;

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -1407,7 +1407,7 @@ yin_parse_typedef(struct lys_yin_parser_ctx *ctx, struct tree_node_meta *typedef
 
     /* store data for collision check */
     if (typedef_meta->parent && !(typedef_meta->parent->nodetype & (LYS_GROUPING | LYS_RPC | LYS_ACTION | LYS_INOUT | LYS_NOTIF))) {
-        LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, typedef_meta->parent, 0) == -1, LY_EMEM);
+        LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, typedef_meta->parent, 0, NULL));
     }
 
     return LY_SUCCESS;

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -96,7 +96,7 @@ json_print_array_open(struct jsonpr_ctx *ctx, const struct lyd_node *node)
 {
     /* leaf-list's content is always printed on a single line */
     ly_print_(ctx->out, "[%s", (!node->schema || node->schema->nodetype != LYS_LEAFLIST) && DO_FORMAT ? "\n" : "");
-    ly_set_add(&ctx->open, (void *)node, 0);
+    ly_set_add(&ctx->open, (void *)node, 0, NULL);
     LEVEL_INC;
 }
 

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -465,8 +465,7 @@ lyb_print_data_models(struct ly_out *out, const struct lyd_node *root, struct ly
     const struct lyd_node *node;
     uint32_t i;
 
-    set = ly_set_new();
-    LY_CHECK_RET(!set, LY_EMEM);
+    LY_CHECK_RET(ly_set_new(&set));
 
     /* collect all data node modules */
     LY_LIST_FOR(root, node) {
@@ -475,14 +474,17 @@ lyb_print_data_models(struct ly_out *out, const struct lyd_node *root, struct ly
         }
 
         mod = node->schema->module;
-        ly_set_add(set, mod, 0);
+        ret = ly_set_add(set, mod, 0, NULL);
+        LY_CHECK_GOTO(ret, cleanup);
 
         /* add also their modules deviating or augmenting them */
         LY_ARRAY_FOR(mod->compiled->deviated_by, u) {
-            ly_set_add(set, mod->compiled->deviated_by[u], 0);
+            ret = ly_set_add(set, mod->compiled->deviated_by[u], 0, NULL);
+            LY_CHECK_GOTO(ret, cleanup);
         }
         LY_ARRAY_FOR(mod->compiled->augmented_by, u) {
-            ly_set_add(set, mod->compiled->augmented_by[u], 0);
+            ret = ly_set_add(set, mod->compiled->augmented_by[u], 0, NULL);
+            LY_CHECK_GOTO(ret, cleanup);
         }
     }
 

--- a/src/set.h
+++ b/src/set.h
@@ -63,9 +63,12 @@ struct ly_set
 /**
  * @brief Create and initiate new ::ly_set structure.
  *
- * @return Created ::ly_set structure or NULL in case of error.
+ * @param[out] set Pointer to store the created ::ly_set structure.
+ * @return LY_SUCCESS on success.
+ * @return LY_EINVAL in case of NULL @p set parameter.
+ * @return LY_EMEM in case of memory allocation failure.
  */
-struct ly_set *ly_set_new(void);
+LY_ERR ly_set_new(struct ly_set **set_p);
 
 /**
  * @brief Duplicate the existing set.
@@ -76,22 +79,23 @@ struct ly_set *ly_set_new(void);
  * the original set.
  * @return Duplication of the original set.
  */
-struct ly_set *ly_set_dup(const struct ly_set *set, void *(*duplicator)(void *obj));
+LY_ERR ly_set_dup(const struct ly_set *set, void *(*duplicator)(void *obj), struct ly_set **newset_p);
 
 /**
  * @brief Add an object into the set
- *
- * Since it is a set, the function checks for duplicity and if the
- * node is already in the set, the index of the previously added
- * node is returned.
  *
  * @param[in] set Set where the \p object will be added.
  * @param[in] object Object to be added into the \p set;
  * @param[in] options Options to change behavior of the function. Accepted options are:
  * - #LY_SET_OPT_USEASLIST - do not check for duplicities
- * @return -1 on failure, index of the \p node in the set on success
+ * @param[out] index_p Optional pointer to return index of the added @p object. Usually it is the last index (::ly_set::count - 1),
+ * but in case the duplicities are checked and the object is already in the set, the @p object is not added and index of the
+ * already present object is returned.
+ * @return LY_SUCCESS in case of success
+ * @return LY_EINVAL in case of invalid input parameters.
+ * @return LY_EMEM in case of memory allocation failure.
  */
-int ly_set_add(struct ly_set *set, void *object, uint32_t options);
+LY_ERR ly_set_add(struct ly_set *set, void *object, uint32_t options, uint32_t *index_p);
 
 /**
  * @brief Add all objects from \p src to \p trg.
@@ -105,18 +109,21 @@ int ly_set_add(struct ly_set *set, void *object, uint32_t options);
  * @param[in] duplicator Optional pointer to function that duplicates the objects being added
  * from \p src into \p trg set. If not provided, the \p trg set will point to the exact same
  * objects as the \p src set.
- * @return -1 on failure, number of objects added into \p trg on success.
+ * @return LY_SUCCESS in case of success
+ * @return LY_EINVAL in case of invalid input parameters.
+ * @return LY_EMEM in case of memory allocation failure.
  */
-int ly_set_merge(struct ly_set *trg, struct ly_set *src, uint32_t options, void *(*duplicator)(void *obj));
+LY_ERR ly_set_merge(struct ly_set *trg, struct ly_set *src, uint32_t options, void *(*duplicator)(void *obj));
 
 /**
  * @brief Learn whether the set contains the specified object.
  *
  * @param[in] set Set to explore.
  * @param[in] object Object to be found in the set.
- * @return Index of the object in the set or -1 if the object is not present in the set.
+ * @param[out] index_p Optional pointer to return index of the searched @p object.
+ * @return Boolean value (0 is false) if the @p object was found in the @p set.
  */
-int ly_set_contains(const struct ly_set *set, void *object);
+uint8_t ly_set_contains(const struct ly_set *set, void *object, uint32_t *index_p);
 
 /**
  * @brief Remove all objects from the set, but keep the set container for further use.

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1434,7 +1434,7 @@ lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struc
                 if (ret == LY_EINCOMPLETE) {
                     if (node_types) {
                         /* remember to resolve type */
-                        ly_set_add(node_types, node, LY_SET_OPT_USEASLIST);
+                        LY_CHECK_RET(ly_set_add(node_types, node, LY_SET_OPT_USEASLIST, NULL));
                     }
                 } else if (ret) {
                     return ret;
@@ -1444,7 +1444,7 @@ lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struc
 
                 if (iter->when && node_when) {
                     /* remember to resolve when */
-                    ly_set_add(node_when, node, LY_SET_OPT_USEASLIST);
+                    LY_CHECK_RET(ly_set_add(node_when, node, LY_SET_OPT_USEASLIST, NULL));
                 }
                 if (diff) {
                     /* add into diff */
@@ -1462,7 +1462,7 @@ lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struc
                     if (ret == LY_EINCOMPLETE) {
                         if (node_types) {
                             /* remember to resolve type */
-                            ly_set_add(node_types, node, LY_SET_OPT_USEASLIST);
+                            LY_CHECK_RET(ly_set_add(node_types, node, LY_SET_OPT_USEASLIST, NULL));
                         }
                     } else if (ret) {
                         return ret;
@@ -1472,7 +1472,7 @@ lyd_new_implicit_r(struct lyd_node *parent, struct lyd_node **first, const struc
 
                     if (iter->when && node_when) {
                         /* remember to resolve when */
-                        ly_set_add(node_when, node, LY_SET_OPT_USEASLIST);
+                        LY_CHECK_RET(ly_set_add(node_when, node, LY_SET_OPT_USEASLIST, NULL));
                     }
                     if (diff) {
                         /* add into diff */
@@ -3335,8 +3335,8 @@ lyd_find_xpath(const struct lyd_node *ctx_node, const char *xpath, struct ly_set
     LY_CHECK_GOTO(ret, cleanup);
 
     /* allocate return set */
-    *set = ly_set_new();
-    LY_CHECK_ERR_GOTO(!*set, LOGMEM(LYD_CTX(ctx_node)); ret = LY_EMEM, cleanup);
+    ret = ly_set_new(set);
+    LY_CHECK_GOTO(ret, cleanup);
 
     /* transform into ly_set */
     if (xp_set.type == LYXP_SET_NODE_SET) {
@@ -3347,7 +3347,8 @@ lyd_find_xpath(const struct lyd_node *ctx_node, const char *xpath, struct ly_set
 
         for (i = 0; i < xp_set.used; ++i) {
             if (xp_set.val.nodes[i].type == LYXP_NODE_ELEM) {
-                ly_set_add(*set, xp_set.val.nodes[i].node, LY_SET_OPT_USEASLIST);
+                ret = ly_set_add(*set, xp_set.val.nodes[i].node, LY_SET_OPT_USEASLIST, NULL);
+                LY_CHECK_GOTO(ret, cleanup);
             }
         }
     }

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -209,7 +209,7 @@ lyd_parse_set_data_flags(struct lyd_node *node, struct ly_set *when_check, struc
             node->flags |= LYD_WHEN_TRUE;
         } else {
             /* remember we need to evaluate this node's when */
-            ly_set_add(when_check, node, LY_SET_OPT_USEASLIST);
+            LY_CHECK_RET(ly_set_add(when_check, node, LY_SET_OPT_USEASLIST, NULL), );
         }
     }
 

--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -6810,8 +6810,8 @@ lys_compile_unres_when_cyclic(struct lyxp_set *set, const struct lysc_node *node
                     /* skip roots'n'stuff */
                     if (tmp_set.val.scnodes[j].type == LYXP_NODE_ELEM) {
                         /* try to find this node in our set */
-                        int idx = lyxp_set_scnode_dup_node_check(set, tmp_set.val.scnodes[j].scnode, LYXP_NODE_ELEM, -1);
-                        if ((idx > -1) && (set->val.scnodes[idx].in_ctx == -1)) {
+                        uint32_t idx;
+                        if (lyxp_set_scnode_contains(set, tmp_set.val.scnodes[j].scnode, LYXP_NODE_ELEM, -1, &idx) && (set->val.scnodes[idx].in_ctx == -1)) {
                             LOGVAL(set->ctx, LY_VLOG_LYSC, node, LY_VCODE_CIRC_WHEN, node->name, set->val.scnodes[idx].scnode->name);
                             ret = LY_EVALID;
                             goto cleanup;

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -553,7 +553,7 @@ lysp_parse_finalize_reallocated(struct lys_parser_ctx *ctx, struct lysp_grp *gro
             groupings[u].groupings[v].parent = (struct lysp_node *)&groupings[u];
         }
         if (groupings[u].typedefs) {
-            ly_set_add(&ctx->tpdfs_nodes, &groupings[u], 0);
+            LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, &groupings[u], 0, NULL));
         }
     }
 
@@ -581,7 +581,7 @@ lysp_parse_finalize_reallocated(struct lys_parser_ctx *ctx, struct lysp_grp *gro
                 actions[u].input.groupings[v].parent = (struct lysp_node *)&actions[u].input;
             }
             if (actions[u].input.typedefs) {
-                ly_set_add(&ctx->tpdfs_nodes, &actions[u].input, 0);
+                LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, &actions[u].input, 0, NULL));
             }
         }
         if (actions[u].output.parent) {
@@ -593,14 +593,14 @@ lysp_parse_finalize_reallocated(struct lys_parser_ctx *ctx, struct lysp_grp *gro
                 actions[u].output.groupings[v].parent = (struct lysp_node *)&actions[u].output;
             }
             if (actions[u].output.typedefs) {
-                ly_set_add(&ctx->tpdfs_nodes, &actions[u].output, 0);
+                LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, &actions[u].output, 0, NULL));
             }
         }
         LY_ARRAY_FOR(actions[u].groupings, v) {
             actions[u].groupings[v].parent = (struct lysp_node *)&actions[u];
         }
         if (actions[u].typedefs) {
-            ly_set_add(&ctx->tpdfs_nodes, &actions[u], 0);
+            LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, &actions[u], 0, NULL));
         }
     }
 
@@ -613,7 +613,7 @@ lysp_parse_finalize_reallocated(struct lys_parser_ctx *ctx, struct lysp_grp *gro
             notifs[u].groupings[v].parent = (struct lysp_node *)&notifs[u];
         }
         if (notifs[u].typedefs) {
-            ly_set_add(&ctx->tpdfs_nodes, &notifs[u], 0);
+            LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, &notifs[u], 0, NULL));
         }
     }
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -686,11 +686,10 @@ lyd_validate_unique(const struct lyd_node *first, const struct lysc_node *snode,
     assert(uniques);
 
     /* get all list instances */
-    set = ly_set_new();
-    LY_CHECK_ERR_RET(!set, LOGMEM(ctx), LY_EMEM);
+    LY_CHECK_RET(ly_set_new(&set));
     LY_LIST_FOR(first, diter) {
         if (diter->schema == snode) {
-            ly_set_add(set, (void *)diter, LY_SET_OPT_USEASLIST);
+            LY_CHECK_RET(ly_set_add(set, (void *)diter, LY_SET_OPT_USEASLIST, NULL));
         }
     }
 
@@ -1036,12 +1035,12 @@ lyd_validate_subtree(struct lyd_node *root, struct ly_set *type_check, struct ly
         if ((node->flags & (LYD_DEFAULT | LYD_NEW)) != (LYD_DEFAULT | LYD_NEW)) {
             LY_LIST_FOR(node->meta, meta) {
                 /* metadata type resolution */
-                ly_set_add(type_meta_check, (void *)meta, LY_SET_OPT_USEASLIST);
+                LY_CHECK_RET(ly_set_add(type_meta_check, (void *)meta, LY_SET_OPT_USEASLIST, NULL));
             }
 
             if (node->schema->nodetype & LYD_NODE_TERM) {
                 /* node type resolution */
-                ly_set_add(type_check, (void *)node, LY_SET_OPT_USEASLIST);
+                LY_CHECK_RET(ly_set_add(type_check, (void *)node, LY_SET_OPT_USEASLIST, NULL));
             } else if (node->schema->nodetype & LYD_NODE_INNER) {
                 /* new node validation, autodelete */
                 LY_CHECK_RET(lyd_validate_new(lyd_node_children_p((struct lyd_node *)node), node->schema, NULL, diff));
@@ -1054,7 +1053,7 @@ lyd_validate_subtree(struct lyd_node *root, struct ly_set *type_check, struct ly
 
             if (!(node->schema->nodetype & (LYS_RPC | LYS_ACTION | LYS_NOTIF)) && node->schema->when) {
                 /* when evaluation */
-                ly_set_add(when_check, (void *)node, LY_SET_OPT_USEASLIST);
+                LY_CHECK_RET(ly_set_add(when_check, (void *)node, LY_SET_OPT_USEASLIST, NULL));
             }
         }
 

--- a/src/xml.c
+++ b/src/xml.c
@@ -145,6 +145,7 @@ lyxml_parse_identifier(struct lyxml_ctx *xmlctx, const char **start, const char 
 LY_ERR
 lyxml_ns_add(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_len, char *uri)
 {
+    LY_ERR ret = LY_SUCCESS;
     struct lyxml_ns *ns;
 
     ns = malloc(sizeof *ns);
@@ -163,8 +164,9 @@ lyxml_ns_add(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_len, ch
         ns->prefix = NULL;
     }
 
-    LY_CHECK_ERR_RET(ly_set_add(&xmlctx->ns, ns, LY_SET_OPT_USEASLIST) == -1,
-                     free(ns->prefix); free(ns->uri); free(ns), LY_EMEM);
+    ret = ly_set_add(&xmlctx->ns, ns, LY_SET_OPT_USEASLIST, NULL);
+    LY_CHECK_ERR_RET(ret, free(ns->prefix); free(ns->uri); free(ns), ret);
+
     return LY_SUCCESS;
 }
 
@@ -592,7 +594,7 @@ lyxml_open_element(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_l
     e->prefix = prefix;
     e->name_len = name_len;
     e->prefix_len = prefix_len;
-    ly_set_add(&xmlctx->elements, e, LY_SET_OPT_USEASLIST);
+    LY_CHECK_RET(ly_set_add(&xmlctx->elements, e, LY_SET_OPT_USEASLIST, NULL));
 
     /* skip WS */
     ign_xmlws(xmlctx);

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -340,9 +340,11 @@ void lyxp_set_free_content(struct lyxp_set *set);
  * @param[in] set Set to insert into.
  * @param[in] node Node to insert.
  * @param[in] node_type Node type of @p node.
- * @return Index of the inserted node in set.
+ * @param[out] index_p Optional pointer to store index if the inserted @p node.
+ * @return LY_SUCCESS on success.
+ * @return LY_EMEM on memory allocation failure.
  */
-int lyxp_set_scnode_insert_node(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type);
+LY_ERR lyxp_set_scnode_insert_node(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type, uint32_t *index_p);
 
 /**
  * @brief Check for duplicates in a schema node set.
@@ -351,10 +353,12 @@ int lyxp_set_scnode_insert_node(struct lyxp_set *set, const struct lysc_node *no
  * @param[in] node Node to look for in @p set.
  * @param[in] node_type Type of @p node.
  * @param[in] skip_idx Index from @p set to skip.
- * @return Index of the found node, -1 if not found.
+ * @param[out] index_p Optional pointer to store index if the node is found.
+ * @return 0 if not found
+ * @return 1 if the @p node found.
  */
-int lyxp_set_scnode_dup_node_check(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type,
-        int skip_idx);
+uint8_t lyxp_set_scnode_contains(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type,
+        int skip_idx, uint32_t *index_p);
 
 /**
  * @brief Merge 2 schema node sets.

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -492,9 +492,15 @@ main_ni(int argc, char* argv[])
                 goto cleanup;
             }
             if (!searchpaths) {
-                searchpaths = ly_set_new();
+                if (ly_set_new(&searchpaths)) {
+                    fprintf(stderr, "yanglint error: Preparing storage for searchpaths failed.\n");
+                    goto cleanup;
+                }
             }
-            ly_set_add(searchpaths, optarg, 0);
+            if (ly_set_add(searchpaths, optarg, 0, NULL)) {
+                fprintf(stderr, "yanglint error: Storing searchpath failed.\n");
+                goto cleanup;
+            }
             break;
 #if 0
         case 'r':
@@ -681,7 +687,10 @@ main_ni(int argc, char* argv[])
     /* derefered setting of verbosity in libyang after context initiation */
     ly_verb(verbose);
 
-    mods = ly_set_new();
+    if (ly_set_new(&mods)) {
+        fprintf(stderr, "yanglint error: Preparing storage for the parsed modules failed.\n");
+        goto cleanup;
+    }
 
 
     /* divide input files */
@@ -710,7 +719,10 @@ main_ni(int argc, char* argv[])
             if (!mod) {
                 goto cleanup;
             }
-            ly_set_add(mods, (void *)mod, 0);
+            if (ly_set_add(mods, (void *)mod, 0, NULL)) {
+                fprintf(stderr, "yanglint error: Storing parsed module for further processing failed.\n");
+                goto cleanup;
+            }
         } else {
             if (autodetection && informat_d != LYD_XML) {
                 /* data file content autodetection is possible only for XML input */


### PR DESCRIPTION
Some of the functions were mixing the return code of -1 for failure and positive values to return some information. Instead, make them return LY_ERR value and the information is returned via an optional output parameter.