### PR TITLE
python binding BUGFIX Should be taking global lock before calling back to python code + Data_Node missing .reset()

### DIFF
--- a/swig/python/yang.i
+++ b/swig/python/yang.i
@@ -69,6 +69,9 @@ private:
 
 static const char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev, const char *submod_name, const char *sub_rev,
                                    void *user_data, LYS_INFORMAT *format, void (**free_module_data)(void *model_data, void *user_data)) {
+#if defined(SWIG_PYTHON_THREADS)
+    SWIG_Python_Thread_Block safety;
+#endif
     Wrap_cb *ctx = (Wrap_cb *) user_data;
     (void)free_module_data;
     auto pair = ctx->ly_module_imp_clb(mod_name, mod_rev, submod_name, sub_rev, ctx->private_ctx);
@@ -114,6 +117,10 @@ static const char *g_ly_module_imp_clb(const char *mod_name, const char *mod_rev
 
         return casted;
     }
+
+    void reset(libyang::Data_Node reset_val){
+         *self=reset_val;
+     }
 };
 
 %extend libyang::Schema_Node {


### PR DESCRIPTION
sysrepo python oper example shows calling .reset() when populating parent.
    
This is missing when using the libyang python binding definition, which prevents returning data in the parent node
