### PR TITLE
schema tree REFACTOR compile case like a general node

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -112,9 +112,10 @@ next:
             next = (struct lysc_node *)(&notifs[u + 1]);
         }
         goto repeat;
+    } else {
+        next = last->next;
     }
 
-    next = last->next;
 repeat:
     if (next && parent && parent->nodetype == LYS_CASE && next->parent != parent) {
         /* inside case (as an explicit parent, not when diving into it from choice),
@@ -147,8 +148,15 @@ check:
     case LYS_ANYDATA:
     case LYS_LIST:
     case LYS_LEAFLIST:
-    case LYS_CASE:
         break;
+    case LYS_CASE:
+        if (options & LYS_GETNEXT_WITHCASE) {
+            break;
+        } else {
+            /* go into */
+            next = ((struct lysc_node_case *)next)->child;
+        }
+        goto repeat;
     case LYS_CONTAINER:
         if (!(((struct lysc_node_container *)next)->flags & LYS_PRESENCE) && (options & LYS_GETNEXT_INTONPCONT)) {
             if (((struct lysc_node_container *)next)->child) {
@@ -162,7 +170,7 @@ check:
         break;
     case LYS_CHOICE:
         if (options & LYS_GETNEXT_WITHCHOICE) {
-            return next;
+            break;
         } else if ((options & LYS_GETNEXT_NOCHOICE) || !((struct lysc_node_choice *)next)->cases) {
             next = next->next;
         } else {

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -26,7 +26,6 @@
 #include "xpath.h"
 
 void lysp_grp_free(struct ly_ctx *ctx, struct lysp_grp *grp);
-void lysp_node_free(struct ly_ctx *ctx, struct lysp_node *node);
 void lysc_extension_free(struct ly_ctx *ctx, struct lysc_ext **ext);
 
 static void
@@ -759,13 +758,18 @@ lysc_node_choice_free(struct ly_ctx *ctx, struct lysc_node_choice *node)
 {
     struct lysc_node *child, *child_next;
 
-    if (node->cases) {
-        LY_LIST_FOR_SAFE(node->cases->child, child_next, child) {
-            lysc_node_free(ctx, child);
-        }
-        LY_LIST_FOR_SAFE((struct lysc_node *)node->cases, child_next, child) {
-            lysc_node_free(ctx, child);
-        }
+    LY_LIST_FOR_SAFE((struct lysc_node *)node->cases, child_next, child) {
+        lysc_node_free(ctx, child);
+    }
+}
+
+static void
+lysc_node_case_free(struct ly_ctx *ctx, struct lysc_node_case *node)
+{
+    struct lysc_node *child, *child_next;
+
+    LY_LIST_FOR_SAFE(node->child, child_next, child) {
+        lysc_node_free(ctx, child);
     }
 }
 
@@ -801,7 +805,7 @@ lysc_node_free(struct ly_ctx *ctx, struct lysc_node *node)
         lysc_node_choice_free(ctx, (struct lysc_node_choice *)node);
         break;
     case LYS_CASE:
-        /* nothing specific */
+        lysc_node_case_free(ctx, (struct lysc_node_case *)node);
         break;
     case LYS_ANYDATA:
     case LYS_ANYXML:

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -1358,11 +1358,7 @@ lysc_node_children_p(const struct lysc_node *node, uint16_t flags)
     case LYS_CONTAINER:
         return &((struct lysc_node_container *)node)->child;
     case LYS_CHOICE:
-        if (((struct lysc_node_choice *)node)->cases) {
-            return &((struct lysc_node_choice *)node)->cases->child;
-        } else {
-            return NULL;
-        }
+        return (struct lysc_node **)&((struct lysc_node_choice *)node)->cases;
     case LYS_CASE:
         return &((struct lysc_node_case *)node)->child;
     case LYS_LIST:

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -652,6 +652,14 @@ void lysp_ext_instance_free(struct ly_ctx *ctx, struct lysp_ext_instance *ext);
 LY_ERR lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt kw, void **result, struct lysp_ext_instance **exts);
 
 /**
+ * @brief Free a parsed node.
+ *
+ * @param[in] ctx libyang context.
+ * @param[in] node Node to free.
+ */
+void lysp_node_free(struct ly_ctx *ctx, struct lysp_node *node);
+
+/**
  * @brief Free the compiled type structure.
  * @param[in] ctx libyang context where the string data resides in a dictionary.
  * @param[in,out] type Compiled type structure to be freed. The structure has refcount, so it is freed only in case the value is decreased to 0.


### PR DESCRIPTION
Change included - all choice data children are not linked
siblings anymore but standard children of their case.
Fixes #1157