### PR TITLE
libyang FEATURE introduce and use new ly_bool type

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -573,7 +573,7 @@ ly_parse_instance_predicate(const char **pred, size_t limit, LYD_FORMAT format,
     LY_ERR ret = LY_EVALID;
     const char *in = *pred;
     size_t offset = 1;
-    uint8_t expr = 0;
+    uint8_t expr = 0; /* 0 - position predicate; 1 - leaf-list-predicate; 2 - key-predicate */
     char quot;
 
     assert(in[0] == '\[');

--- a/src/context.c
+++ b/src/context.c
@@ -51,7 +51,7 @@ static struct internal_modules_s {
     const char *name;
     const char *revision;
     const char *data;
-    uint8_t implemented;
+    ly_bool implemented;
     LYS_INFORMAT format;
 } internal_modules[] = {
     {"ietf-yang-metadata", "2016-08-05", (const char *)ietf_yang_metadata_2016_08_05_yang, 1, LYS_IN_YANG},
@@ -532,7 +532,7 @@ ly_ctx_get_submodule(const struct ly_ctx *ctx, const char *module, const char *s
 }
 
 API const struct lysc_node *
-ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, const char *data_path, uint8_t output)
+ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, const char *data_path, ly_bool output)
 {
     const struct lysc_node *snode = NULL;
     struct lyxp_expr *exp = NULL;
@@ -621,7 +621,7 @@ ylib_feature(struct lyd_node *parent, const struct lys_module *cur_mod)
 }
 
 static LY_ERR
-ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, uint8_t bis)
+ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, ly_bool bis)
 {
     LY_ARRAY_COUNT_TYPE i;
     struct lys_module *mod;
@@ -646,7 +646,7 @@ ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, uint8_
 }
 
 static LY_ERR
-ylib_submodules(struct lyd_node *parent, const struct lys_module *cur_mod, uint8_t bis)
+ylib_submodules(struct lyd_node *parent, const struct lys_module *cur_mod, ly_bool bis)
 {
     LY_ERR ret;
     LY_ARRAY_COUNT_TYPE i;
@@ -693,7 +693,7 @@ ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root_p)
 {
     LY_ERR ret;
     uint32_t i;
-    uint8_t bis = 0;
+    ly_bool bis = 0;
     int r;
     char id[8], *str;
     const struct lys_module *mod;

--- a/src/context.h
+++ b/src/context.h
@@ -418,7 +418,7 @@ struct lys_module *ly_ctx_get_module_implemented_ns(const struct ly_ctx *ctx, co
  * @return Found schema node or NULL.
  */
 const struct lysc_node *ly_ctx_get_node(const struct ly_ctx *ctx, const struct lysc_node *ctx_node,
-        const char *data_path, uint8_t output);
+        const char *data_path, ly_bool output);
 
 /**
  * @brief Reset cached latest revision information of the schemas in the context.

--- a/src/diff.c
+++ b/src/diff.c
@@ -516,7 +516,7 @@ lyd_diff_attrs(const struct lyd_node *first, const struct lyd_node *second, uint
  * @return LY_ERR value.
  */
 static LY_ERR
-lyd_diff_siblings_r(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, uint8_t nosiblings,
+lyd_diff_siblings_r(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, ly_bool nosiblings,
         struct lyd_node **diff)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -669,7 +669,7 @@ cleanup:
 }
 
 static LY_ERR
-lyd_diff(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, uint8_t nosiblings, struct lyd_node **diff)
+lyd_diff(const struct lyd_node *first, const struct lyd_node *second, uint16_t options, ly_bool nosiblings, struct lyd_node **diff)
 {
     const struct ly_ctx *ctx;
 

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -23,9 +23,15 @@
 #include "compat.h"
 #include "common.h"
 #include "dict.h"
+#include "log.h"
 
-static uint8_t
-lydict_val_eq(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *cb_data)
+/**
+ * @brief Comparison callback for dictionary's hash table
+ *
+ * Implementation of ::values_equal_cb.
+ */
+static ly_bool
+lydict_val_eq(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *cb_data)
 {
     LY_CHECK_ARG_RET(NULL, val1_p, val2_p, cb_data, 0);
 
@@ -173,7 +179,7 @@ finish:
 }
 
 static char *
-dict_insert(const struct ly_ctx *ctx, char *value, size_t len, uint8_t zerocopy)
+dict_insert(const struct ly_ctx *ctx, char *value, size_t len, ly_bool zerocopy)
 {
     LY_ERR ret = 0;
     struct dict_rec *match = NULL, rec;
@@ -332,7 +338,7 @@ lyht_free(struct hash_table *ht)
 }
 
 static LY_ERR
-lyht_resize(struct hash_table *ht, uint8_t enlarge)
+lyht_resize(struct hash_table *ht, ly_bool enlarge)
 {
     struct ht_rec *rec;
     unsigned char *old_recs;
@@ -477,7 +483,7 @@ lyht_find_collision(struct hash_table *ht, struct ht_rec **last, struct ht_rec *
  * @param[in] ht Hash table to search in.
  * @param[in] val_p Pointer to the value to find.
  * @param[in] hash Hash to find.
- * @param[in] mod Operation kind for the val_equal callback.
+ * @param[in] mod Whether the operation modifies the hash table (insert or remove) or not (find).
  * @param[out] crec_p Optional found first record.
  * @param[out] col Optional collision number of @p rec_p, 0 for no collision.
  * @param[out] rec_p Found exact matching record, may be a collision of @p crec_p.
@@ -485,7 +491,7 @@ lyht_find_collision(struct hash_table *ht, struct ht_rec **last, struct ht_rec *
  * @return LY_SUCCESS if record was found.
  */
 static LY_ERR
-lyht_find_rec(struct hash_table *ht, void *val_p, uint32_t hash, uint8_t mod, struct ht_rec **crec_p, uint32_t *col,
+lyht_find_rec(struct hash_table *ht, void *val_p, uint32_t hash, ly_bool mod, struct ht_rec **crec_p, uint32_t *col,
         struct ht_rec **rec_p)
 {
     struct ht_rec *rec, *crec;
@@ -682,7 +688,7 @@ lyht_remove(struct hash_table *ht, void *val_p, uint32_t hash)
 {
     struct ht_rec *rec, *crec;
     int32_t i;
-    uint8_t first_matched = 0;
+    ly_bool first_matched = 0;
     LY_ERR r, ret = LY_SUCCESS;
 
     LY_CHECK_ERR_RET(lyht_find_first(ht, hash, &rec), LOGARG(NULL, hash), LY_ENOTFOUND); /* hash not found */

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -45,9 +45,9 @@ uint32_t dict_hash(const char *key, size_t len);
  * @param[in] val2_p Pointer to the second value, the one stored in the hash table.
  * @param[in] mod Whether the operation modifies the hash table (insert or remove) or not (find).
  * @param[in] cb_data User callback data.
- * @return 0 on non-equal, non-zero on equal.
+ * @return false (non-equal) or true (equal).
  */
-typedef uint8_t (*values_equal_cb)(void *val1_p, void *val2_p, uint8_t mod, void *cb_data);
+typedef ly_bool (*values_equal_cb)(void *val1_p, void *val2_p, ly_bool mod, void *cb_data);
 
 /** when the table is at least this much percent full, it is enlarged (double the size) */
 #define LYHT_ENLARGE_PERCENTAGE 75

--- a/src/json.c
+++ b/src/json.c
@@ -87,7 +87,7 @@ skip_ws(struct lyjson_ctx *jsonctx)
  * @brief Set value corresponding to the current context's status
  */
 static void
-lyjson_ctx_set_value(struct lyjson_ctx *jsonctx, const char *value, size_t value_len, uint8_t dynamic)
+lyjson_ctx_set_value(struct lyjson_ctx *jsonctx, const char *value, size_t value_len, ly_bool dynamic)
 {
     assert(jsonctx);
 
@@ -437,7 +437,7 @@ invalid_character:
             }
         }
         /* copy the value */
-        uint8_t dp_placed;
+        ly_bool dp_placed;
         size_t j;
         for (dp_placed = dp_position ? 0 : 1, j = minus; j < exponent; j++) {
             if (in[j] == '.') {
@@ -681,7 +681,7 @@ LY_ERR
 lyjson_ctx_next(struct lyjson_ctx *jsonctx, enum LYJSON_PARSER_STATUS *status)
 {
     LY_ERR ret = LY_SUCCESS;
-    uint8_t toplevel = 0;
+    ly_bool toplevel = 0;
     enum LYJSON_PARSER_STATUS prev;
 
     assert(jsonctx);

--- a/src/json.h
+++ b/src/json.h
@@ -60,14 +60,14 @@ struct lyjson_ctx {
 
     const char *value;      /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
     size_t value_len;       /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
-    uint8_t dynamic;        /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
+    ly_bool dynamic;        /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
 
     struct {
         enum LYJSON_PARSER_STATUS status;
         uint32_t status_count;
         const char *value;
         size_t value_len;
-        uint8_t dynamic;
+        ly_bool dynamic;
         const char *input;
     } backup;
 };

--- a/src/log.c
+++ b/src/log.c
@@ -34,7 +34,7 @@
 volatile LY_LOG_LEVEL ly_log_level = LY_LLWRN;
 volatile uint32_t ly_log_opts = LY_LOLOG | LY_LOSTORE_LAST;
 static ly_log_clb log_clb;
-static volatile uint8_t path_flag = 1;
+static volatile ly_bool path_flag = 1;
 #ifndef NDEBUG
 volatile uint32_t ly_log_dbg_groups = 0;
 #endif
@@ -210,7 +210,7 @@ ly_verb_dbg(uint32_t dbg_groups)
 }
 
 API void
-ly_set_log_clb(ly_log_clb clb, uint8_t path)
+ly_set_log_clb(ly_log_clb clb, ly_bool path)
 {
     log_clb = clb;
     path_flag = path;
@@ -294,7 +294,7 @@ log_vprintf(const struct ly_ctx *ctx, LY_LOG_LEVEL level, LY_ERR no, LY_VECODE v
         const char *format, va_list args)
 {
     char *msg = NULL;
-    uint8_t free_strs;
+    ly_bool free_strs;
 
     if (level > ly_log_level) {
         /* do not print or store the message */

--- a/src/log.h
+++ b/src/log.h
@@ -25,6 +25,13 @@ extern "C" {
 struct ly_ctx;
 
 /**
+ * @brief Type to indicate boolean value.
+ *
+ * Do not test for actual value. Instead, handle it as true/false value in condition.
+ */
+typedef uint8_t ly_bool;
+
+/**
  * @defgroup log Logger
  * @{
  *
@@ -131,7 +138,7 @@ typedef void (*ly_log_clb)(LY_LOG_LEVEL level, const char *msg, const char *path
  *            presence) or it can be NULL, so consider it as an optional parameter. If the flag is 0, libyang will
  *            not bother with resolving the path.
  */
-void ly_set_log_clb(ly_log_clb clb, uint8_t path);
+void ly_set_log_clb(ly_log_clb clb, ly_bool path);
 
 /**
  * @brief Get logger callback.

--- a/src/parser.c
+++ b/src/parser.c
@@ -288,7 +288,7 @@ lys_parser_fill_filepath(struct ly_ctx *ctx, struct ly_in *in, const char **file
 }
 
 API void
-ly_in_free(struct ly_in *in, uint8_t destroy)
+ly_in_free(struct ly_in *in, ly_bool destroy)
 {
     if (!in) {
         return;
@@ -407,7 +407,7 @@ lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *snode)
 
 LY_ERR
 lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-        uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
+        ly_bool *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
 {
     LY_ERR ret;
 
@@ -423,7 +423,7 @@ lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, c
 
 LY_ERR
 lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod,
-        const char *name, size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hints,
+        const char *name, size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hints,
         LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode)
 {
     LY_ERR ret;

--- a/src/parser.h
+++ b/src/parser.h
@@ -167,7 +167,7 @@ size_t ly_in_parsed(const struct ly_in *in);
  * @param[in] destroy Flag to free the input data buffer (for LY_IN_MEMORY) or to
  * close stream/file descriptor (for LY_IN_FD and LY_IN_FILE)
  */
-void ly_in_free(struct ly_in *in, uint8_t destroy);
+void ly_in_free(struct ly_in *in, ly_bool destroy);
 
 #ifdef __cplusplus
 }

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -171,7 +171,7 @@ LY_ERR lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *s
  * @param[in] value_hints Data parser's hint for the value's type.
  */
 LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const char *value, size_t value_len,
-        uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
+        ly_bool *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
 
 /**
  * @brief Wrapper around lyd_create_meta() for data parsers.
@@ -181,7 +181,7 @@ LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *sc
  */
 LY_ERR lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct lyd_meta **meta,
         const struct lys_module *mod, const char *name, size_t name_len, const char *value,
-        size_t value_len, uint8_t *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format,
+        size_t value_len, ly_bool *dynamic, uint32_t value_hints, LY_PREFIX_FORMAT format,
         void *prefix_data, const struct lysc_node *ctx_snode);
 
 #endif /* LY_PARSER_INTERNAL_H_ */

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -86,11 +86,11 @@ lyd_json_ctx_free(struct lyd_ctx *lydctx)
  */
 static void
 lydjson_parse_name(const char *value, size_t value_len, const char **name_p, size_t *name_len_p, const char **prefix_p,
-        size_t *prefix_len_p, uint8_t *is_meta_p)
+        size_t *prefix_len_p, ly_bool *is_meta_p)
 {
     const char *name, *prefix = NULL;
     size_t name_len, prefix_len = 0;
-    uint8_t is_meta = 0;
+    ly_bool is_meta = 0;
 
     name = memchr(value, ':', value_len);
     if (name != NULL) {
@@ -183,7 +183,7 @@ lydjson_get_node_prefix(struct lyd_node *node, const char *local_prefix, size_t 
  * @return LY_ENOT in case the input data are expected to be skipped
  */
 static LY_ERR
-lydjson_get_snode(const struct lyd_json_ctx *lydctx, uint8_t is_attr, const char *prefix, size_t prefix_len, const char *name,
+lydjson_get_snode(const struct lyd_json_ctx *lydctx, ly_bool is_attr, const char *prefix, size_t prefix_len, const char *name,
         size_t name_len, const struct lyd_node_inner *parent, const struct lysc_node **snode_p)
 {
     struct lys_module *mod = NULL;
@@ -372,7 +372,7 @@ lydjson_check_list(struct lyjson_ctx *jsonctx, const struct lysc_node *list)
         while (key_set.count && status != LYJSON_OBJECT_CLOSED) {
             const char *name, *prefix;
             size_t name_len, prefix_len;
-            uint8_t is_attr;
+            ly_bool is_attr;
 
             /* match the key */
             snode = NULL;
@@ -556,7 +556,7 @@ lydjson_metadata_finish(struct lyd_json_ctx *lydctx, struct lyd_node **first_p)
     LY_LIST_FOR_SAFE(*first_p, next, attr) {
         struct lyd_node_opaq *meta_container = (struct lyd_node_opaq *)attr;
         uint64_t match = 0;
-        uint8_t is_attr;
+        ly_bool is_attr;
         const char *name, *prefix;
         size_t name_len, prefix_len;
         const struct lysc_node *snode;
@@ -600,7 +600,7 @@ lydjson_metadata_finish(struct lyd_json_ctx *lydctx, struct lyd_node **first_p)
                     /* convert opaq node to a attribute of the opaq node */
                     struct lyd_node_opaq *meta = (struct lyd_node_opaq *)meta_iter;
                     struct ly_prefix *val_prefs = NULL;
-                    uint8_t dynamic = 0;
+                    ly_bool dynamic = 0;
 
                     /* get value prefixes */
                     LY_CHECK_GOTO(ret = lydjson_get_value_prefixes(lydctx->jsonctx->ctx, lydctx->jsonctx->value, lydctx->jsonctx->value_len, &val_prefs), cleanup);
@@ -635,7 +635,7 @@ lydjson_metadata_finish(struct lyd_json_ctx *lydctx, struct lyd_node **first_p)
                     /* convert opaq node to a metadata of the node */
                     struct lyd_node_opaq *meta = (struct lyd_node_opaq *)meta_iter;
                     struct lys_module *mod = NULL;
-                    uint8_t dynamic = 0;
+                    ly_bool dynamic = 0;
 
                     mod = ly_ctx_get_module_implemented(lydctx->jsonctx->ctx, meta->prefix.id);
                     if (mod) {
@@ -702,13 +702,13 @@ lydjson_metadata(struct lyd_json_ctx *lydctx, const struct lysc_node *snode, str
     LY_ERR ret = LY_SUCCESS;
     enum LYJSON_PARSER_STATUS status;
     const char *expected;
-    uint8_t in_parent = 0;
+    ly_bool in_parent = 0;
     const char *name, *prefix = NULL;
     size_t name_len, prefix_len = 0;
     struct lys_module *mod;
     struct lyd_meta *meta = NULL;
     const struct ly_ctx *ctx = lydctx->jsonctx->ctx;
-    uint8_t is_attr = 0;
+    ly_bool is_attr = 0;
     struct lyd_node *prev = node;
     uint32_t instance = 0;
     uint16_t nodetype;
@@ -929,7 +929,7 @@ lydjson_parse_opaq(struct lyd_json_ctx *lydctx, const char *name, size_t name_le
     const char *value = NULL, *module_name;
     size_t value_len = 0, module_name_len = 0;
     struct ly_prefix *val_prefs = NULL;
-    uint8_t dynamic = 0;
+    ly_bool dynamic = 0;
     uint32_t type_hint = 0;
 
     if (*status_inner_p != LYJSON_OBJECT && *status_inner_p != LYJSON_OBJECT_EMPTY) {
@@ -1200,7 +1200,7 @@ lydjson_subtree_r(struct lyd_json_ctx *lydctx, struct lyd_node_inner *parent, st
     enum LYJSON_PARSER_STATUS status_inner = 0;
     const char *name, *prefix = NULL;
     size_t name_len, prefix_len = 0;
-    uint8_t is_meta = 0;
+    ly_bool is_meta = 0;
     const struct lysc_node *snode = NULL;
     struct lyd_node *node = NULL, *attr_node = NULL;
     const struct ly_ctx *ctx = lydctx->jsonctx->ctx;
@@ -1465,7 +1465,7 @@ lydjson_notif_envelope(struct lyjson_ctx *jsonctx, struct lyd_node **envp_p)
     LY_ERR ret = LY_ENOT, r;
     const char *name, *prefix, *value = NULL;
     size_t name_len, prefix_len, value_len;
-    uint8_t is_attr, dynamic = 0;
+    ly_bool is_attr, dynamic = 0;
     enum LYJSON_PARSER_STATUS status;
     struct lyd_node *et;
 
@@ -1632,7 +1632,7 @@ lydjson_object_envelope(struct lyjson_ctx *jsonctx, struct lyd_node *parent, con
     LY_ERR ret = LY_ENOT, r;
     const char *name, *prefix;
     size_t name_len, prefix_len;
-    uint8_t is_attr;
+    ly_bool is_attr;
     enum LYJSON_PARSER_STATUS status;
 
     *envp_p = NULL;

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -171,9 +171,9 @@ lyb_read_number(void *num, size_t num_size, size_t bytes, struct lylyb_ctx *lybc
  * @return LY_ERR value.
  */
 static LY_ERR
-lyb_read_string(char **str, uint8_t with_length, struct lylyb_ctx *lybctx)
+lyb_read_string(char **str, ly_bool with_length, struct lylyb_ctx *lybctx)
 {
-    uint8_t next_chunk = 0;
+    ly_bool next_chunk = 0;
     size_t len = 0, cur_len;
 
     *str = NULL;
@@ -345,7 +345,7 @@ static LY_ERR
 lyb_parse_metadata(struct lyd_lyb_ctx *lybctx, const struct lysc_node *sparent, struct lyd_meta **meta)
 {
     LY_ERR ret = LY_SUCCESS;
-    uint8_t dynamic;
+    ly_bool dynamic;
     uint8_t i, count = 0;
     char *meta_name = NULL, *meta_value;
     const struct lys_module *mod;
@@ -464,7 +464,7 @@ lyb_parse_attributes(struct lylyb_ctx *lybctx, struct lyd_attr **attr)
     uint8_t count, i;
     struct lyd_attr *attr2;
     char *prefix = NULL, *module_name = NULL, *name = NULL, *value = NULL;
-    uint8_t dynamic = 0;
+    ly_bool dynamic = 0;
     LYD_FORMAT format = 0;
     struct ly_prefix *val_prefs = NULL;
 
@@ -688,7 +688,7 @@ lyb_parse_subtree_r(struct lyd_lyb_ctx *lybctx, struct lyd_node_inner *parent, s
     struct ly_prefix *val_prefs = NULL;
     LYD_ANYDATA_VALUETYPE value_type;
     char *value = NULL, *name = NULL, *prefix = NULL, *module_key = NULL;
-    uint8_t dynamic = 0;
+    ly_bool dynamic = 0;
     LYD_FORMAT format = 0;
     uint32_t prev_lo;
     const struct ly_ctx *ctx = lybctx->lybctx->ctx;

--- a/src/parser_schema.h
+++ b/src/parser_schema.h
@@ -107,7 +107,7 @@ LY_ERR lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format,
  * file suffix.
  * @return LY_ERR value (LY_SUCCESS is returned even if the file is not found, then the *localfile is NULL).
  */
-LY_ERR lys_search_localfile(const char * const *searchpaths, uint8_t cwd, const char *name, const char *revision,
+LY_ERR lys_search_localfile(const char * const *searchpaths, ly_bool cwd, const char *name, const char *revision,
         char **localfile, LYS_INFORMAT *format);
 
 /** @} schematree */

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -32,7 +32,8 @@
 static LY_ERR
 lysp_stmt_validate_value(struct lys_parser_ctx *ctx, enum yang_arg val_type, const char *val)
 {
-    uint8_t prefix = 0, first = 1;
+    uint8_t prefix = 0;
+    ly_bool first = 1;
     uint32_t c;
     size_t utf8_char_len;
 

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -139,7 +139,7 @@ buf_add_char(struct ly_ctx *ctx, struct ly_in *in, size_t len, char **buf, size_
  */
 LY_ERR
 buf_store_char(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg, char **word_p, size_t *word_len,
-        char **word_b, size_t *buf_len, uint8_t need_buf, uint8_t *prefix)
+        char **word_b, size_t *buf_len, ly_bool need_buf, uint8_t *prefix)
 {
     uint32_t c;
     size_t len;
@@ -297,7 +297,8 @@ read_qstring(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg ar
      *         5 - string continues after +, skipping whitespaces */
     uint8_t string;
     uint64_t block_indent = 0, current_indent = 0;
-    uint8_t need_buf = 0, prefix = 0;
+    ly_bool need_buf = 0;
+    uint8_t prefix = 0;
     const char *c;
     uint64_t trailing_ws = 0; /* current number of stored trailing whitespace characters */
 

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -174,7 +174,7 @@ ly_type_compare_simple(const struct lyd_value *val1, const struct lyd_value *val
  */
 static const char *
 ly_type_print_simple(const struct lyd_value *value, LY_PREFIX_FORMAT UNUSED(format),
-        void *UNUSED(prefix_data), uint8_t *dynamic)
+        void *UNUSED(prefix_data), ly_bool *dynamic)
 {
     *dynamic = 0;
     return (char *)value->canonical;
@@ -850,7 +850,7 @@ ly_type_store_bits(const struct ly_ctx *ctx, struct lysc_type *type, const char 
     LY_ARRAY_COUNT_TYPE u, v;
     char *errmsg = NULL;
     struct lysc_type_bits *type_bits = (struct lysc_type_bits *)type;
-    uint8_t iscanonical = 1;
+    ly_bool iscanonical = 1;
     size_t ws_count;
     size_t lws_count; /* leading whitespace count */
     const char *can = NULL;
@@ -1186,7 +1186,7 @@ ly_type_identity_isderived(struct lysc_ident *base, struct lysc_ident *der)
 }
 
 static const char *ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        uint8_t *dynamic);
+        ly_bool *dynamic);
 
 /**
  * @brief Validate, canonize and store value of the YANG built-in identiytref type.
@@ -1206,7 +1206,7 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
     LY_ARRAY_COUNT_TYPE u;
     struct lysc_ident *ident = NULL, *identities;
     int rc = 0;
-    uint8_t dyn;
+    ly_bool dyn;
 
     if (options & LY_TYPE_OPTS_SECOND_CALL) {
         return LY_SUCCESS;
@@ -1313,7 +1313,7 @@ ly_type_compare_identityref(const struct lyd_value *val1, const struct lyd_value
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
+ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, ly_bool *dynamic)
 {
     char *result = NULL;
 
@@ -1326,7 +1326,7 @@ ly_type_print_identityref(const struct lyd_value *value, LY_PREFIX_FORMAT format
 }
 
 static const char *ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        uint8_t *dynamic);
+        ly_bool *dynamic);
 
 /**
  * @brief Validate and store value of the YANG built-in instance-identifier type.
@@ -1347,7 +1347,7 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
     const struct lysc_node *ctx_scnode;
     int rc = 0;
     uint32_t prefix_opt = 0;
-    uint8_t dyn;
+    ly_bool dyn;
 
     /* init */
     *err = NULL;
@@ -1376,7 +1376,7 @@ ly_type_store_instanceid(const struct ly_ctx *ctx, struct lysc_type *type, const
         if (ly_path_eval(storage->target, tree, NULL)) {
             /* in error message we print the JSON format of the instance-identifier - in case of XML, it is not possible
              * to get the exactly same string as original, JSON is less demanding and still well readable/understandable. */
-            uint8_t dynamic = 0;
+            ly_bool dynamic = 0;
             const char *id = storage->realtype->plugin->print(storage, LY_PREF_JSON, NULL, &dynamic);
             rc = asprintf(&errmsg, "Invalid instance-identifier \"%s\" value - required instance not found.", id);
             if (dynamic) {
@@ -1523,7 +1523,7 @@ ly_type_compare_instanceid(const struct lyd_value *val1, const struct lyd_value 
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
+ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, ly_bool *dynamic)
 {
     LY_ARRAY_COUNT_TYPE u, v;
     char *result = NULL;
@@ -1550,7 +1550,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LIST:
                 {
                     /* key-predicate */
-                    uint8_t d = 0;
+                    ly_bool d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1566,7 +1566,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LEAFLIST:
                 {
                     /* leaf-list-predicate */
-                    uint8_t d = 0;
+                    ly_bool d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1603,7 +1603,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LIST:
                 {
                     /* key-predicate */
-                    uint8_t d = 0;
+                    ly_bool d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1618,7 +1618,7 @@ ly_type_print_instanceid(const struct lyd_value *value, LY_PREFIX_FORMAT format,
                 case LY_PATH_PREDTYPE_LEAFLIST:
                 {
                     /* leaf-list-predicate */
-                    uint8_t d = 0;
+                    ly_bool d = 0;
                     const char *value = pred->value.realtype->plugin->print(&pred->value, format, prefix_data, &d);
                     char quot = '\'';
                     if (strchr(value, quot)) {
@@ -1676,7 +1676,7 @@ ly_type_find_leafref(const struct lysc_type_leafref *lref, const struct lyd_node
     LY_ERR ret;
     struct lyxp_set set = {0};
     const char *val_str;
-    uint8_t dynamic;
+    ly_bool dynamic;
     uint32_t i;
 
     /* find all target data instances */
@@ -1813,7 +1813,7 @@ ly_type_compare_leafref(const struct lyd_value *val1, const struct lyd_value *va
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_leafref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
+ly_type_print_leafref(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, ly_bool *dynamic)
 {
     return value->realtype->plugin->print(value, format, prefix_data, dynamic);
 }
@@ -2189,7 +2189,7 @@ ly_type_compare_union(const struct lyd_value *val1, const struct lyd_value *val2
  * Implementation of the ly_type_print_clb.
  */
 static const char *
-ly_type_print_union(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, uint8_t *dynamic)
+ly_type_print_union(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data, ly_bool *dynamic)
 {
     return value->subvalue->value->realtype->plugin->print(value->subvalue->value, format, prefix_data, dynamic);
 }

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -234,7 +234,7 @@ typedef LY_ERR (*ly_type_compare_clb)(const struct lyd_value *val1, const struct
  * @return NULL in case of error.
  */
 typedef const char *(*ly_type_print_clb)(const struct lyd_value *value, LY_PREFIX_FORMAT format, void *prefix_data,
-        uint8_t *dynamic);
+        ly_bool *dynamic);
 
 /**
  * @brief Callback to duplicate data in data structure. Note that callback is even responsible for duplicating lyd_value::canonized.

--- a/src/printer.c
+++ b/src/printer.c
@@ -71,7 +71,7 @@ struct ext_substmt_info_s ext_substmt_info[] = {
     {"unique", "tag", 0},                       /**< LYEXT_SUBSTMT_UNIQUE */
 };
 
-uint8_t
+ly_bool
 ly_is_default(const struct lyd_node *node)
 {
     const struct lysc_node_leaf *leaf;
@@ -109,7 +109,7 @@ ly_is_default(const struct lyd_node *node)
     return 1;
 }
 
-uint8_t
+ly_bool
 ly_should_print(const struct lyd_node *node, uint32_t options)
 {
     const struct lyd_node *elem;
@@ -429,7 +429,7 @@ ly_out_filepath(struct ly_out *out, const char *filepath)
 }
 
 API void
-ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), uint8_t destroy)
+ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), ly_bool destroy)
 {
     if (!out) {
         return;

--- a/src/printer.h
+++ b/src/printer.h
@@ -237,7 +237,7 @@ size_t ly_out_printed(const struct ly_out *out);
  * @param[in] destroy Flag to free allocated buffer (for LY_OUT_MEMORY) or to
  * close stream/file descriptor (for LY_OUT_FD, LY_OUT_FDSTREAM and LY_OUT_FILE)
  */
-void ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), uint8_t destroy);
+void ly_out_free(struct ly_out *out, void (*clb_arg_destructor)(void *arg), ly_bool destroy);
 
 #ifdef __cplusplus
 }

--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -188,20 +188,18 @@ LY_ERR lyb_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t 
  * @brief Check whether a node value equals to its default one.
  *
  * @param[in] node Term node to test.
- * @return 0 if no,
- * @return 1 if yes.
+ * @return false (no, it is not a default node) or true (yes, it is default)
  */
-uint8_t ly_is_default(const struct lyd_node *node);
+ly_bool ly_is_default(const struct lyd_node *node);
 
 /**
  * @brief Check whether the node should even be printed.
  *
  * @param[in] node Node to check.
  * @param[in] options Printer options.
- * @return 0 if no.
- * @return 1 if yes.
+ * @return false (no, it should not be printed) or true (yes, it is supposed to be printed)
  */
-uint8_t ly_should_print(const struct lyd_node *node, uint32_t options);
+ly_bool ly_should_print(const struct lyd_node *node, uint32_t options);
 
 /**
  * @brief Generic printer of the given format string into the specified output.

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -261,7 +261,7 @@ json_print_string(struct ly_out *out, const char *text)
  * @return LY_ERR value.
  */
 static LY_ERR
-json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, uint8_t is_attr)
+json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, ly_bool is_attr)
 {
     PRINT_COMMA;
     if (LEVEL == 1 || json_nscmp(node, (const struct lyd_node *)node->parent)) {
@@ -289,7 +289,7 @@ json_print_member(struct jsonpr_ctx *ctx, const struct lyd_node *node, uint8_t i
  */
 static LY_ERR
 json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FORMAT format,
-        const struct ly_prefix *prefix, const char *name, uint8_t is_attr)
+        const struct ly_prefix *prefix, const char *name, ly_bool is_attr)
 {
     const char *module_name = NULL;
 
@@ -336,7 +336,7 @@ json_print_member2(struct jsonpr_ctx *ctx, const struct lyd_node *parent, LYD_FO
 static LY_ERR
 json_print_value(struct jsonpr_ctx *ctx, const struct lyd_value *val)
 {
-    uint8_t dynamic = 0;
+    ly_bool dynamic = 0;
     const char *value = val->realtype->plugin->print(val, LY_PREF_JSON, NULL, &dynamic);
 
     /* leafref is not supported */
@@ -447,11 +447,11 @@ json_print_metadata(struct jsonpr_ctx *ctx, const struct lyd_node *node, const s
  *
  * @param[in] ctx JSON printer context.
  * @param[in] node Data node where the attributes/metadata are placed.
- * @param[in] wdmod With-defaults module to mark that default attribute is supposed to be printed.
+ * @param[in] inner Flag if the @p node is an inner node in the tree.
  * @return LY_ERR value.
  */
 static LY_ERR
-json_print_attributes(struct jsonpr_ctx *ctx, const struct lyd_node *node, uint8_t inner)
+json_print_attributes(struct jsonpr_ctx *ctx, const struct lyd_node *node, ly_bool inner)
 {
     const struct lys_module *wdmod = NULL;
 
@@ -592,7 +592,7 @@ json_print_inner(struct jsonpr_ctx *ctx, const struct lyd_node *node)
 {
     struct lyd_node *child;
     struct lyd_node *children = lyd_node_children(node, 0);
-    uint8_t has_content = 0;
+    ly_bool has_content = 0;
 
     if (node->meta || children) {
         has_content = 1;
@@ -752,7 +752,7 @@ json_print_metadata_leaflist(struct jsonpr_ctx *ctx)
 static LY_ERR
 json_print_opaq(struct jsonpr_ctx *ctx, const struct lyd_node_opaq *node)
 {
-    uint8_t first = 1, last = 1;
+    ly_bool first = 1, last = 1;
 
     if (node->hint & LYD_NODE_OPAQ_ISLIST) {
         const struct lyd_node_opaq *prev = (const struct lyd_node_opaq *)node->prev;

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -38,9 +38,11 @@
 
 /**
  * @brief Hash table equal callback for checking hash equality only.
+ *
+ * Implementation of ::values_equal_cb.
  */
-static uint8_t
-lyb_hash_equal_cb(void *UNUSED(val1_p), void *UNUSED(val2_p), uint8_t UNUSED(mod), void *UNUSED(cb_data))
+static ly_bool
+lyb_hash_equal_cb(void *UNUSED(val1_p), void *UNUSED(val2_p), ly_bool UNUSED(mod), void *UNUSED(cb_data))
 {
     /* for this purpose, if hash matches, the value does also, we do not want 2 values to have the same hash */
     return 1;
@@ -48,9 +50,11 @@ lyb_hash_equal_cb(void *UNUSED(val1_p), void *UNUSED(val2_p), uint8_t UNUSED(mod
 
 /**
  * @brief Hash table equal callback for checking value pointer equality only.
+ *
+ * Implementation of ::values_equal_cb.
  */
-static uint8_t
-lyb_ptr_equal_cb(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *UNUSED(cb_data))
+static ly_bool
+lyb_ptr_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UNUSED(cb_data))
 {
     struct lysc_node *val1 = *(struct lysc_node **)val1_p;
     struct lysc_node *val2 = *(struct lysc_node **)val2_p;
@@ -379,7 +383,7 @@ lyb_write_number(uint64_t num, size_t bytes, struct ly_out *out, struct lylyb_ct
  * @return LY_ERR value.
  */
 static LY_ERR
-lyb_write_string(const char *str, size_t str_len, uint8_t with_length, struct ly_out *out, struct lylyb_ctx *lybctx)
+lyb_write_string(const char *str, size_t str_len, ly_bool with_length, struct ly_out *out, struct lylyb_ctx *lybctx)
 {
     if (!str) {
         str = "";

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -140,11 +140,11 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
     const char **prefs, **nss;
     const char *xml_expr = NULL, *mod_name;
     uint32_t ns_count, i;
-    uint8_t rpc_filter = 0;
+    ly_bool rpc_filter = 0;
     char *p;
     size_t len;
 #endif
-    uint8_t dynamic;
+    ly_bool dynamic;
 
     /* with-defaults */
     if (node->schema->nodetype & LYD_NODE_TERM) {
@@ -288,7 +288,7 @@ static void
 xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
 {
     struct ly_set ns_list = {0};
-    uint8_t dynamic;
+    ly_bool dynamic;
     const char *value;
 
     xml_print_node_open(ctx, (struct lyd_node *)node);

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -122,7 +122,7 @@ ypr_encode(struct ly_out *out, const char *text, ssize_t len)
 }
 
 static void
-ypr_open(struct ly_out *out, uint8_t *flag)
+ypr_open(struct ly_out *out, ly_bool *flag)
 {
     if (flag && !*flag) {
         *flag = 1;
@@ -131,7 +131,7 @@ ypr_open(struct ly_out *out, uint8_t *flag)
 }
 
 static void
-ypr_close(struct ypr_ctx *ctx, uint8_t flag)
+ypr_close(struct ypr_ctx *ctx, ly_bool flag)
 {
     if (flag) {
         ly_print_(ctx->out, "%*s}\n", INDENT);
@@ -141,7 +141,7 @@ ypr_close(struct ypr_ctx *ctx, uint8_t flag)
 }
 
 static void
-ypr_text(struct ypr_ctx *ctx, const char *name, const char *text, uint8_t singleline, uint8_t closed)
+ypr_text(struct ypr_ctx *ctx, const char *name, const char *text, ly_bool singleline, ly_bool closed)
 {
     const char *s, *t;
 
@@ -219,11 +219,11 @@ yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
  */
 static void
 yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
-        struct lysp_ext_instance *ext, uint8_t *flag, LY_ARRAY_COUNT_TYPE count)
+        struct lysp_ext_instance *ext, ly_bool *flag, LY_ARRAY_COUNT_TYPE count)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_stmt *stmt;
-    uint8_t child_presence;
+    ly_bool child_presence;
     const char *argument;
 
     if (!count && ext) {
@@ -285,7 +285,7 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
  */
 static void
 yprc_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
-        struct lysc_ext_instance *ext, uint8_t *flag, LY_ARRAY_COUNT_TYPE count)
+        struct lysc_ext_instance *ext, ly_bool *flag, LY_ARRAY_COUNT_TYPE count)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -310,7 +310,7 @@ static void
 ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, const char *text, void *ext)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t extflag = 0;
+    ly_bool extflag = 0;
 
     if (!text) {
         /* nothing to print */
@@ -340,7 +340,7 @@ ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, c
 }
 
 static void
-ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned long int attr_value, uint8_t *flag)
+ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned long int attr_value, ly_bool *flag)
 {
     char *str;
 
@@ -354,7 +354,7 @@ ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, 
 }
 
 static void
-ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed long int attr_value, uint8_t *flag)
+ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed long int attr_value, ly_bool *flag)
 {
     char *str;
 
@@ -384,7 +384,7 @@ yprp_revision(struct ypr_ctx *ctx, const struct lysp_revision *rev)
 }
 
 static void
-ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
+ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, ly_bool *flag)
 {
     if (flags & LYS_MAND_MASK) {
         ypr_open(ctx->out, flag);
@@ -393,7 +393,7 @@ ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
 }
 
 static void
-ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
+ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, ly_bool *flag)
 {
     if (flags & LYS_CONFIG_MASK) {
         ypr_open(ctx->out, flag);
@@ -402,7 +402,7 @@ ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
 }
 
 static void
-ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
+ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, ly_bool *flag)
 {
     const char *status = NULL;
 
@@ -421,7 +421,7 @@ ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, uint8_t *flag)
 }
 
 static void
-ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, uint8_t *flag)
+ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, ly_bool *flag)
 {
     if (dsc) {
         ypr_open(ctx->out, flag);
@@ -430,7 +430,7 @@ ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, uint8_t *flag)
 }
 
 static void
-ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, uint8_t *flag)
+ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, ly_bool *flag)
 {
     if (ref) {
         ypr_open(ctx->out, flag);
@@ -439,10 +439,10 @@ ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, uint8_t *flag)
 }
 
 static void
-yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance *exts, uint8_t *flag)
+yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance *exts, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t extflag;
+    ly_bool extflag;
 
     LY_ARRAY_FOR(iff, u) {
         ypr_open(ctx->out, flag);
@@ -466,7 +466,7 @@ yprp_iffeatures(struct ypr_ctx *ctx, const char **iff, struct lysp_ext_instance 
 static void
 yprc_iffeature(struct ypr_ctx *ctx, struct lysc_iffeature *feat, size_t *index_e, size_t *index_f)
 {
-    uint8_t brackets_flag = *index_e ? 1 : 0;
+    ly_bool brackets_flag = *index_e ? 1 : 0;
     uint8_t op;
 
     op = lysc_iff_getop(feat->expr, *index_e);
@@ -507,10 +507,10 @@ yprc_iffeature(struct ypr_ctx *ctx, struct lysc_iffeature *feat, size_t *index_e
 }
 
 static void
-yprc_iffeatures(struct ypr_ctx *ctx, struct lysc_iffeature *iff, struct lysc_ext_instance *exts, uint8_t *flag)
+yprc_iffeatures(struct ypr_ctx *ctx, struct lysc_iffeature *iff, struct lysc_ext_instance *exts, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u, v;
-    uint8_t extflag;
+    ly_bool extflag;
 
     LY_ARRAY_FOR(iff, u) {
         size_t index_e = 0, index_f = 0;
@@ -538,7 +538,7 @@ yprc_iffeatures(struct ypr_ctx *ctx, struct lysc_iffeature *iff, struct lysc_ext
 static void
 yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 {
-    uint8_t flag = 0, flag2 = 0;
+    ly_bool flag = 0, flag2 = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     ly_print_(ctx->out, "%*sextension %s", INDENT, ext->name);
@@ -578,7 +578,7 @@ yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 static void
 yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
     LEVEL++;
@@ -594,7 +594,7 @@ yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 static void
 yprc_feature(struct ypr_ctx *ctx, const struct lysc_feature *feat)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "\n%*sfeature %s", INDENT, feat->name);
     LEVEL++;
@@ -610,7 +610,7 @@ yprc_feature(struct ypr_ctx *ctx, const struct lysc_feature *feat)
 static void
 yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     ly_print_(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
@@ -635,7 +635,7 @@ yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
 static void
 yprc_identity(struct ypr_ctx *ctx, const struct lysc_ident *ident)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     ly_print_(ctx->out, "\n%*sidentity %s", INDENT, ident->name);
@@ -662,9 +662,9 @@ yprc_identity(struct ypr_ctx *ctx, const struct lysc_ident *ident)
 }
 
 static void
-yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, uint8_t *flag)
+yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
 
     if (!restr) {
         return;
@@ -698,9 +698,9 @@ yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name
 }
 
 static void
-yprc_must(struct ypr_ctx *ctx, const struct lysc_must *must, uint8_t *flag)
+yprc_must(struct ypr_ctx *ctx, const struct lysc_must *must, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
 
     ypr_open(ctx->out, flag);
     ly_print_(ctx->out, "%*smust \"", INDENT);
@@ -725,9 +725,9 @@ yprc_must(struct ypr_ctx *ctx, const struct lysc_must *must, uint8_t *flag)
 }
 
 static void
-yprc_range(struct ypr_ctx *ctx, const struct lysc_range *range, LY_DATA_TYPE basetype, uint8_t *flag)
+yprc_range(struct ypr_ctx *ctx, const struct lysc_range *range, LY_DATA_TYPE basetype, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
     LY_ARRAY_COUNT_TYPE u;
 
     if (!range) {
@@ -774,9 +774,9 @@ yprc_range(struct ypr_ctx *ctx, const struct lysc_range *range, LY_DATA_TYPE bas
 }
 
 static void
-yprc_pattern(struct ypr_ctx *ctx, const struct lysc_pattern *pattern, uint8_t *flag)
+yprc_pattern(struct ypr_ctx *ctx, const struct lysc_pattern *pattern, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
 
     ypr_open(ctx->out, flag);
     ly_print_(ctx->out, "%*spattern \"", INDENT);
@@ -806,9 +806,9 @@ yprc_pattern(struct ypr_ctx *ctx, const struct lysc_pattern *pattern, uint8_t *f
 }
 
 static void
-yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, uint8_t *flag)
+yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
 
     if (!when) {
         return;
@@ -828,9 +828,9 @@ yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, uint8_t *flag)
 }
 
 static void
-yprc_when(struct ypr_ctx *ctx, struct lysc_when *when, uint8_t *flag)
+yprc_when(struct ypr_ctx *ctx, struct lysc_when *when, ly_bool *flag)
 {
-    uint8_t inner_flag = 0;
+    ly_bool inner_flag = 0;
 
     if (!when) {
         return;
@@ -850,10 +850,10 @@ yprc_when(struct ypr_ctx *ctx, struct lysc_when *when, uint8_t *flag)
 }
 
 static void
-yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, uint8_t *flag)
+yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t inner_flag;
+    ly_bool inner_flag;
 
     LY_ARRAY_FOR(items, u) {
         ypr_open(ctx->out, flag);
@@ -887,7 +887,7 @@ static void
 yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "%*stype %s", INDENT, type->name);
     LEVEL++;
@@ -929,7 +929,7 @@ yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
 static void
 yprc_dflt_value(struct ypr_ctx *ctx, const struct lyd_value *value, struct lysc_ext_instance *exts)
 {
-    uint8_t dynamic;
+    ly_bool dynamic;
     const char *str;
 
     str = value->realtype->plugin->print(value, LY_PREF_JSON, NULL, &dynamic);
@@ -943,7 +943,7 @@ static void
 yprc_type(struct ypr_ctx *ctx, const struct lysc_type *type)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "%*stype %s", INDENT, lys_datatype2str(type->basetype));
     LEVEL++;
@@ -982,7 +982,7 @@ yprc_type(struct ypr_ctx *ctx, const struct lysc_type *type)
         struct lysc_type_bits *bits = (struct lysc_type_bits *)type;
         LY_ARRAY_FOR(bits->bits, u) {
             struct lysc_type_bitenum_item *item = &bits->bits[u];
-            uint8_t inner_flag = 0;
+            ly_bool inner_flag = 0;
 
             ypr_open(ctx->out, &flag);
             ly_print_(ctx->out, "%*s%s \"", INDENT, type->basetype == LY_TYPE_BITS ? "bit" : "enum");
@@ -1086,7 +1086,7 @@ static void
 yprp_grouping(struct ypr_ctx *ctx, const struct lysp_grp *grp)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *data;
 
     ly_print_(ctx->out, "\n%*sgrouping %s", INDENT, grp->name);
@@ -1121,7 +1121,7 @@ yprp_grouping(struct ypr_ctx *ctx, const struct lysp_grp *grp)
 }
 
 static void
-yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, uint8_t *flag)
+yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node *data;
@@ -1155,7 +1155,7 @@ yprp_inout(struct ypr_ctx *ctx, const struct lysp_action_inout *inout, uint8_t *
 }
 
 static void
-yprc_inout(struct ypr_ctx *ctx, const struct lysc_action *action, const struct lysc_action_inout *inout, uint8_t *flag)
+yprc_inout(struct ypr_ctx *ctx, const struct lysc_action *action, const struct lysc_action_inout *inout, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysc_node *data;
@@ -1188,7 +1188,7 @@ static void
 yprp_notification(struct ypr_ctx *ctx, const struct lysp_notif *notif)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *data;
 
     ly_print_(ctx->out, "%*snotification %s", INDENT, notif->name);
@@ -1227,7 +1227,7 @@ static void
 yprc_notification(struct ypr_ctx *ctx, const struct lysc_notif *notif)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node *data;
 
     ly_print_(ctx->out, "%*snotification %s", INDENT, notif->name);
@@ -1258,7 +1258,7 @@ static void
 yprp_action(struct ypr_ctx *ctx, const struct lysp_action *action)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
 
@@ -1289,7 +1289,7 @@ yprp_action(struct ypr_ctx *ctx, const struct lysp_action *action)
 static void
 yprc_action(struct ypr_ctx *ctx, const struct lysc_action *action)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "%*s%s %s", INDENT, action->parent ? "action" : "rpc", action->name);
 
@@ -1308,7 +1308,7 @@ yprc_action(struct ypr_ctx *ctx, const struct lysc_action *action)
 }
 
 static void
-yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, uint8_t *flag)
+yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, ly_bool *flag)
 {
     ly_print_(ctx->out, "%*s%s %s%s", INDENT, lys_nodetype2str(node->nodetype), node->name, flag ? "" : " {\n");
     LEVEL++;
@@ -1319,7 +1319,7 @@ yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, uint8_t *fl
 }
 
 static void
-yprc_node_common1(struct ypr_ctx *ctx, const struct lysc_node *node, uint8_t *flag)
+yprc_node_common1(struct ypr_ctx *ctx, const struct lysc_node *node, ly_bool *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -1344,13 +1344,13 @@ yprc_node_common1(struct ypr_ctx *ctx, const struct lysc_node *node, uint8_t *fl
     ypr_reference(ctx, node->ref, node->exts, flag)
 
 static void
-yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, uint8_t *flag)
+yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, ly_bool *flag)
 {
     YPR_NODE_COMMON2;
 }
 
 static void
-yprc_node_common2(struct ypr_ctx *ctx, const struct lysc_node *node, uint8_t *flag)
+yprc_node_common2(struct ypr_ctx *ctx, const struct lysc_node *node, ly_bool *flag)
 {
     YPR_NODE_COMMON2;
 }
@@ -1361,7 +1361,7 @@ static void
 yprp_container(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *child;
     struct lysp_node_container *cont = (struct lysp_node_container *)node;
 
@@ -1410,7 +1410,7 @@ static void
 yprc_container(struct ypr_ctx *ctx, const struct lysc_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node *child;
     struct lysc_node_container *cont = (struct lysc_node_container *)node;
 
@@ -1450,7 +1450,7 @@ yprc_container(struct ypr_ctx *ctx, const struct lysc_node *node)
 static void
 yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *child;
     struct lysp_node_case *cas = (struct lysp_node_case *)node;
 
@@ -1469,7 +1469,7 @@ yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
 static void
 yprc_case(struct ypr_ctx *ctx, const struct lysc_node_case *cs)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node *child;
 
     yprc_node_common1(ctx, (struct lysc_node *)cs, &flag);
@@ -1489,7 +1489,7 @@ yprc_case(struct ypr_ctx *ctx, const struct lysc_node_case *cs)
 static void
 yprp_choice(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *child;
     struct lysp_node_choice *choice = (struct lysp_node_choice *)node;
 
@@ -1514,7 +1514,7 @@ yprp_choice(struct ypr_ctx *ctx, const struct lysp_node *node)
 static void
 yprc_choice(struct ypr_ctx *ctx, const struct lysc_node *node)
 {
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node_case *cs;
     struct lysc_node_choice *choice = (struct lysc_node_choice *)node;
 
@@ -1663,7 +1663,7 @@ static void
 yprp_list(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node *child;
     struct lysp_node_list *list = (struct lysp_node_list *)node;
 
@@ -1735,7 +1735,7 @@ static void
 yprc_list(struct ypr_ctx *ctx, const struct lysc_node *node)
 {
     LY_ARRAY_COUNT_TYPE u, v;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node *child;
     struct lysc_node_list *list = (struct lysc_node_list *)node;
 
@@ -1801,7 +1801,7 @@ static void
 yprp_refine(struct ypr_ctx *ctx, struct lysp_refine *refine)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
 
     ly_print_(ctx->out, "%*srefine \"%s\"", INDENT, refine->nodeid);
     LEVEL++;
@@ -1883,7 +1883,7 @@ static void
 yprp_uses(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node_uses *uses = (struct lysp_node_uses *)node;
 
     yprp_node_common1(ctx, node, &flag);
@@ -1907,7 +1907,7 @@ static void
 yprp_anydata(struct ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysp_node_anydata *any = (struct lysp_node_anydata *)node;
 
     yprp_node_common1(ctx, node, &flag);
@@ -1927,7 +1927,7 @@ static void
 yprc_anydata(struct ypr_ctx *ctx, const struct lysc_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
-    uint8_t flag = 0;
+    ly_bool flag = 0;
     struct lysc_node_anydata *any = (struct lysc_node_anydata *)node;
 
     yprc_node_common1(ctx, node, &flag);

--- a/src/set.c
+++ b/src/set.c
@@ -75,7 +75,7 @@ ly_set_free(struct ly_set *set, void (*destructor)(void *obj))
     free(set);
 }
 
-API uint8_t
+API ly_bool
 ly_set_contains(const struct ly_set *set, void *object, uint32_t *index_p)
 {
     LY_CHECK_ARG_RET(NULL, set, 0);

--- a/src/set.h
+++ b/src/set.h
@@ -121,9 +121,9 @@ LY_ERR ly_set_merge(struct ly_set *trg, struct ly_set *src, uint32_t options, vo
  * @param[in] set Set to explore.
  * @param[in] object Object to be found in the set.
  * @param[out] index_p Optional pointer to return index of the searched @p object.
- * @return Boolean value (0 is false) if the @p object was found in the @p set.
+ * @return Boolean value whether the @p object was found in the @p set.
  */
-uint8_t ly_set_contains(const struct ly_set *set, void *object, uint32_t *index_p);
+ly_bool ly_set_contains(const struct ly_set *set, void *object, uint32_t *index_p);
 
 /**
  * @brief Remove all objects from the set, but keep the set container for further use.

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -54,7 +54,7 @@ static LY_ERR lyd_find_sibling_schema(const struct lyd_node *siblings, const str
         struct lyd_node **match);
 
 LY_ERR
-lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, uint8_t *dynamic, uint8_t second,
+lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, ly_bool *dynamic, ly_bool second,
         uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -91,7 +91,7 @@ error:
 
 /* similar to lyd_value_parse except can be used just to store the value, hence also does not support a second call */
 LY_ERR
-lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic,
+lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len, ly_bool *dynamic,
         LY_PREFIX_FORMAT format, void *prefix_data)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -122,8 +122,8 @@ lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const cha
 }
 
 LY_ERR
-lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len, uint8_t *dynamic,
-        uint8_t second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode,
+lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len, ly_bool *dynamic,
+        ly_bool second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode,
         const struct lyd_node *tree)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -533,7 +533,7 @@ lyd_parse_notif(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, s
 }
 
 LY_ERR
-lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
+lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node)
 {
     LY_ERR ret;
@@ -693,7 +693,7 @@ lyd_create_any(const struct lysc_node *schema, const void *value, LYD_ANYDATA_VA
 
 LY_ERR
 lyd_create_opaq(const struct ly_ctx *ctx, const char *name, size_t name_len, const char *value, size_t value_len,
-        uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix, size_t pref_len,
+        ly_bool *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix, size_t pref_len,
         const char *module_key, size_t module_key_len, struct lyd_node **node)
 {
     struct lyd_node_opaq *opaq;
@@ -1087,7 +1087,7 @@ lyd_change_term(struct lyd_node *term, const char *val_str)
     struct lyd_node_term *t;
     struct lyd_node *parent;
     struct lyd_value val = {0};
-    uint8_t dflt_change, val_change;
+    ly_bool dflt_change, val_change;
 
     LY_CHECK_ARG_RET(NULL, term, term->schema, term->schema->nodetype & LYD_NODE_TERM, LY_EINVAL);
 
@@ -1163,7 +1163,7 @@ lyd_change_meta(struct lyd_meta *meta, const char *val_str)
     LY_ERR ret = LY_SUCCESS;
     struct lyd_meta *m2;
     struct lyd_value val;
-    uint8_t val_change;
+    ly_bool val_change;
 
     LY_CHECK_ARG_RET(NULL, meta, LY_EINVAL);
 
@@ -1601,7 +1601,7 @@ lyd_insert_get_next_anchor(const struct lyd_node *first_sibling, const struct ly
 {
     const struct lysc_node *schema, *sparent;
     struct lyd_node *match = NULL;
-    uint8_t found;
+    ly_bool found;
 
     assert(new_node);
 
@@ -2118,7 +2118,7 @@ lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta)
 
 LY_ERR
 lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
-        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LY_PREFIX_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint, LY_PREFIX_FORMAT format,
         void *prefix_data, const struct lysc_node *ctx_snode)
 {
     LY_ERR ret;
@@ -2196,7 +2196,7 @@ lyd_insert_attr(struct lyd_node *parent, struct lyd_attr *attr)
 
 LY_ERR
 lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const struct ly_ctx *ctx, const char *name,
-        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint, LYD_FORMAT format,
         struct ly_prefix *val_prefs, const char *prefix, size_t prefix_len, const char *module_key, size_t module_key_len)
 {
     struct lyd_attr *at, *last;
@@ -2614,7 +2614,7 @@ lyd_dup_get_local_parent(const struct lyd_node *node, const struct lyd_node_inne
         struct lyd_node_inner **local_parent)
 {
     const struct lyd_node_inner *orig_parent, *iter;
-    uint8_t repeat = 1;
+    ly_bool repeat = 1;
 
     *dup_parent = NULL;
     *local_parent = NULL;
@@ -2660,7 +2660,7 @@ lyd_dup_get_local_parent(const struct lyd_node *node, const struct lyd_node_inne
 }
 
 static LY_ERR
-lyd_dup(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, uint8_t  nosiblings, struct lyd_node **dup)
+lyd_dup(const struct lyd_node *node, struct lyd_node_inner *parent, uint32_t options, ly_bool nosiblings, struct lyd_node **dup)
 {
     LY_ERR rc;
     const struct lyd_node *orig;          /* original node to be duplicated */
@@ -2828,10 +2828,10 @@ lyd_merge_sibling_r(struct lyd_node **first_trg, struct lyd_node *parent_trg, co
 }
 
 static LY_ERR
-lyd_merge(struct lyd_node **target, const struct lyd_node *source, uint16_t options, uint8_t nosiblings)
+lyd_merge(struct lyd_node **target, const struct lyd_node *source, uint16_t options, ly_bool nosiblings)
 {
     const struct lyd_node *sibling_src, *tmp;
-    uint8_t first;
+    ly_bool first;
 
     LY_CHECK_ARG_RET(NULL, target, LY_EINVAL);
 
@@ -2846,7 +2846,7 @@ lyd_merge(struct lyd_node **target, const struct lyd_node *source, uint16_t opti
     }
 
     LY_LIST_FOR_SAFE(source, tmp, sibling_src) {
-        first = sibling_src == source ? 1 : 0;
+        first = (sibling_src == source) ? 1 : 0;
         LY_CHECK_RET(lyd_merge_sibling_r(target, NULL, &sibling_src, options));
         if (first && !sibling_src) {
             /* source was spent (unlinked), move to the next node */
@@ -2879,7 +2879,7 @@ lyd_merge_siblings(struct lyd_node **target, const struct lyd_node *source, uint
 }
 
 static LY_ERR
-lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, uint8_t is_static)
+lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, ly_bool is_static)
 {
     /* ending \0 */
     ++reqlen;
@@ -2901,7 +2901,7 @@ lyd_path_str_enlarge(char **buffer, size_t *buflen, size_t reqlen, uint8_t is_st
 }
 
 LY_ERR
-lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
+lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, ly_bool is_static)
 {
     const struct lyd_node *key;
     size_t len;
@@ -2934,7 +2934,7 @@ lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *bufl
  * @return LY_ERR
  */
 static LY_ERR
-lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
+lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, ly_bool is_static)
 {
     size_t len;
     const char *val;
@@ -2964,7 +2964,7 @@ lyd_path_leaflist_predicate(const struct lyd_node *node, char **buffer, size_t *
  * @return LY_ERR
  */
 static LY_ERR
-lyd_path_position_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static)
+lyd_path_position_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, ly_bool is_static)
 {
     const struct lyd_node *first, *iter;
     size_t len;
@@ -3003,7 +3003,7 @@ cleanup:
 API char *
 lyd_path(const struct lyd_node *node, LYD_PATH_TYPE pathtype, char *buffer, size_t buflen)
 {
-    uint8_t is_static = 0;
+    ly_bool is_static = 0;
     uint32_t i, depth;
     size_t bufused = 0, len;
     const struct lyd_node *iter;
@@ -3192,8 +3192,15 @@ lyd_find_sibling_first(const struct lyd_node *siblings, const struct lyd_node *t
     return LY_SUCCESS;
 }
 
-static uint8_t
-lyd_hash_table_schema_val_equal(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *UNUSED(cb_data))
+/**
+ * @brief Comparison callback to match schema node with a schema of a data node.
+ *
+ * @param[in] val1_p Pointer to the schema node
+ * @param[in] val2_p Pointer to the data node
+ * Implementation of ::values_equal_cb.
+ */
+static ly_bool
+lyd_hash_table_schema_val_equal(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UNUSED(cb_data))
 {
     struct lysc_node *val1;
     struct lyd_node *val2;

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -89,7 +89,7 @@ struct lysc_node;
  * @param ELEM Iterator intended for use in the block.
  */
 #define LYD_TREE_DFS_BEGIN(START, ELEM) \
-    { uint8_t LYD_TREE_DFS_continue = 0; struct lyd_node *LYD_TREE_DFS_next; \
+    { ly_bool LYD_TREE_DFS_continue = 0; struct lyd_node *LYD_TREE_DFS_next; \
     for ((ELEM) = (LYD_TREE_DFS_next) = (struct lyd_node *)(START); \
          (ELEM); \
          (ELEM) = (LYD_TREE_DFS_next), LYD_TREE_DFS_continue = 0)

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -23,7 +23,7 @@
 #include "plugins_types.h"
 
 static void
-lyd_free_meta(struct lyd_meta *meta, uint8_t siblings)
+lyd_free_meta(struct lyd_meta *meta, ly_bool siblings)
 {
     struct lyd_meta *iter;
 
@@ -77,7 +77,7 @@ lyd_free_meta_siblings(struct lyd_meta *meta)
 }
 
 static void
-ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, uint8_t siblings)
+ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, ly_bool siblings)
 {
     struct lyd_attr *iter;
     LY_ARRAY_COUNT_TYPE u;
@@ -157,7 +157,7 @@ ly_free_val_prefs(const struct ly_ctx *ctx, struct ly_prefix *val_prefs)
  * @param[in] top Recursion flag to unlink the root of the subtree being freed.
  */
 static void
-lyd_free_subtree(struct lyd_node *node, uint8_t top)
+lyd_free_subtree(struct lyd_node *node, ly_bool top)
 {
     struct lyd_node *iter, *next;
     struct lyd_node *children;
@@ -222,7 +222,7 @@ lyd_free_tree(struct lyd_node *node)
 }
 
 static void
-lyd_free_(struct lyd_node *node, uint8_t top)
+lyd_free_(struct lyd_node *node, ly_bool top)
 {
     struct lyd_node *iter, *next;
 

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -83,8 +83,13 @@ lyd_hash(struct lyd_node *node)
     return LY_SUCCESS;
 }
 
-static uint8_t
-lyd_hash_table_val_equal(void *val1_p, void *val2_p, uint8_t mod, void *UNUSED(cb_data))
+/**
+ * @brief Compare callback for values in hash table.
+ *
+ * Implementation of ::values_equal_cb.
+ */
+static ly_bool
+lyd_hash_table_val_equal(void *val1_p, void *val2_p, ly_bool mod, void *UNUSED(cb_data))
 {
     struct lyd_node *val1, *val2;
 
@@ -120,7 +125,7 @@ lyd_hash_table_val_equal(void *val1_p, void *val2_p, uint8_t mod, void *UNUSED(c
  * @return LY_ERR value.
  */
 static LY_ERR
-lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, uint8_t empty_ht)
+lyd_insert_hash_add(struct hash_table *ht, struct lyd_node *node, ly_bool empty_ht)
 {
     uint32_t hash;
 

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -339,7 +339,7 @@ lyb_hash(struct lysc_node *sibling, uint8_t collision_id)
     return hash;
 }
 
-uint8_t
+ly_bool
 lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models)
 {
     LY_ARRAY_COUNT_TYPE u;

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -15,6 +15,7 @@
 #ifndef LY_TREE_DATA_INTERNAL_H_
 #define LY_TREE_DATA_INTERNAL_H_
 
+#include "log.h"
 #include "lyb.h"
 #include "plugins_types.h"
 #include "set.h"
@@ -42,15 +43,14 @@ struct lysc_module;
 LYB_HASH lyb_hash(struct lysc_node *sibling, uint8_t collision_id);
 
 /**
- * @brief Check whether a sibling module is in a module array.
+ * @brief Check whether a sibling's module is in a module array.
  *
  * @param[in] sibling Sibling to check.
  * @param[in] models Modules in a sized array.
  * @return non-zero if the module was found,
- * @return 0 if not found.
- * @return 1 if found.
+ * @return Boolean value whether @p sibling's module found in the given @p models array.
  */
-uint8_t lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models);
+ly_bool lyb_has_schema_model(const struct lysc_node *sibling, const struct lys_module **models);
 
 /**
  * @brief Check whether a node to be deleted is the first top-level sibling.
@@ -103,7 +103,7 @@ struct lyd_node *lys_getnext_data(const struct lyd_node *last, const struct lyd_
  * @return LY_EINCOMPLETE in case data tree is needed to finish the validation.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
+LY_ERR lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, struct lyd_node **node);
 
 /**
@@ -182,7 +182,7 @@ LY_ERR lyd_create_any(const struct lysc_node *schema, const void *value, LYD_ANY
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_opaq(const struct ly_ctx *ctx, const char *name, size_t name_len, const char *value, size_t value_len,
-        uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix,
+        ly_bool *dynamic, uint32_t value_hint, LYD_FORMAT format, struct ly_prefix *val_prefs, const char *prefix,
         size_t pref_len, const char *module_key, size_t module_key_len, struct lyd_node **node);
 
 /**
@@ -249,7 +249,7 @@ void lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
-        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint,
+        size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint,
         LY_PREFIX_FORMAT format, void *prefix_data, const struct lysc_node *ctx_snode);
 
 /**
@@ -282,7 +282,7 @@ void lyd_insert_attr(struct lyd_node *parent, struct lyd_attr *attr);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const struct ly_ctx *ctx, const char *name,
-        size_t name_len, const char *value, size_t value_len, uint8_t *dynamic, uint32_t value_hint, LYD_FORMAT format,
+        size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, uint32_t value_hint, LYD_FORMAT format,
         struct ly_prefix *val_prefs, const char *prefix, size_t prefix_len, const char *module_key, size_t module_key_len);
 
 /**
@@ -316,12 +316,12 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @return LY_EINCOMPLETE in case the @p trees is not provided and it was needed to finish the validation.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, uint8_t *dynamic, uint8_t second,
+LY_ERR lyd_value_parse(struct lyd_node_term *node, const char *value, size_t value_len, ly_bool *dynamic, ly_bool second,
         uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data, const struct lyd_node *tree);
 
 /* similar to lyd_value_parse except can be used just to store the value, hence does also not support a second call */
 LY_ERR lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, const char *value, size_t value_len,
-        uint8_t *dynamic, LY_PREFIX_FORMAT format, void *prefix_data);
+        ly_bool *dynamic, LY_PREFIX_FORMAT format, void *prefix_data);
 
 /**
  * @brief Validate, canonize and store the given @p value into the metadata according to the annotation type's rules.
@@ -344,7 +344,7 @@ LY_ERR lyd_value_store(struct lyd_value *val, const struct lysc_node *schema, co
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_value_parse_meta(const struct ly_ctx *ctx, struct lyd_meta *meta, const char *value, size_t value_len,
-        uint8_t *dynamic, uint8_t second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data,
+        ly_bool *dynamic, ly_bool second, uint32_t value_hint, LY_PREFIX_FORMAT format, void *prefix_data,
         const struct lysc_node *ctx_snode, const struct lyd_node *tree);
 
 /* generic function lys_value_validate */
@@ -604,6 +604,6 @@ void ly_free_val_prefs(const struct ly_ctx *ctx, struct ly_prefix *val_prefs);
  * @param[in] is_static Whether buffer is static or can be reallocated.
  * @return LY_ERR
  */
-LY_ERR lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, uint8_t is_static);
+LY_ERR lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *buflen, size_t *bufused, ly_bool is_static);
 
 #endif /* LY_TREE_DATA_INTERNAL_H_ */

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -44,7 +44,7 @@ lys_getnext(const struct lysc_node *last, const struct lysc_node *parent, const 
 {
     const struct lysc_node *next = NULL;
     struct lysc_node **snode;
-    uint8_t action_flag = 0, notif_flag = 0;
+    ly_bool action_flag = 0, notif_flag = 0;
     const struct lysc_action *actions;
     const struct lysc_notif *notifs;
     LY_ARRAY_COUNT_TYPE u;
@@ -549,13 +549,14 @@ lysc_iffeature_value(const struct lysc_iffeature *iff)
  * @param[in] name Name of the feature to set. Asterisk ('*') can be used to
  * set all the features in the module.
  * @param[in] value Desired value of the feature: 1 (enable) or 0 (disable).
+ * @param[in] skip_checks Flag to skip checking of if-features and just set @p value of the feature.
  * @return LY_ERR value.
  */
 static LY_ERR
-lys_feature_change(const struct lys_module *mod, const char *name, uint8_t value, uint8_t skip_checks)
+lys_feature_change(const struct lys_module *mod, const char *name, ly_bool value, ly_bool skip_checks)
 {
     LY_ERR ret = LY_SUCCESS;
-    uint8_t all = 0;
+    ly_bool all = 0;
     LY_ARRAY_COUNT_TYPE u, disabled_count;
     uint32_t changed_count;
     struct lysc_feature *f, **df;
@@ -774,7 +775,7 @@ lys_feature_value(const struct lys_module *module, const char *feature)
 }
 
 API const struct lysc_node *
-lysc_node_is_disabled(const struct lysc_node *node, uint8_t recursive)
+lysc_node_is_disabled(const struct lysc_node *node, ly_bool recursive)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -972,7 +973,7 @@ error:
 }
 
 LY_ERR
-lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, uint8_t implement,
+lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_bool implement,
         LY_ERR (*custom_check)(const struct ly_ctx *ctx, struct lysp_module *mod, struct lysp_submodule *submod, void *data),
         void *check_data, struct lys_module **module)
 {
@@ -1240,12 +1241,12 @@ lys_parse_path(struct ly_ctx *ctx, const char *path, LYS_INFORMAT format, const 
 }
 
 API LY_ERR
-lys_search_localfile(const char * const *searchpaths, uint8_t cwd, const char *name, const char *revision,
+lys_search_localfile(const char * const *searchpaths, ly_bool cwd, const char *name, const char *revision,
         char **localfile, LYS_INFORMAT *format)
 {
     LY_ERR ret = LY_EMEM;
     size_t len, flen, match_len = 0, dir_len;
-    uint8_t implicit_cwd = 0;
+    ly_bool implicit_cwd = 0;
     char *wd, *wn = NULL;
     DIR *dir = NULL;
     struct dirent *file;

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -69,7 +69,7 @@ struct ly_set;
  * @param ELEM Iterator intended for use in the block.
  */
 #define LYSC_TREE_DFS_BEGIN(START, ELEM) \
-    { uint8_t LYSC_TREE_DFS_continue = 0; struct lysc_node *LYSC_TREE_DFS_next; \
+    { ly_bool LYSC_TREE_DFS_continue = 0; struct lysc_node *LYSC_TREE_DFS_next; \
     for ((ELEM) = (LYSC_TREE_DFS_next) = (struct lysc_node*)(START); \
          (ELEM); \
          (ELEM) = (LYSC_TREE_DFS_next), LYSC_TREE_DFS_continue = 0)
@@ -1724,10 +1724,9 @@ const struct lysc_node *lysc_node_children(const struct lysc_node *node, uint16_
  *
  * @param[in] node Node to examine.
  * @return non-zero if it is,
- * @return 0 if not.
- * @return 1 if the @p node is user-ordered
+ * @return Boolean value whether the @p node is user-ordered or not.
  */
-uint8_t lysc_is_userordered(const struct lysc_node *schema);
+ly_bool lysc_is_userordered(const struct lysc_node *schema);
 
 /**
  * @brief Set a schema private pointer to a user pointer.
@@ -2016,7 +2015,7 @@ LY_ERR lys_set_implemented(struct lys_module *mod);
  * @return NULL if enabled,
  * @return pointer to the node with the unsatisfied (disabled) if-feature expression.
  */
-const struct lysc_node *lysc_node_is_disabled(const struct lysc_node *node, uint8_t recursive);
+const struct lysc_node *lysc_node_is_disabled(const struct lysc_node *node, ly_bool recursive);
 
 /**
  * @brief Set a schema private pointer to a user pointer.

--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -1500,7 +1500,7 @@ decimal:
  * @return LY_SUCCESS or LY_EEXIST for invalid order.
  */
 static LY_ERR
-range_part_check_ascendancy(uint8_t unsigned_value, uint8_t max, int64_t value, int64_t prev_value)
+range_part_check_ascendancy(ly_bool unsigned_value, ly_bool max, int64_t value, int64_t prev_value)
 {
     if (unsigned_value) {
         if ((max && (uint64_t)prev_value > (uint64_t)value) || (!max && (uint64_t)prev_value >= (uint64_t)value)) {
@@ -1531,8 +1531,8 @@ range_part_check_ascendancy(uint8_t unsigned_value, uint8_t max, int64_t value, 
  * frdigits value), LY_EMEM.
  */
 static LY_ERR
-range_part_minmax(struct lysc_ctx *ctx, struct lysc_range_part *part, uint8_t max, int64_t prev, LY_DATA_TYPE basetype,
-        uint8_t first, uint8_t length_restr, uint8_t frdigits, struct lysc_range *base_range, const char **value)
+range_part_minmax(struct lysc_ctx *ctx, struct lysc_range_part *part, ly_bool max, int64_t prev, LY_DATA_TYPE basetype,
+        ly_bool first, ly_bool length_restr, uint8_t frdigits, struct lysc_range *base_range, const char **value)
 {
     LY_ERR ret = LY_SUCCESS;
     char *valcopy = NULL;
@@ -1694,13 +1694,13 @@ finalize:
  * @return LY_ERR value.
  */
 static LY_ERR
-lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA_TYPE basetype, uint8_t length_restr,
+lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA_TYPE basetype, ly_bool length_restr,
         uint8_t frdigits, struct lysc_range *base_range, struct lysc_range **range)
 {
     LY_ERR ret = LY_EVALID;
     const char *expr;
     struct lysc_range_part *parts = NULL, *part;
-    uint8_t range_expected = 0, uns;
+    ly_bool range_expected = 0, uns;
     LY_ARRAY_COUNT_TYPE parts_done = 0, u, v;
 
     assert(range);
@@ -2401,7 +2401,7 @@ done:
  */
 LY_ERR
 lys_path_token(const char **path, const char **prefix, size_t *prefix_len, const char **name, size_t *name_len,
-        int32_t *parent_times, uint8_t *has_predicate)
+        int32_t *parent_times, ly_bool *has_predicate)
 {
     int32_t par_times = 0;
 
@@ -2921,7 +2921,7 @@ lys_compile_type(struct lysc_ctx *ctx, struct lysp_node *context_node_p, uint16_
         struct lysc_type **type, const char **units, const char **dflt, struct lys_module **dflt_mod)
 {
     LY_ERR ret = LY_SUCCESS;
-    uint8_t dummyloops = 0;
+    ly_bool dummyloops = 0;
     struct type_context {
         const struct lysp_tpdf *tpdf;
         struct lysp_node *node;
@@ -4247,7 +4247,7 @@ lys_compile_node_case(struct lysc_ctx *ctx, struct lysp_node *node_p, struct lys
  */
 static LY_ERR
 lys_compile_change_config(struct lysc_ctx *ctx, struct lysc_node *node, uint16_t config_flag,
-        uint8_t inheriting, uint8_t refine_flag)
+        ly_bool inheriting, ly_bool refine_flag)
 {
     struct lysc_node *child;
     uint16_t config = config_flag & LYS_CONFIG_MASK;
@@ -4302,7 +4302,7 @@ lys_compile_change_config(struct lysc_ctx *ctx, struct lysc_node *node, uint16_t
  * (mandatory children was removed).
  */
 static void
-lys_compile_mandatory_parents(struct lysc_node *parent, uint8_t add)
+lys_compile_mandatory_parents(struct lysc_node *parent, ly_bool add)
 {
     struct lysc_node *iter;
 
@@ -4427,7 +4427,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, const stru
     struct lysc_node *node;
     struct lysc_when **when, *when_shared;
     struct lys_module **aug_mod;
-    uint8_t allow_mandatory = 0;
+    ly_bool allow_mandatory = 0;
     uint16_t flags = 0;
     LY_ARRAY_COUNT_TYPE u, v;
     uint32_t opt_prev = ctx->options;
@@ -4594,7 +4594,7 @@ error:
  * @return LY_ERR value.
  */
 static LY_ERR
-lys_compile_change_mandatory(struct lysc_ctx *ctx, struct lysc_node *node, uint16_t mandatory_flag, uint8_t refine_flag)
+lys_compile_change_mandatory(struct lysc_ctx *ctx, struct lysc_node *node, uint16_t mandatory_flag, ly_bool refine_flag)
 {
     if (!(node->nodetype & (LYS_LEAF | LYS_ANYDATA | LYS_ANYXML | LYS_CHOICE))) {
         LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
@@ -4653,7 +4653,7 @@ lys_compile_uses_find_grouping(struct lysc_ctx *ctx, struct lysp_node_uses *uses
     struct lysp_node *node_p;
     struct lysp_grp *grp;
     LY_ARRAY_COUNT_TYPE u, v;
-    uint8_t found = 0;
+    ly_bool found = 0;
     const char *id, *name, *prefix;
     size_t prefix_len, name_len;
     struct lys_module *mod;
@@ -5500,7 +5500,7 @@ struct lysc_deviation {
     struct lysc_node *target;      /* target node of the deviation */
     struct lysp_deviate **deviates;/* sized array of pointers to parsed deviate statements to apply on target */
     uint16_t flags;                /* target's flags from lysc_resolve_schema_nodeid() */
-    uint8_t not_supported;         /* flag if deviates contains not-supported deviate */
+    ly_bool not_supported;         /* flag if deviates contains not-supported deviate */
 };
 
 /* MACROS for deviates checking */
@@ -5550,7 +5550,7 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysc_node *target, uint32_t d
 
 #define DEV_CHECK_NONPRESENCE_VALUE(TYPE, COND, MEMBER, PROPERTY, VALUEMEMBER) \
     if (((TYPE)target)->MEMBER && (COND)) { \
-        uint8_t dynamic_ = 0; const char *val_; \
+        ly_bool dynamic_ = 0; const char *val_; \
         val_ = ((TYPE)target)->VALUEMEMBER->realtype->plugin->print(((TYPE)target)->VALUEMEMBER, LY_PREF_SCHEMA, \
                                                                              ctx->mod_def, &dynamic_); \
         LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, \
@@ -5749,7 +5749,7 @@ static LY_ERR
 lys_apply_deviate_delete_leaf_dflt(struct lysc_ctx *ctx, struct lysc_node *target, const char *dflt)
 {
     struct lysc_node_leaf *leaf = (struct lysc_node_leaf *)target;
-    uint8_t dyn = 0;
+    ly_bool dyn = 0;
     const char *orig_dflt;
     uint32_t i;
 
@@ -5812,7 +5812,7 @@ static LY_ERR
 lys_apply_deviate_delete_llist_dflts(struct lysc_ctx *ctx, struct lysc_node *target, const char **dflts)
 {
     struct lysc_node_leaflist *llist = (struct lysc_node_leaflist *)target;
-    uint8_t dyn = 0, found;
+    ly_bool dyn = 0, found;
     const char *orig_dflt, **orig_dflts;
     uint32_t i;
     LY_ARRAY_COUNT_TYPE x, y;
@@ -6098,7 +6098,7 @@ lys_apply_deviate_replace_dflt_recompile(struct lysc_ctx *ctx, struct lysc_node 
     struct ly_err_item *err = NULL;
     LY_ARRAY_COUNT_TYPE x;
     const char *dflt;
-    uint8_t dyn;
+    ly_bool dyn;
 
     if (target->module != ctx->mod) {
         /* foreign deviation */
@@ -6553,7 +6553,7 @@ lys_compile_deviations(struct lysc_ctx *ctx, struct lysp_module *mod_p)
 
     /* apply deviations */
     for (u = 0; u < devs_p.count && devs[u]; ++u) {
-        uint8_t match = 0;
+        ly_bool match = 0;
 
         if (devs[u]->flags & LYSC_OPT_INTERNAL) {
             /* fix the target pointer in case of RPC's/action's input/output */
@@ -6681,7 +6681,7 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
     /* keep order of the processing the same as the order in the defined substmts,
      * the order is important for some of the statements depending on others (e.g. type needs status and units) */
     for (u = 0; substmts[u].stmt; ++u) {
-        uint8_t stmt_present = 0;
+        ly_bool stmt_present = 0;
 
         for (stmt = ext->child; stmt; stmt = stmt->next) {
             if (substmts[u].stmt != stmt->kw) {
@@ -6882,7 +6882,7 @@ lys_compile_unres_xpath(struct lysc_ctx *ctx, const struct lysc_node *node)
     uint32_t i;
     LY_ARRAY_COUNT_TYPE u;
     uint32_t opts;
-    uint8_t input_done = 0;
+    ly_bool input_done = 0;
     struct lysc_when **when = NULL;
     struct lysc_must *musts = NULL;
     LY_ERR ret = LY_SUCCESS;
@@ -7215,7 +7215,7 @@ lys_compile_unres_llist_dflts(struct lysc_ctx *ctx, struct lysc_node_leaflist *l
         for (u = orig_count; u < LY_ARRAY_COUNT(llist->dflts); ++u) {
             for (v = 0; v < u; ++v) {
                 if (!llist->dflts[u]->realtype->plugin->compare(llist->dflts[u], llist->dflts[v])) {
-                    uint8_t dynamic = 0;
+                    ly_bool dynamic = 0;
                     const char *val = llist->type->plugin->print(llist->dflts[u], LY_PREF_SCHEMA, (void *)dflt_mod, &dynamic);
 
                     lysc_update_path(ctx, llist->parent, llist->name);

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -36,7 +36,7 @@
 
 LY_ERR
 lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t nodeid_len, const struct lysc_node *context_node,
-        const struct lys_module *context_module, uint16_t nodetype, uint8_t implement,
+        const struct lys_module *context_module, uint16_t nodetype, ly_bool implement,
         const struct lysc_node **target, uint16_t *result_flag)
 {
     LY_ERR ret = LY_EVALID;
@@ -242,7 +242,7 @@ error:
 void
 lysp_sort_revisions(struct lysp_revision *revs)
 {
-    uint8_t i, r;
+    LY_ARRAY_COUNT_TYPE i, r;
     struct lysp_revision rev;
 
     for (i = 1, r = 0; revs && i < LY_ARRAY_COUNT(revs); i++) {
@@ -523,8 +523,12 @@ lysp_check_typedef(struct lys_parser_ctx *ctx, struct lysp_node *node, const str
     return LY_SUCCESS;
 }
 
-static uint8_t
-lysp_id_cmp(void *val1, void *val2, uint8_t UNUSED(mod), void *UNUSED(cb_data))
+/**
+ * @brief Compare identifiers.
+ * Implementation of ::values_equal_cb.
+ */
+static ly_bool
+lysp_id_cmp(void *val1, void *val2, ly_bool UNUSED(mod), void *UNUSED(cb_data))
 {
     return strcmp(val1, val2) == 0 ? 1 : 0;
 }
@@ -744,8 +748,8 @@ lysp_load_module_check(const struct ly_ctx *ctx, struct lysp_module *mod, struct
 }
 
 LY_ERR
-lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement,
-        struct lys_parser_ctx *main_ctx, const char *main_name, uint8_t required, void **result)
+lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, ly_bool implement,
+        struct lys_parser_ctx *main_ctx, const char *main_name, ly_bool required, void **result)
 {
     struct ly_in *in;
     char *filepath = NULL;
@@ -803,7 +807,7 @@ cleanup:
 }
 
 LY_ERR
-lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement, uint8_t require_parsed,
+lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, ly_bool implement, ly_bool require_parsed,
         struct lys_module **mod)
 {
     const char *module_data = NULL;
@@ -939,7 +943,7 @@ lysp_check_stringchar(struct lys_parser_ctx *ctx, uint32_t c)
 }
 
 LY_ERR
-lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, uint8_t first, uint8_t *prefix)
+lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, ly_bool first, uint8_t *prefix)
 {
     if (first || (prefix && (*prefix) == 1)) {
         if (!is_yangidentstartchar(c)) {
@@ -1644,7 +1648,7 @@ lysc_data_parent(const struct lysc_node *schema)
     return parent;
 }
 
-uint8_t
+ly_bool
 lysc_is_output(const struct lysc_node *schema)
 {
     const struct lysc_node *parent;
@@ -1658,7 +1662,7 @@ lysc_is_output(const struct lysc_node *schema)
     return 0;
 }
 
-API uint8_t
+API ly_bool
 lysc_is_userordered(const struct lysc_node *schema)
 {
     if (!schema || !(schema->nodetype & (LYS_LEAFLIST | LYS_LIST)) || !(schema->flags & LYS_ORDBY_USER)) {

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -213,7 +213,7 @@ LY_ERR lysp_check_stringchar(struct lys_parser_ctx *ctx, uint32_t c);
  * If the identifier cannot be prefixed, NULL is expected.
  * @return LY_ERR values.
  */
-LY_ERR lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, uint8_t first, uint8_t *prefix);
+LY_ERR lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, ly_bool first, uint8_t *prefix);
 
 /**
  * @brief Check the currently present prefixes in the module for collision with the new one.
@@ -304,7 +304,7 @@ LY_ERR lysp_check_enum_name(struct lys_parser_ctx *ctx, const char *name, size_t
  * @param[out] mod Parsed module structure.
  * @return LY_ERR value.
  */
-LY_ERR lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement, uint8_t require_parsed, struct lys_module **mod);
+LY_ERR lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, ly_bool implement, ly_bool require_parsed, struct lys_module **mod);
 
 /**
  * @brief Parse included submodule into the simply parsed YANG module.
@@ -443,7 +443,7 @@ LY_ERR lysc_check_status(struct lysc_ctx *ctx,
  * @return LY_ERR values - LY_ENOTFOUND, LY_EVALID, LY_EDENIED or LY_SUCCESS.
  */
 LY_ERR lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t nodeid_len, const struct lysc_node *context_node,
-        const struct lys_module *context_module, uint16_t nodetype, uint8_t implement,
+        const struct lys_module *context_module, uint16_t nodetype, ly_bool implement,
         const struct lysc_node **target, uint16_t *result_flag);
 
 /**
@@ -496,7 +496,7 @@ typedef LY_ERR (*lys_custom_check)(const struct ly_ctx *ctx, struct lysp_module 
  * @param[out] module Parsed module.
  * @return LY_ERR value.
  */
-LY_ERR lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, uint8_t implement,
+LY_ERR lys_parse_mem_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_bool implement,
         lys_custom_check custom_check, void *check_data, struct lys_module **module);
 
 /**
@@ -545,8 +545,8 @@ void lys_parser_fill_filepath(struct ly_ctx *ctx, struct ly_in *in, const char *
  * If it is a module, it is already in the context!
  * @return LY_ERR value, in case of LY_SUCCESS, the \arg result is always provided.
  */
-LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, uint8_t implement,
-        struct lys_parser_ctx *main_ctx, const char *main_name, uint8_t required, void **result);
+LY_ERR lys_module_localfile(struct ly_ctx *ctx, const char *name, const char *revision, ly_bool implement,
+        struct lys_parser_ctx *main_ctx, const char *main_name, ly_bool required, void **result);
 
 /**
  * @brief Compile information from the identity statement
@@ -750,7 +750,7 @@ void lys_module_free(struct lys_module *module, void (*private_destructor)(const
  * @brief Make the specific module implemented, use the provided value as flag.
  *
  * @param[in] mod Module to make implemented. It is not an error to provide already implemented module, it just does nothing.
- * @param[in] implemented Flag value for the ::lys_module#implemented item.
+ * @param[in] implemented Flag value for the ::lys_module::implemented item.
  * @return LY_SUCCESS or LY_EDENIED in case the context contains some other revision of the
  * same module which is already implemented.
  */
@@ -792,9 +792,8 @@ const struct lysc_node *lysc_data_parent(const struct lysc_node *schema);
  * @brief Learn whether a node is inside an operation output.
  *
  * @param[in] schema Schema node to examine.
- * @return 0 if it is not.
- * @return 1 if the node is under an operation output
+ * @return Boolean value whether the node is under an operation output or not.
  */
-uint8_t lysc_is_output(const struct lysc_node *schema);
+ly_bool lysc_is_output(const struct lysc_node *schema);
 
 #endif /* LY_TREE_SCHEMA_INTERNAL_H_ */

--- a/src/validation.c
+++ b/src/validation.c
@@ -126,7 +126,7 @@ lyd_validate_unres(struct lyd_node **tree, struct ly_set *node_when, struct ly_s
                 /* evaluate all when expressions that affect this node's existence */
                 struct lyd_node *node = (struct lyd_node *)node_when->objs[i];
                 const struct lysc_node *schema = node->schema;
-                uint8_t unres_when = 0;
+                ly_bool unres_when = 0;
 
                 do {
                     LY_ARRAY_COUNT_TYPE u;
@@ -213,7 +213,7 @@ static LY_ERR
 lyd_validate_duplicates(const struct lyd_node *first, const struct lyd_node *node)
 {
     struct lyd_node **match_p;
-    uint8_t fail = 0;
+    ly_bool fail = 0;
 
     if ((node->schema->nodetype & (LYS_LIST | LYS_LEAFLIST)) && (node->schema->flags & LYS_CONFIG_R)) {
         /* duplicate instances allowed */
@@ -263,7 +263,7 @@ lyd_validate_cases(struct lyd_node **first, const struct lysc_node_choice *choic
 {
     const struct lysc_node *scase, *iter, *old_case = NULL, *new_case = NULL;
     struct lyd_node *match, *to_del;
-    uint8_t found;
+    ly_bool found;
 
     LY_LIST_FOR((struct lysc_node *)choic->cases, scase) {
         found = 0;
@@ -563,10 +563,12 @@ lyd_val_uniq_find_leaf(const struct lysc_node_leaf *uniq_leaf, const struct lyd_
 /**
  * @brief Callback for comparing 2 list unique leaf values.
  *
+ * Implementation of ::values_equal_cb.
+ *
  * @param[in] cb_data 0 to compare all uniques, n to compare only n-th unique.
  */
-static uint8_t
-lyd_val_uniq_list_equal(void *val1_p, void *val2_p, uint8_t UNUSED(mod), void *cb_data)
+static ly_bool
+lyd_val_uniq_list_equal(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *cb_data)
 {
     struct ly_ctx *ctx;
     struct lysc_node_list *slist;
@@ -677,7 +679,7 @@ lyd_validate_unique(const struct lyd_node *first, const struct lysc_node *snode,
     LY_ARRAY_COUNT_TYPE u, v, x = 0;
     LY_ERR ret = LY_SUCCESS;
     uint32_t hash, i, size = 0;
-    uint8_t dynamic;
+    ly_bool dynamic;
     const char *str;
     struct hash_table **uniqtables = NULL;
     struct lyd_value *val;

--- a/src/xml.c
+++ b/src/xml.c
@@ -38,16 +38,16 @@
 /* Ignore whitespaces in the input string p */
 #define ign_xmlws(c) while (is_xmlws(*(c)->in->current)) {if (*(c)->in->current == '\n') {++c->line;} ly_in_skip(c->in, 1);}
 
-static LY_ERR lyxml_next_attr_content(struct lyxml_ctx *xmlctx, const char **value, size_t *value_len, uint8_t *ws_only,
-        uint8_t *dynamic);
+static LY_ERR lyxml_next_attr_content(struct lyxml_ctx *xmlctx, const char **value, size_t *value_len, ly_bool *ws_only,
+        ly_bool *dynamic);
 
 /**
  * @brief Ignore any characters until the delim of the size delim_len is read
  *
  * Detects number of read new lines.
- * Returns 0 if delim was found, 1 if was not.
+ * Returns Boolean value whether delim was found or not.
  */
-static uint8_t
+static ly_bool
 ign_todelim(register const char *input, const char *delim, size_t delim_len, size_t *newlines, size_t *parsed)
 {
     size_t i;
@@ -229,7 +229,7 @@ lyxml_skip_until_end_or_after_otag(struct lyxml_ctx *xmlctx)
     const struct ly_ctx *ctx = xmlctx->ctx; /* shortcut */
     const char *endtag, *sectname;
     size_t endtag_len, newlines, parsed;
-    uint8_t rc;
+    ly_bool rc;
 
     while (1) {
         ign_xmlws(xmlctx);
@@ -335,7 +335,7 @@ lyxml_parse_qname(struct lyxml_ctx *xmlctx, const char **prefix, size_t *prefix_
  * @return LY_ERR value.
  */
 static LY_ERR
-lyxml_parse_value(struct lyxml_ctx *xmlctx, char endchar, char **value, size_t *length, uint8_t *ws_only, uint8_t *dynamic)
+lyxml_parse_value(struct lyxml_ctx *xmlctx, char endchar, char **value, size_t *length, ly_bool *ws_only, ly_bool *dynamic)
 {
 #define BUFSIZE 24
 #define BUFSIZE_STEP 128
@@ -349,7 +349,7 @@ lyxml_parse_value(struct lyxml_ctx *xmlctx, char endchar, char **value, size_t *
     void *p;
     uint32_t n;
     size_t u;
-    uint8_t ws = 1;
+    ly_bool ws = 1;
 
     assert(xmlctx);
 
@@ -518,7 +518,7 @@ success:
  */
 static LY_ERR
 lyxml_close_element(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_len, const char *name, size_t name_len,
-        uint8_t empty)
+        ly_bool empty)
 {
     struct lyxml_elem *e;
 
@@ -584,7 +584,7 @@ lyxml_open_element(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_l
     const char *prev_input;
     char *value;
     size_t parsed, value_len;
-    uint8_t ws_only, dynamic, is_ns;
+    ly_bool ws_only, dynamic, is_ns;
     uint32_t c;
 
     /* store element opening tag information */
@@ -651,7 +651,7 @@ cleanup:
  * @return LY_ERR value.
  */
 static LY_ERR
-lyxml_next_attr_content(struct lyxml_ctx *xmlctx, const char **value, size_t *value_len, uint8_t *ws_only, uint8_t *dynamic)
+lyxml_next_attr_content(struct lyxml_ctx *xmlctx, const char **value, size_t *value_len, ly_bool *ws_only, ly_bool *dynamic)
 {
     char quot;
 
@@ -712,7 +712,7 @@ lyxml_next_attribute(struct lyxml_ctx *xmlctx, const char **prefix, size_t *pref
     char *value;
     uint32_t c;
     size_t parsed, value_len;
-    uint8_t ws_only, dynamic;
+    ly_bool ws_only, dynamic;
 
     /* skip WS */
     ign_xmlws(xmlctx);
@@ -763,7 +763,7 @@ lyxml_next_attribute(struct lyxml_ctx *xmlctx, const char **prefix, size_t *pref
  */
 static LY_ERR
 lyxml_next_element(struct lyxml_ctx *xmlctx, const char **prefix, size_t *prefix_len, const char **name, size_t *name_len,
-        uint8_t *closing)
+        ly_bool *closing)
 {
     /* skip WS until EOF or after opening tag '<' */
     LY_CHECK_RET(lyxml_skip_until_end_or_after_otag(xmlctx));
@@ -795,7 +795,7 @@ lyxml_ctx_new(const struct ly_ctx *ctx, struct ly_in *in, struct lyxml_ctx **xml
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyxml_ctx *xmlctx;
-    uint8_t closing;
+    ly_bool closing;
 
     /* new context */
     xmlctx = calloc(1, sizeof *xmlctx);
@@ -837,7 +837,7 @@ LY_ERR
 lyxml_ctx_next(struct lyxml_ctx *xmlctx)
 {
     LY_ERR ret = LY_SUCCESS;
-    uint8_t closing;
+    ly_bool closing;
     struct lyxml_elem *e;
 
     /* if the value was not used, free it */
@@ -967,7 +967,7 @@ lyxml_ctx_peek(struct lyxml_ctx *xmlctx, enum LYXML_PARSER_STATUS *next)
     LY_ERR ret = LY_SUCCESS;
     const char *prefix, *name, *prev_input;
     size_t prefix_len, name_len;
-    uint8_t closing;
+    ly_bool closing;
 
     prev_input = xmlctx->in->current;
 
@@ -1040,7 +1040,7 @@ lyxml_ctx_free(struct lyxml_ctx *xmlctx)
 }
 
 LY_ERR
-lyxml_dump_text(struct ly_out *out, const char *text, uint8_t attribute)
+lyxml_dump_text(struct ly_out *out, const char *text, ly_bool attribute)
 {
     LY_ERR ret;
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -92,11 +92,11 @@ struct lyxml_ctx {
     };
     union {
         const char *name;   /* LYXML_ELEMENT, LYXML_ATTRIBUTE - elem/attr name */
-        uint8_t ws_only;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is empty/white-space only */
+        ly_bool ws_only;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is empty/white-space only */
     };
     union {
         size_t name_len;    /* LYXML_ELEMENT, LYXML_ATTRIBUTE - elem/attr name length */
-        uint8_t dynamic;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is dynamically allocated */
+        ly_bool dynamic;    /* LYXML_ELEM_CONTENT, LYXML_ATTR_CONTENT - whether elem/attr value is dynamically allocated */
     };
 
     struct ly_set elements; /* list of not-yet-closed elements */
@@ -153,7 +153,7 @@ const struct lyxml_ns *lyxml_ns_get(const struct ly_set *ns_set, const char *pre
  * @param[in] attribute Flag for attribute's value where a double quotes must be replaced.
  * @return LY_ERR values.
  */
-LY_ERR lyxml_dump_text(struct ly_out *out, const char *text, uint8_t attribute);
+LY_ERR lyxml_dump_text(struct ly_out *out, const char *text, ly_bool attribute);
 
 /**
  * @brief Remove the allocated working memory of the context.

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -238,7 +238,7 @@ struct lyxp_set {
         } *meta;
         char *str;
         long double num;
-        uint8_t bln; /* boolean */
+        ly_bool bln; /* boolean */
     } val;
 
     /* this is valid only for type LYXP_SET_NODE_SET and LYXP_SET_SCNODE_SET */
@@ -354,10 +354,9 @@ LY_ERR lyxp_set_scnode_insert_node(struct lyxp_set *set, const struct lysc_node 
  * @param[in] node_type Type of @p node.
  * @param[in] skip_idx Index from @p set to skip.
  * @param[out] index_p Optional pointer to store index if the node is found.
- * @return 0 if not found
- * @return 1 if the @p node found.
+ * @return Boolean value whether the @p node found or not.
  */
-uint8_t lyxp_set_scnode_contains(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type,
+ly_bool lyxp_set_scnode_contains(struct lyxp_set *set, const struct lysc_node *node, enum lyxp_node_type node_type,
         int skip_idx, uint32_t *index_p);
 
 /**
@@ -381,7 +380,7 @@ void lyxp_set_scnode_merge(struct lyxp_set *set1, struct lyxp_set *set2);
  * information about expressions and their operators (fill repeat).
  * @return Filled expression structure or NULL on error.
  */
-struct lyxp_expr *lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr, size_t expr_len, uint8_t reparse);
+struct lyxp_expr *lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr, size_t expr_len, ly_bool reparse);
 
 /**
  * @brief Duplicate parsed XPath expression.


### PR DESCRIPTION
To indicate simple flags or true/false return values, use a standalone
ly_bool type.

We do not use stdbool's bool type to avoid need to mimic all its
features on platforms that do not provide it. ly_bool is just a simple
rename for uint8_t and the reason to use it is only a better readability
of the meaning of the variables or function's return values.