### PR TITLE
printers CHANGE unify formatting options for data and schema printers

### DIFF
--- a/src/printer.h
+++ b/src/printer.h
@@ -30,6 +30,11 @@ extern "C" {
 struct ly_out;
 
 /**
+ * @brief Common value for data as well as schema printers to avoid formatting indentations and new lines
+ */
+#define LY_PRINT_SHRINK 0x02
+
+/**
  * @brief Types of the printer's output
  */
 typedef enum LY_OUT_TYPE {

--- a/src/printer_data.h
+++ b/src/printer_data.h
@@ -36,23 +36,23 @@ struct ly_out;
  *
  * @{
  */
-#define LYD_PRINT_WITHSIBLINGS  0x01  /**< Flag for printing also the (following) sibling nodes of the data node. */
-#define LYD_PRINT_FORMAT        0x02  /**< Flag for formatted output. */
-#define LYD_PRINT_KEEPEMPTYCONT 0x04  /**< Preserve empty non-presence containers */
-#define LYD_PRINT_WD_MASK       0xF0  /**< Mask for with-defaults modes */
-#define LYD_PRINT_WD_EXPLICIT   0x00  /**< Explicit mode - print only data explicitly being present in the data tree.
-                                           Note that this is the default value when no WD option is specified. */
-#define LYD_PRINT_WD_TRIM       0x10  /**< Do not print the nodes with the value equal to their default value */
-#define LYD_PRINT_WD_ALL        0x20  /**< Include implicit default nodes */
-#define LYD_PRINT_WD_ALL_TAG    0x40  /**< Same as #LYDP_WD_ALL but also adds attribute 'default' with value 'true' to
-                                           all nodes that has its default value. The 'default' attribute has namespace:
-                                           urn:ietf:params:xml:ns:netconf:default:1.0 and thus the attributes are
-                                           printed only when the ietf-netconf-with-defaults module is present in libyang
-                                           context (but in that case this namespace is always printed). */
-#define LYD_PRINT_WD_IMPL_TAG   0x80  /**< Same as LYDP_WD_ALL_TAG but the attributes are added only to the nodes that
-                                           are not explicitly present in the original data tree despite their
-                                           value is equal to their default value.  There is the same limitation regarding
-                                           the presence of ietf-netconf-with-defaults module in libyang context. */
+#define LYD_PRINT_WITHSIBLINGS  0x01             /**< Flag for printing also the (following) sibling nodes of the data node. */
+#define LYD_PRINT_SHRINK        LY_PRINT_SHRINK  /**< Flag for output without indentation and formatting new lines. */
+#define LYD_PRINT_KEEPEMPTYCONT 0x04             /**< Preserve empty non-presence containers */
+#define LYD_PRINT_WD_MASK       0xF0             /**< Mask for with-defaults modes */
+#define LYD_PRINT_WD_EXPLICIT   0x00             /**< Explicit mode - print only data explicitly being present in the data tree.
+                                                      Note that this is the default value when no WD option is specified. */
+#define LYD_PRINT_WD_TRIM       0x10             /**< Do not print the nodes with the value equal to their default value */
+#define LYD_PRINT_WD_ALL        0x20             /**< Include implicit default nodes */
+#define LYD_PRINT_WD_ALL_TAG    0x40             /**< Same as #LYDP_WD_ALL but also adds attribute 'default' with value 'true' to
+                                                      all nodes that has its default value. The 'default' attribute has namespace:
+                                                      urn:ietf:params:xml:ns:netconf:default:1.0 and thus the attributes are
+                                                      printed only when the ietf-netconf-with-defaults module is present in libyang
+                                                      context (but in that case this namespace is always printed). */
+#define LYD_PRINT_WD_IMPL_TAG   0x80             /**< Same as LYDP_WD_ALL_TAG but the attributes are added only to the nodes that
+                                                      are not explicitly present in the original data tree despite their
+                                                      value is equal to their default value.  There is the same limitation regarding
+                                                      the presence of ietf-netconf-with-defaults module in libyang context. */
 /**
  * @}
  */

--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -87,7 +87,7 @@ LY_ERR yang_print_parsed_module(struct ly_out *out, const struct lys_module *mod
 /**
  * @brief Helper macros for data printers
  */
-#define DO_FORMAT (ctx->options & LYD_PRINT_FORMAT)
+#define DO_FORMAT (!(ctx->options & LY_PRINT_SHRINK))
 #define LEVEL ctx->level                      /**< current level */
 #define INDENT (DO_FORMAT ? (LEVEL)*2 : 0),"" /**< indentation parameters for printer functions */
 #define LEVEL_INC LEVEL++                     /**< increase indentation level */

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -859,7 +859,7 @@ json_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t option
 {
     const struct lyd_node *node;
     struct jsonpr_ctx ctx = {0};
-    const char *delimiter = (options & LYD_PRINT_FORMAT) ? "\n" : "";
+    const char *delimiter = (options & LYD_PRINT_SHRINK) ? "" : "\n";
 
     if (!root) {
         ly_print_(out, "{}%s", delimiter);

--- a/src/printer_schema.h
+++ b/src/printer_schema.h
@@ -39,13 +39,13 @@ struct lysp_submodule;
  * @defgroup schemaprinterflags Schema output options
  * @{
  */
-/* Keep the value 0x02 reserver for implicit LYS_PRINT_FORMAT */
-#define LYS_OUTPUT_NO_SUBSTMT        0x10 /**< Print only top-level/referede node information,
-                                               do not print information from the substatements */
-// #define LYS_OUTOPT_TREE_RFC        0x01 /**< Conform to the RFC TODO tree output (only for tree format) */
-// #define LYS_OUTOPT_TREE_GROUPING   0x02 /**< Print groupings separately (only for tree format) */
-// #define LYS_OUTOPT_TREE_USES       0x04 /**< Print only uses instead the resolved grouping nodes (only for tree format) */
-// #define LYS_OUTOPT_TREE_NO_LEAFREF 0x08 /**< Do not print the target of leafrefs (only for tree format) */
+#define LYS_PRINT_SHRINK             LY_PRINT_SHRINK /**< Flag for output without indentation and formatting new lines. */
+#define LYS_PRINT_NO_SUBSTMT         0x10            /**< Print only top-level/referede node information,
+                                                          do not print information from the substatements */
+// #define LYS_PRINT_TREE_RFC        0x01 /**< Conform to the RFC TODO tree output (only for tree format) */
+// #define LYS_PRINT_TREE_GROUPING   0x02 /**< Print groupings separately (only for tree format) */
+// #define LYS_PRINT_TREE_USES       0x04 /**< Print only uses instead the resolved grouping nodes (only for tree format) */
+// #define LYS_PRINT_TREE_NO_LEAFREF 0x08 /**< Do not print the target of leafrefs (only for tree format) */
 
 /** @} schemaprinterflags */
 

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -545,7 +545,7 @@ xml_print_data(struct ly_out *out, const struct lyd_node *root, uint32_t options
     }
 
     ctx.out = out;
-    ctx.level = (options & LYD_PRINT_FORMAT ? 1 : 0);
+    ctx.level = (options & LYD_PRINT_SHRINK ? 0 : 1);
     ctx.options = options;
     ctx.ctx = LYD_CTX(root);
 

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -1174,7 +1174,7 @@ yprc_inout(struct ypr_ctx *ctx, const struct lysc_action *action, const struct l
         yprc_must(ctx, &inout->musts[u], NULL);
     }
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         LY_LIST_FOR(inout->data, data) {
             yprc_node(ctx, data);
         }
@@ -1243,7 +1243,7 @@ yprc_notification(struct ypr_ctx *ctx, const struct lysc_notif *notif)
     ypr_description(ctx, notif->dsc, notif->exts, &flag);
     ypr_reference(ctx, notif->ref, notif->exts, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         LY_LIST_FOR(notif->data, data) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, data);
@@ -1426,7 +1426,7 @@ yprc_container(struct ypr_ctx *ctx, const struct lysc_node *node)
 
     yprc_node_common2(ctx, node, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         LY_LIST_FOR(cont->child, child) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -1475,7 +1475,7 @@ yprc_case(struct ypr_ctx *ctx, const struct lysc_node_case *cs)
     yprc_node_common1(ctx, (struct lysc_node *)cs, &flag);
     yprc_node_common2(ctx, (struct lysc_node *)cs, &flag);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         for (child = cs->child; child && child->parent == (struct lysc_node *)cs; child = child->next) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -1776,7 +1776,7 @@ yprc_list(struct ypr_ctx *ctx, const struct lysc_node *node)
     ypr_description(ctx, node->dsc, node->exts, NULL);
     ypr_reference(ctx, node->ref, node->exts, NULL);
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         LY_LIST_FOR(list->child, child) {
             ypr_open(ctx->out, &flag);
             yprc_node(ctx, child);
@@ -2202,7 +2202,7 @@ LY_ERR
 yang_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .schema = YPR_PARSED, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .schema = YPR_PARSED, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "%*smodule %s {\n", INDENT, module->name);
     LEVEL++;
@@ -2259,7 +2259,7 @@ LY_ERR
 yang_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .schema = YPR_PARSED, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .schema = YPR_PARSED, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "%*ssubmodule %s {\n", INDENT, submodp->name);
     LEVEL++;
@@ -2303,7 +2303,7 @@ yang_print_parsed_submodule(struct ly_out *out, const struct lys_module *module,
 LY_ERR
 yang_print_compiled_node(struct ly_out *out, const struct lysc_node *node, uint32_t options)
 {
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = node->module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = node->module, .options = options}, *ctx = &ctx_;
 
     yprc_node(ctx, node);
 
@@ -2317,7 +2317,7 @@ yang_print_compiled(struct ly_out *out, const struct lys_module *module, uint32_
     LY_ARRAY_COUNT_TYPE u;
     struct lysc_node *data;
     struct lysc_module *modc = module->compiled;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "%*smodule %s {\n", INDENT, module->name);
     LEVEL++;
@@ -2359,7 +2359,7 @@ yang_print_compiled(struct ly_out *out, const struct lys_module *module, uint32_
         yprc_identity(ctx, &modc->identities[u]);
     }
 
-    if (!(ctx->options & LYS_OUTPUT_NO_SUBSTMT)) {
+    if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {
         LY_LIST_FOR(modc->data, data) {
             yprc_node(ctx, data);
         }

--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -1455,7 +1455,7 @@ LY_ERR
 yin_print_parsed_module(struct ly_out *out, const struct lys_module *module, const struct lysp_module *modp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     ly_print_(ctx->out, "%*s<module name=\"%s\"\n", INDENT, module->name);
@@ -1517,7 +1517,7 @@ LY_ERR
 yin_print_parsed_submodule(struct ly_out *out, const struct lys_module *module, const struct lysp_submodule *submodp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options | LYD_PRINT_FORMAT}, *ctx = &ctx_;
+    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     ly_print_(ctx->out, "%*s<submodule name=\"%s\"\n", INDENT, submodp->name);

--- a/tests/utests/data/test_diff.c
+++ b/tests/utests/data/test_diff.c
@@ -292,8 +292,8 @@ test_same(void **state)
     assert_null(st->diff1);
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 }
 
@@ -316,7 +316,7 @@ test_empty1(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"create\">"
             "<foo>42</foo><b1_1>42</b1_1>"
@@ -327,8 +327,8 @@ test_empty1(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 }
 
@@ -348,7 +348,7 @@ test_empty2(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">"
             "<foo>42</foo><b1_1>42</b1_1>"
@@ -378,7 +378,7 @@ test_empty_nested(void **state)
     assert_int_equal(lyd_diff_siblings(NULL, lyd_node_children(st->first, 0), 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"create\">42</foo>"
@@ -389,7 +389,7 @@ test_empty_nested(void **state)
     assert_int_equal(lyd_diff_siblings(lyd_node_children(st->first, 0), NULL, 0, &st->diff2), LY_SUCCESS);
 
     assert_non_null(st->diff2);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"delete\">42</foo>"
@@ -431,7 +431,7 @@ test_leaf(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"replace\" yang:orig-value=\"42\">41</foo>"
@@ -444,8 +444,8 @@ test_leaf(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -453,7 +453,7 @@ test_leaf(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"replace\" yang:orig-value=\"41\">40</foo>"
@@ -466,16 +466,16 @@ test_leaf(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"replace\" yang:orig-value=\"42\">40</foo>"
@@ -515,7 +515,7 @@ test_list(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<list yang:operation=\"delete\">"
@@ -534,8 +534,8 @@ test_list(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -543,7 +543,7 @@ test_list(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<list yang:operation=\"delete\">"
@@ -559,16 +559,16 @@ test_list(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<list yang:operation=\"none\">"
@@ -619,7 +619,7 @@ test_userord_llist(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"replace\" yang:orig-value=\"3\" yang:value=\"1\">4</llist>"
@@ -628,8 +628,8 @@ test_userord_llist(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -637,7 +637,7 @@ test_userord_llist(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"delete\" yang:orig-value=\"\">1</llist>"
@@ -647,16 +647,16 @@ test_userord_llist(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"replace\" yang:orig-value=\"3\" yang:value=\"1\">4</llist>"
@@ -703,7 +703,7 @@ test_userord_llist2(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"replace\" yang:orig-value=\"3\" yang:value=\"2\">4</llist>"
@@ -711,8 +711,8 @@ test_userord_llist2(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -720,7 +720,7 @@ test_userord_llist2(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"delete\" yang:orig-value=\"1\">2</llist>"
@@ -730,16 +730,16 @@ test_userord_llist2(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"replace\" yang:orig-value=\"3\" yang:value=\"\">4</llist>"
@@ -778,7 +778,7 @@ test_userord_mix(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"delete\" yang:orig-value=\"1\">2</llist>"
@@ -787,8 +787,8 @@ test_userord_mix(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -796,7 +796,7 @@ test_userord_mix(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"replace\" yang:orig-value=\"3\" yang:value=\"\">1</llist>"
@@ -806,16 +806,16 @@ test_userord_mix(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<llist yang:operation=\"delete\" yang:orig-value=\"1\">2</llist>"
@@ -853,7 +853,7 @@ test_wd(void **state)
     assert_int_equal(lyd_diff_siblings(st->first, st->second, LYD_DIFF_DEFAULTS, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"replace\" yang:orig-default=\"true\" yang:orig-value=\"42\">41</foo>"
@@ -865,8 +865,8 @@ test_wd(void **state)
     );
 
     assert_int_equal(lyd_diff_apply_all(&st->first, st->diff1), LY_SUCCESS);
-    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS);
-    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->first, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
+    lyd_print_mem(&st->xml2, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* diff2 */
@@ -874,7 +874,7 @@ test_wd(void **state)
 
     assert_non_null(st->diff2);
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL);
+    lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:operation=\"replace\" yang:orig-value=\"41\">42</foo>"
@@ -884,16 +884,16 @@ test_wd(void **state)
 
     assert_int_equal(lyd_diff_apply_all(&st->second, st->diff2), LY_SUCCESS);
     free(st->xml1);
-    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml1, st->second, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     free(st->xml2);
-    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&st->xml2, st->third, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml1, st->xml2);
 
     /* merge */
     assert_int_equal(lyd_diff_merge_all(&st->diff1, st->diff2), LY_SUCCESS);
 
     free(st->xml);
-    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL);
+    lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(st->xml,
         "<df xmlns=\"urn:libyang:tests:defaults\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<foo yang:orig-default=\"true\" yang:operation=\"none\">42</foo>"

--- a/tests/utests/data/test_merge.c
+++ b/tests/utests/data/test_merge.c
@@ -246,7 +246,7 @@ test_batch(void **state)
         st->source = NULL;
     }
 
-    lyd_print_mem(&str, st->target, LYD_XML, 0);
+    lyd_print_mem(&str, st->target, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, output_template);
 
     ly_in_free(in, 0);
@@ -285,7 +285,7 @@ test_leaf(void **state)
     assert_int_equal(lyd_validate_all(&st->target, NULL, LYD_VALIDATE_PRESENT, NULL), LY_SUCCESS);
 
     /* check the result */
-    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(printed, result);
     free(printed);
 }
@@ -327,7 +327,7 @@ test_container(void **state)
     assert_int_equal(lyd_validate_all(&st->target, NULL, LYD_VALIDATE_PRESENT, NULL), LY_SUCCESS);
 
     /* check the result */
-    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(printed, result);
     free(printed);
 }
@@ -397,7 +397,7 @@ test_list(void **state)
     assert_int_equal(lyd_validate_all(&st->target, NULL, LYD_VALIDATE_PRESENT, NULL), LY_SUCCESS);
 
     /* check the result */
-    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(printed, result);
     free(printed);
 }
@@ -476,7 +476,7 @@ test_list2(void **state)
     assert_int_equal(lyd_validate_all(&st->target, NULL, LYD_VALIDATE_PRESENT, NULL), LY_SUCCESS);
 
     /* check the result */
-    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(printed, result);
     free(printed);
 }
@@ -534,7 +534,7 @@ test_case(void **state)
     assert_int_equal(lyd_validate_all(&st->target, NULL, LYD_VALIDATE_PRESENT, NULL), LY_SUCCESS);
 
     /* check the result */
-    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&printed, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(printed, result);
     free(printed);
 }
@@ -646,7 +646,7 @@ test_leafrefs(void **state)
 
     assert_int_equal(lyd_merge_siblings(&st->target, st->source, 0), LY_SUCCESS);
 
-    lyd_print_mem(&prt, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS);
+    lyd_print_mem(&prt, st->target, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
     assert_string_equal(prt, res);
     free(prt);
 }

--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -146,7 +146,7 @@ test_leaf(void **state)
     assert_string_equal("default-val", leaf->value.canonical);
     assert_true(leaf->flags & LYD_DEFAULT);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -161,7 +161,7 @@ test_leaf(void **state)
     assert_string_equal("default-val", leaf->value.canonical);
     assert_false(leaf->flags & LYD_DEFAULT);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -177,7 +177,7 @@ test_leaf(void **state)
     assert_true(leaf->flags & LYD_DEFAULT);
 
     /* TODO default values
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     */
@@ -203,7 +203,7 @@ test_leaf(void **state)
     assert_ptr_equal(tree, tree->meta->next->parent);
     assert_null(tree->meta->next->next);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, "{\"a:foo\":\"xxx\",\"@a:foo\":{\"a:hint\":1,\"a:hint\":2}}");
     ly_out_free(out, NULL, 1);
     lyd_free_all(tree);
@@ -250,7 +250,7 @@ test_leaflist(void **state)
     ll = (struct lyd_node_term*)tree->next;
     assert_string_equal("11", ll->value.canonical);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -274,7 +274,7 @@ test_leaflist(void **state)
     assert_string_equal("2", ll->meta->value.canonical);
     assert_null(ll->meta->next);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -321,7 +321,7 @@ test_leaflist(void **state)
     assert_ptr_equal(ll, ll->meta->parent);
     assert_null(ll->meta->next);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, "{\"a:ll1\":[1,2,3],\"@a:ll1\":[{\"a:hint\":1,\"a:hint\":10},null,{\"a:hint\":3}]}");
     ly_out_free(out, NULL, 1);
     lyd_free_all(tree);
@@ -360,7 +360,7 @@ test_anydata(void **state)
     assert_int_equal(LYS_ANYDATA, tree->schema->nodetype);
     assert_string_equal("any", tree->schema->name);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
 
@@ -394,7 +394,7 @@ test_list(void **state)
         assert_int_not_equal(0, iter->hash);
     }
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -435,7 +435,7 @@ test_list(void **state)
     assert_string_equal("d", leaf->schema->name);
     logbuf_assert("");
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, "{\"a:l1\":[{\"a\":\"a\",\"b\":\"b\",\"c\":1,\"d\":\"d\"}]}");
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -455,7 +455,7 @@ test_list(void **state)
     assert_string_equal("c", leaf->schema->name);
     logbuf_assert("");
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, "{\"a:l1\":[{\"a\":\"a\",\"b\":\"b\",\"c\":1}]}");
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -471,7 +471,7 @@ test_list(void **state)
     assert_ptr_equal(tree, tree->meta->parent);
     assert_null(tree->meta->next);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_free(out, NULL, 1);
     lyd_free_all(tree);
@@ -499,7 +499,7 @@ test_container(void **state)
     cont = (struct lyd_node_inner*)tree;
     assert_true(cont->flags & LYD_DEFAULT);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, "{}");
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -512,7 +512,7 @@ test_container(void **state)
     cont = (struct lyd_node_inner*)tree;
     assert_false(cont->flags & LYD_DEFAULT);
 
-    lyd_print_all(out, tree, LYD_JSON, 0);
+    lyd_print_all(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(printed, data);
     ly_out_free(out, NULL, 1);
     lyd_free_all(tree);
@@ -545,7 +545,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "foo3");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -563,7 +563,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -581,7 +581,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -593,7 +593,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -605,7 +605,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -664,7 +664,7 @@ test_rpc(void **state)
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "l1");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -708,7 +708,7 @@ test_action(void **state)
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "action");
     assert_null(((struct lyd_node_opaq *)node)->attr);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -756,7 +756,7 @@ test_notification(void **state)
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "c");
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -773,7 +773,7 @@ test_notification(void **state)
     assert_non_null(tree);
     assert_ptr_equal(ntf, tree);
 
-    lyd_print_tree(out, tree, LYD_JSON, 0);
+    lyd_print_tree(out, tree, LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -826,10 +826,10 @@ test_reply(void **state)
     assert_string_equal(node->schema->name, "c");
 
     /* TODO print only rpc-reply node and then output subtree */
-    lyd_print_tree(out, lyd_node_children(op, 0), LYD_JSON, 0);
+    lyd_print_tree(out, lyd_node_children(op, 0), LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, "{\"a:al\":25}");
     ly_out_reset(out);
-    lyd_print_tree(out, lyd_node_children(tree, 0), LYD_JSON, 0);
+    lyd_print_tree(out, lyd_node_children(tree, 0), LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, "{\"a:c\":{\"act\":{\"al\":25}}}");
     ly_out_reset(out);
     lyd_free_all(tree);

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -193,7 +193,7 @@ test_anydata(void **state)
     assert_int_equal(LYS_ANYDATA, tree->schema->nodetype);
     assert_string_equal("any", tree->schema->name);
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<any xmlns=\"urn:tests:a\">"
             "<element1>"
@@ -343,7 +343,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "foo3");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, "<foo3 xmlns=\"urn:tests:a\"/>");
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -361,7 +361,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -379,7 +379,7 @@ test_opaq(void **state)
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "l1");
     assert_string_equal(((struct lyd_node_opaq *)tree)->value, "");
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -454,7 +454,7 @@ test_rpc(void **state)
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "l1");
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
             "<edit-config>"
@@ -524,7 +524,7 @@ test_action(void **state)
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "action");
     assert_null(((struct lyd_node_opaq *)node)->attr);
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" msgid=\"25\" custom-attr=\"val\">"
             "<action xmlns=\"urn:ietf:params:xml:ns:yang:1\">"
@@ -589,7 +589,7 @@ test_notification(void **state)
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "c");
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -606,7 +606,7 @@ test_notification(void **state)
     assert_non_null(tree);
     assert_ptr_equal(ntf, tree);
 
-    lyd_print_tree(out, tree, LYD_XML, 0);
+    lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str, data);
     ly_out_reset(out);
     lyd_free_all(tree);
@@ -668,7 +668,7 @@ test_reply(void **state)
     assert_string_equal(node->schema->name, "c");
 
     /* TODO print only rpc-reply node and then output subtree */
-    lyd_print_tree(out, lyd_node_children(op, 0), LYD_XML, 0);
+    lyd_print_tree(out, lyd_node_children(op, 0), LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<al xmlns=\"urn:tests:a\">25</al>");
     ly_out_reset(out);

--- a/tests/utests/data/test_printer_xml.c
+++ b/tests/utests/data/test_printer_xml.c
@@ -186,7 +186,7 @@ test_leaf(void **state)
     data = "<int8 xmlns=\"urn:tests:types\">\n 15 \t\n  </int8>";
     result = "<int8 xmlns=\"urn:tests:types\">15</int8>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
-    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, 0));
+    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, result);
     lyd_free_all(tree);
@@ -209,7 +209,7 @@ test_anydata(void **state)
 
     data = "<any xmlns=\"urn:tests:types\"><somexml xmlns:x=\"url:x\" xmlns=\"example.com\"><x:x/></somexml></any>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
-    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, 0));
+    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     /* canonized */
     data = "<any xmlns=\"urn:tests:types\"><somexml xmlns=\"example.com\"><x xmlns=\"url:x\"/></somexml></any>";
@@ -219,7 +219,7 @@ test_anydata(void **state)
 
     data = "<any xmlns=\"urn:tests:types\"/>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
-    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, 0));
+    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
@@ -241,7 +241,7 @@ test_anydata(void **state)
     assert_string_equal(((struct lyd_node_any *)tree)->value.tree->schema->name, "cont");
     /* but its children not */
     assert_null(((struct lyd_node_inner *)(((struct lyd_node_any *)tree)->value.tree))->child->schema);
-    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, 0));
+    assert_int_equal(LY_SUCCESS, lyd_print_tree(out, tree, LYD_XML, LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     /* canonized */
     data =
@@ -279,18 +279,18 @@ test_defaults(void **state)
     data = "<c xmlns=\"urn:defaults\">aa</c>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:d=\"urn:defaults\">/d:b</a><c xmlns=\"urn:defaults\">aa</c>";
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\""
         " ncwd:default=\"true\" xmlns:d=\"urn:defaults\">/d:b</a>"
@@ -298,7 +298,7 @@ test_defaults(void **state)
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\""
         " ncwd:default=\"true\" xmlns:d=\"urn:defaults\">/d:b</a>"
@@ -312,22 +312,22 @@ test_defaults(void **state)
     data = "<a xmlns=\"urn:defaults\">/d:b</a><c xmlns=\"urn:defaults\">aa</c>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     assert_string_equal(printed, data);
     ly_out_reset(out);
@@ -338,19 +338,19 @@ test_defaults(void **state)
     data = "<a xmlns=\"urn:defaults\" xmlns:d=\"urn:defaults\">/d:b</a><b xmlns=\"urn:defaults\">val</b><c xmlns=\"urn:defaults\">aa</c>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(s->ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_TRIM | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<b xmlns=\"urn:defaults\">val</b><c xmlns=\"urn:defaults\">aa</c>";
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:d=\"urn:defaults\">/d:b</a><b xmlns=\"urn:defaults\">val</b><c xmlns=\"urn:defaults\">aa</c>";
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_ALL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\""
         " ncwd:default=\"true\" xmlns:d=\"urn:defaults\">/d:b</a>"
@@ -359,7 +359,7 @@ test_defaults(void **state)
     assert_string_equal(printed, data);
     ly_out_reset(out);
 
-    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG));
+    assert_int_equal(LY_SUCCESS, lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK));
     assert_int_equal(strlen(printed), ly_out_printed(out));
     data = "<a xmlns=\"urn:defaults\" xmlns:d=\"urn:defaults\">/d:b</a><b xmlns=\"urn:defaults\">val</b><c xmlns=\"urn:defaults\">aa</c>";
     assert_string_equal(printed, data);
@@ -393,13 +393,13 @@ test_rpc(void **state)
     reply = "<result xmlns=\"urn:tests:types\">30</result>";
     result = "<sum xmlns=\"urn:tests:types\"><result>30</result></sum>";
     assert_non_null(tree1 = lyd_parse_mem(s->ctx, request, LYD_XML, LYD_OPT_RPC, NULL));
-    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, request);
     ly_out_reset(out);
     assert_non_null(trees = lyd_trees_new(1, tree1));
     assert_non_null(tree2 = lyd_parse_mem(s->ctx, reply, LYD_XML, LYD_OPT_RPCREPLY, trees));
-    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, result);
     ly_out_reset(out);
@@ -412,13 +412,13 @@ test_rpc(void **state)
     reply = "";
     result = "<sum xmlns=\"urn:tests:types\"/>";
     assert_non_null(tree1 = lyd_parse_mem(s->ctx, request, LYD_XML, LYD_OPT_RPC, NULL));
-    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, request);
     ly_out_reset(out);
     assert_non_null(trees = lyd_trees_new(1, tree1));
     assert_non_null(tree2 = lyd_parse_mem(s->ctx, reply, LYD_XML, LYD_OPT_RPCREPLY, trees));
-    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, result);
     ly_out_reset(out);
@@ -436,13 +436,13 @@ test_rpc(void **state)
     reply = "<b xmlns=\"urn:tests:types\">test-reply</b>";
     result = "<cont xmlns=\"urn:tests:types\"><listtarget><id>10</id><test><b>test-reply</b></test></listtarget></cont>";;
     assert_non_null(tree1 = lyd_parse_mem(s->ctx, request, LYD_XML, LYD_OPT_RPC, NULL));
-    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree1, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, request);
     ly_out_reset(out);
     assert_non_null(trees = lyd_trees_new(1, tree1));
     assert_non_null(tree2 = lyd_parse_mem(s->ctx, reply, LYD_XML, LYD_OPT_RPCREPLY, trees));
-    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, 0)) >= 0);
+    assert_true((len = lyd_print_tree(out, tree2, LYD_XML, LYD_PRINT_SHRINK)) >= 0);
     assert_int_equal(len, strlen(printed));
     assert_string_equal(printed, result);
     ly_out_reset(out);

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -1032,7 +1032,7 @@ test_defaults(void **state)
     assert_non_null(diff);
 
     /* check all defaults exist */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<ll1 xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def1</ll1>"
         "<ll1 xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">def2</ll1>"
@@ -1051,7 +1051,7 @@ test_defaults(void **state)
     ly_out_reset(out);
 
     /* check diff */
-    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL);
+    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<ll1 xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"create\">def1</ll1>"
         "<ll1 xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"create\">def2</ll1>"
@@ -1077,7 +1077,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate_all(&tree, ctx, LYD_VALIDATE_PRESENT, &diff), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\" xmlns:ncwd=\"urn:ietf:params:xml:ns:yang:ietf-netconf-with-defaults\" ncwd:default=\"true\">15</d>"
@@ -1094,7 +1094,7 @@ test_defaults(void **state)
     ly_out_reset(out);
 
     /* check diff */
-    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL);
+    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<ll1 xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">def1</ll1>"
         "<ll1 xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">def2</ll1>"
@@ -1111,7 +1111,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate_all(&tree, ctx, LYD_VALIDATE_PRESENT, &diff), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
@@ -1127,7 +1127,7 @@ test_defaults(void **state)
     ly_out_reset(out);
 
     /* check diff */
-    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL);
+    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<d xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">15</d>"
         "<ll2 xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"delete\">dflt1</ll2>"
@@ -1142,7 +1142,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate_all(&tree, ctx, LYD_VALIDATE_PRESENT, &diff), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
@@ -1166,7 +1166,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate_all(&tree, ctx, LYD_VALIDATE_PRESENT, &diff), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
@@ -1191,7 +1191,7 @@ test_defaults(void **state)
     assert_int_equal(lyd_validate_all(&tree, ctx, LYD_VALIDATE_PRESENT, &diff), LY_SUCCESS);
 
     /* check data tree */
-    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG);
+    lyd_print_all(out, tree, LYD_XML, LYD_PRINT_WD_IMPL_TAG | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<l xmlns=\"urn:tests:f\">value</l>"
         "<d xmlns=\"urn:tests:f\">15</d>"
@@ -1204,7 +1204,7 @@ test_defaults(void **state)
     ly_out_reset(out);
 
     /* check diff */
-    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL);
+    lyd_print_all(out, diff, LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<cont xmlns=\"urn:tests:f\" xmlns:yang=\"urn:ietf:params:xml:ns:yang:1\" yang:operation=\"none\">"
             "<ll1 yang:operation=\"delete\">def1</ll1>"

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -434,7 +434,7 @@ cmd_print(const char *arg)
             target_path = optarg;
             break;
         case 's':
-            output_opts |= LYS_OUTPUT_NO_SUBSTMT;
+            output_opts |= LYS_PRINT_NO_SUBSTMT;
             break;
 #if 0
         case 'L':
@@ -819,7 +819,7 @@ cmd_data(const char *arg)
     }
 
     if (outformat) {
-        ret = lyd_print_all(out, data, outformat, LYD_PRINT_FORMAT | printopt);
+        ret = lyd_print_all(out, data, outformat, printopt);
         ret = ret < 0 ? ret * (-1) : 0;
     }
 
@@ -1036,7 +1036,7 @@ print_list(FILE *out, struct ly_ctx *ctx, LYD_FORMAT outformat)
             return 1;
         }
 
-        lyd_print_file(out, ylib, outformat, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_FORMAT);
+        lyd_print_file(out, ylib, outformat, LYD_PRINT_WITHSIBLINGS);
         lyd_free_all(ylib);
         return 0;
     }

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -1086,7 +1086,7 @@ parse_reply:
                 if (!out) {
                     ly_out_new_file(stdout, &out);
                 }
-                lyd_print_all(out, data_item->tree, outformat_d, LYD_PRINT_FORMAT /* TODO defaults | options_dflt */);
+                lyd_print_all(out, data_item->tree, outformat_d, 0 /* TODO defaults | options_dflt */);
 #if 0
                 if (envelope_s) {
                     if (data_item->type == LYD_OPT_RPC && data_item->tree->schema->nodetype != LYS_RPC) {


### PR DESCRIPTION
Replaces LYD_PRINT_FORMAT by the LYD_PRINT_SHRINK with the inverse
meaning. This way the default formating (do format output) is unified
between data and schema printers. The commit also introduces
LYS_PRINT_SHRINK with the same value to have the option explicitely also
for the schema printers and to allow to print schemas without
unnecessary indentations and new lines.