### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -7095,8 +7095,13 @@ ly_set_merge(struct ly_set *trg, struct ly_set *src, int options)
         trg->set.g = new;
     }
 
-    /* copy contents from src into trg */
-    memcpy(trg->set.g + trg->number, src->set.g, src->number * sizeof *(src->set.g));
+    /*
+     * copy contents from src into trg
+     * don't copy anything if there's nothing to copy, memcpy doesn't want NULL as second argument
+     */
+    if (src->number > 0) {
+        memcpy(trg->set.g + trg->number, src->set.g, src->number * sizeof *(src->set.g));
+    }
     ret = src->number;
     trg->number += ret;
 


### PR DESCRIPTION
Hi, another in the series of UBs, I found this one here:
```
/home/vk/git/netconf-cli/submodules/dependencies/libyang/src/tree_data.c:7099:38: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
```
I found this bug in my tests where dump all data through NETCONF. To reproduce:
1) run netopeer2
2) connect with netopeer2-cli
3) type `get`
4) ub appears

I'm not sure if this should be fixed in libyang or sysrepo. Also, I'm not sure about the commit message.
```
#0  ly_set_merge (trg=0x602000050610, src=<optimized out>, options=<optimized out>) at /home/vk/git/netconf-cli/submodules/dependencies/libyang/src/tree_data.c:7099
#1  0x00007ffff6e67bd9 in sr_lyd_dup_enabled_xpath (data=0x6070000466b0, xpaths=0x60300004aef0, xp_count=4, new_data=0x7ffff2cfc7c0) at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/common.c:3615
#2  0x00007ffff6eaa1b6 in sr_module_oper_data_dup_enabled (data=0x6070000466b0, ext_shm_addr=0x7ffff3303000 "\b\003", mod=0x612000031d00, opts=2, enabled_mod_data=0x7ffff2cfc7c0)
    at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/modinfo.c:821
#3  0x00007ffff6e9ba45 in sr_modinfo_module_data_load (mod_info=0x7ffff2cfce40, mod=0x612000031d00, sid=0x7ffff2cfdf10, request_xpath=0x60200005a970 "/*", timeout_ms=5000, opts=2, cb_error_info=0x7ffff2cfce20)
    at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/modinfo.c:1421
#4  0x00007ffff6e9ae34 in sr_modinfo_data_load (mod_info=0x7ffff2cfce40, mod_type=4 '\004', cache=1, sid=0x7ffff2cfdf10, request_xpath=0x60200005a970 "/*", timeout_ms=5000, opts=2, cb_error_info=0x7ffff2cfce20)
    at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/modinfo.c:1916
#5  0x00007ffff6ddcc6e in sr_get_data (session=0x7ffff2cfdf00, xpath=0x60200005a970 "/*", max_depth=0, timeout_ms=5000, opts=2, data=0x7ffff2cfd2a0) at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/sysrepo.c:1873
#6  0x00005555556a8267 in np2srv_rpc_get_cb (session=0x7ffff2cfdf00, op_path=0x60300002ce90 "/ietf-netconf:get", input=0x60700006f060, UNUSED_event=SR_EV_RPC, UNUSED_request_id=2, output=0x607000073580, UNUSED_private_data=0x0)
    at /home/vk/git/netconf-cli/submodules/dependencies/Netopeer2/src/netconf.c:100
#7  0x00007ffff6fb810f in sr_shmsub_rpc_listen_call_callback (rpc_sub=0x606000020cc0, tmp_sess=0x7ffff2cfdf00, input_op=0x60700006f060, event=SR_SUB_EV_RPC, request_id=2, output_op=0x7ffff2cfded0, err_code=0x7ffff2cfdef0)
    at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/shm_sub.c:2553
#8  0x00007ffff6fb4713 in sr_shmsub_rpc_listen_process_rpc_events (rpc_subs=0x617000006720, conn=0x613000000040) at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/shm_sub.c:2839
#9  0x00007ffff6df03b5 in sr_process_events (subscription=0x60d00002cb40, session=0x0, stop_time_in=0x7ffff2cfeb40) at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/sysrepo.c:3104
#10 0x00007ffff6fc2ac8 in sr_shmsub_listen_thread (arg=0x60d00002cb40) at /home/vk/git/netconf-cli/submodules/dependencies/sysrepo/src/shm_sub.c:3208
#11 0x00007ffff6cc73e9 in start_thread () from /usr/lib/libpthread.so.0
#12 0x00007ffff6a82293 in clone () from /usr/lib/libc.so.6
```