### PR TITLE
dictionary REFACTOR unify functions pattern to return LY_ERR

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -302,8 +302,13 @@ extern const char * const ly_devmod_list[];
  * @param[in] LEN length of the string in WORD to store.
  * @param[in,out] DYNAMIC Set to 1 if STR is dynamically allocated, 0 otherwise. If set to 1, zerocopy version of lydict_insert is used.
  */
-#define INSERT_STRING(CTX, STRING, LEN, DYNAMIC) \
-    (DYNAMIC ? lydict_insert_zc(CTX, (char *)(STRING)) : lydict_insert(CTX, LEN ? (STRING) : "", LEN)); DYNAMIC = 0
+#define INSERT_STRING_RET(CTX, STRING, LEN, DYNAMIC, TARGET) \
+    if (DYNAMIC) { \
+        LY_CHECK_RET(lydict_insert_zc(CTX, (char *)(STRING), &(TARGET))); \
+    } else { \
+        LY_CHECK_RET(lydict_insert(CTX, LEN ? (STRING) : "", LEN, &(TARGET))); \
+    } \
+    DYNAMIC = 0
 
 #define FREE_STRING(CTX, STRING) if (STRING) {lydict_remove(CTX, STRING);}
 

--- a/src/dict.h
+++ b/src/dict.h
@@ -19,6 +19,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "log.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -45,9 +47,12 @@ struct ly_ctx;
  * NULL terminated string, the len parameter says number of bytes stored in
  * dictionary. The specified number of bytes is duplicated and terminating NULL
  * byte is added automatically. If \p len is 0, it is count automatically using strlen().
- * @return pointer to the string stored in the dictionary, NULL if \p value was NULL.
+ * @param[out] str_p Optional parameter to get pointer to the string corresponding to the @p value and stored in dictionary.
+ * @return LY_SUCCESS in case of successful insertion into dictionary, note that the function does not return LY_EEXIST.
+ * @return LY_EINVAL in case of invalid input parameters.
+ * @return LY_EMEM in case of memory allocation failure.
  */
-const char *lydict_insert(const struct ly_ctx *ctx, const char *value, size_t len);
+LY_ERR lydict_insert(const struct ly_ctx *ctx, const char *value, size_t len, const char **str_p);
 
 /**
  * @brief Insert string into dictionary - zerocopy version. If the string is
@@ -61,9 +66,12 @@ const char *lydict_insert(const struct ly_ctx *ctx, const char *value, size_t le
  * dictionary. Otherwise, the reference counter is incremented and the value is
  * freed. So, after calling the function, caller is supposed to not use the
  * value address anymore. If NULL, function does nothing.
- * @return pointer to the string stored in the dictionary, NULL if \p value was NULL.
+ * @param[out] str_p Optional parameter to get pointer to the string corresponding to the @p value and stored in dictionary.
+ * @return LY_SUCCESS in case of successful insertion into dictionary, note that the function does not return LY_EEXIST.
+ * @return LY_EINVAL in case of invalid input parameters.
+ * @return LY_EMEM in case of memory allocation failure.
  */
-const char *lydict_insert_zc(const struct ly_ctx *ctx, char *value);
+LY_ERR lydict_insert_zc(const struct ly_ctx *ctx, char *value, const char **str_p);
 
 /**
  * @brief Remove specified string from the dictionary. It decrement reference

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -196,7 +196,8 @@ LY_ERR lyht_find_next(struct hash_table *ht, void *val_p, uint32_t hash, void **
  * @param[in] hash Hash of the stored value.
  * @param[out] match_p Pointer to the stored value, optional
  * @return LY_SUCCESS on success,
- * @return LY_EEXIST if the value is already present.
+ * @return LY_EEXIST in case the value is already present.
+ * @return LY_EMEM in case of memory allocation failure.
  */
 LY_ERR lyht_insert(struct hash_table *ht, void *val_p, uint32_t hash, void **match_p);
 
@@ -212,7 +213,8 @@ LY_ERR lyht_insert(struct hash_table *ht, void *val_p, uint32_t hash, void **mat
  * @param[in] resize_val_equal Val equal callback to use for resizing.
  * @param[out] match_p Pointer to the stored value, optional
  * @return LY_SUCCESS on success,
- * @return LY_EEXIST if the value is already present.
+ * @return LY_EEXIST in case the value is already present.
+ * @return LY_EMEM in case of memory allocation failure.
  */
 LY_ERR lyht_insert_with_resize_cb(struct hash_table *ht, void *val_p, uint32_t hash, values_equal_cb resize_val_equal,
         void **match_p);

--- a/src/parser.c
+++ b/src/parser.c
@@ -257,22 +257,22 @@ lys_parser_fill_filepath(struct ly_ctx *ctx, struct ly_in *in, const char **file
     switch (in->type) {
     case LY_IN_FILEPATH:
         if (realpath(in->method.fpath.filepath, path) != NULL) {
-            *filepath = lydict_insert(ctx, path, 0);
+            lydict_insert(ctx, path, 0, filepath);
         } else {
-            *filepath = lydict_insert(ctx, in->method.fpath.filepath, 0);
+            lydict_insert(ctx, in->method.fpath.filepath, 0, filepath);
         }
 
         break;
     case LY_IN_FD:
 #ifdef __APPLE__
         if (fcntl(in->method.fd, F_GETPATH, path) != -1) {
-            *filepath = lydict_insert(ctx, path, 0);
+            lydict_insert(ctx, path, 0, filepath);
         }
 #else
         /* get URI if there is /proc */
         sprintf(proc_path, "/proc/self/fd/%d", in->method.fd);
         if ((len = readlink(proc_path, path, PATH_MAX - 1)) > 0) {
-            *filepath = lydict_insert(ctx, path, len);
+            lydict_insert(ctx, path, len, filepath);
         }
 #endif
         break;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -317,8 +317,8 @@ lydjson_get_value_prefixes(const struct ly_ctx *ctx, const char *value, size_t v
                 }
                 if (!p) {
                     LY_ARRAY_NEW_GOTO(ctx, prefixes, p, ret, error);
-                    p->id = lydict_insert(ctx, start, len);
-                    p->module_name = lydict_insert(ctx, start, len);
+                    LY_CHECK_GOTO(ret = lydict_insert(ctx, start, len, &p->id), error);
+                    LY_CHECK_GOTO(ret = lydict_insert(ctx, start, len, &p->module_name), error);
                 } /* else the prefix already present */
             }
             stop = stop + bytes;
@@ -569,7 +569,7 @@ lydjson_metadata_finish(struct lyd_json_ctx *lydctx, struct lyd_node **first_p)
         if (prev != meta_container->name) {
             /* metas' names are stored in dictionary, so checking pointers must works */
             lydict_remove(lydctx->jsonctx->ctx, prev);
-            prev = lydict_insert(lydctx->jsonctx->ctx, meta_container->name, 0);
+            LY_CHECK_GOTO(ret = lydict_insert(lydctx->jsonctx->ctx, meta_container->name, 0, &prev), cleanup);
             instance = 1;
         } else {
             instance++;

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -432,14 +432,12 @@ lyb_parse_opaq_prefixes(struct lylyb_ctx *lybctx, struct ly_prefix **prefs)
         LY_ARRAY_INCREMENT(*prefs);
 
         /* prefix */
-        ret = lyb_read_string(&str, 1, lybctx);
-        LY_CHECK_GOTO(ret, cleanup);
-        (*prefs)[i].id = lydict_insert_zc(lybctx->ctx, str);
+        LY_CHECK_GOTO(ret = lyb_read_string(&str, 1, lybctx), cleanup);
+        LY_CHECK_GOTO(ret = lydict_insert_zc(lybctx->ctx, str, &(*prefs)[i].id), cleanup);
 
         /* module reference is the same as JSON name */
-        ret = lyb_read_string(&str, 1, lybctx);
-        LY_CHECK_GOTO(ret, cleanup);
-        (*prefs)[i].module_name = lydict_insert_zc(lybctx->ctx, str);
+        LY_CHECK_GOTO(ret = lyb_read_string(&str, 1, lybctx), cleanup);
+        LY_CHECK_GOTO(ret = lydict_insert_zc(lybctx->ctx, str, &(*prefs)[i].module_name), cleanup);
     }
 
 cleanup:
@@ -540,7 +538,7 @@ cleanup:
     }
     ly_free_val_prefs(lybctx->ctx, val_prefs);
     if (ret) {
-        ly_free_attr_siblings(lybctx->ctx, *attr);
+        lyd_free_attr_siblings(lybctx->ctx, *attr);
         *attr = NULL;
     }
     return ret;
@@ -884,7 +882,7 @@ cleanup:
     ly_free_val_prefs(ctx, val_prefs);
 
     lyd_free_meta_siblings(meta);
-    ly_free_attr_siblings(ctx, attr);
+    lyd_free_attr_siblings(ctx, attr);
     lyd_free_tree(node);
     return ret;
 }

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -81,14 +81,14 @@ lysp_stmt_ext(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SU
     LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *exts, e, LY_EMEM);
 
     /* store name and insubstmt info */
-    e->name = lydict_insert(PARSER_CTX(ctx), stmt->stmt, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->stmt, 0, &e->name));
     e->insubstmt = insubstmt;
     e->insubstmt_index = insubstmt_index;
     /* TODO (duplicate) e->child = stmt->child; */
 
     /* get optional argument */
     if (stmt->arg) {
-        e->argument = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+        LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &e->argument));
     }
 
     return LY_SUCCESS;
@@ -120,7 +120,7 @@ lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, L
     }
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, arg, stmt->arg));
-    *value = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, value));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
@@ -163,7 +163,7 @@ lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, 
 
     /* allocate new pointer */
     LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *texts, item, LY_EMEM);
-    *item = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, item));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
@@ -251,7 +251,7 @@ lysp_stmt_restr(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum l
     const struct lysp_stmt *child;
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
-    restr->arg = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &restr->arg));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
@@ -412,7 +412,7 @@ lysp_stmt_type_enum(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, en
         LY_CHECK_RET(lysp_check_enum_name(ctx, stmt->arg, strlen(stmt->arg)));
     } /* else nothing specific for YANG_BIT */
 
-    enm->name = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &enm->name));
     CHECK_UNIQUENESS(ctx, *enums, name, ly_stmt2str(enum_kw), enm->name);
 
     for (child = stmt->child; child; child = child->next) {
@@ -605,7 +605,7 @@ lysp_stmt_type_pattern_modifier(struct lys_parser_ctx *ctx, const struct lysp_st
 
     assert(buf[0] == 0x06);
     buf[0] = 0x15;
-    *pat = lydict_insert_zc(PARSER_CTX(ctx), buf);
+    LY_CHECK_RET(lydict_insert_zc(PARSER_CTX(ctx), buf, pat));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
@@ -652,7 +652,7 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
     memmove(buf + 1, stmt->arg, arg_len);
     buf[0] = 0x06; /* pattern's default regular-match flag */
     buf[arg_len + 1] = '\0'; /* terminating NULL byte */
-    restr->arg = lydict_insert_zc(PARSER_CTX(ctx), buf);
+    LY_CHECK_RET(lydict_insert_zc(PARSER_CTX(ctx), buf, &restr->arg));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
@@ -709,7 +709,7 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "type");
         return LY_EVALID;
     }
-    type->name = lydict_insert(PARSER_CTX(ctx), stmt->arg, 0);
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &type->name));
 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -195,7 +195,7 @@ lydxml_attrs(struct lyxml_ctx *xmlctx, struct lyd_attr **attr)
 
 cleanup:
     if (ret) {
-        ly_free_attr_siblings(xmlctx->ctx, *attr);
+        lyd_free_attr_siblings(xmlctx->ctx, *attr);
         *attr = NULL;
     }
     return ret;
@@ -611,7 +611,7 @@ lydxml_subtree_r(struct lyd_xml_ctx *lydctx, struct lyd_node_inner *parent, stru
 
 error:
     lyd_free_meta_siblings(meta);
-    ly_free_attr_siblings(ctx, attr);
+    lyd_free_attr_siblings(ctx, attr);
     lyd_free_tree(node);
     return ret;
 }
@@ -710,7 +710,7 @@ lydxml_envelope(struct lyxml_ctx *xmlctx, const char *name, const char *uri, str
     attr = NULL;
 
 cleanup:
-    ly_free_attr_siblings(xmlctx->ctx, attr);
+    lyd_free_attr_siblings(xmlctx->ctx, attr);
     return ret;
 }
 
@@ -897,7 +897,7 @@ lydxml_notif_envelope(struct lyxml_ctx *xmlctx, struct lyd_node **envp)
 cleanup:
     if (ret) {
         lyd_free_tree(*envp);
-        ly_free_attr_siblings(xmlctx->ctx, attr);
+        lyd_free_attr_siblings(xmlctx->ctx, attr);
     }
     return ret;
 }

--- a/src/plugins_exts_nacm.c
+++ b/src/plugins_exts_nacm.c
@@ -103,7 +103,7 @@ invalid_parent:
                 inherited->parent = iter;
                 inherited->parent_type = LYEXT_PAR_NODE;
                 if (c_ext->argument) {
-                    inherited->argument = lydict_insert(cctx->ctx, c_ext->argument, strlen(c_ext->argument));
+                    LY_CHECK_RET(lydict_insert(cctx->ctx, c_ext->argument, strlen(c_ext->argument), &inherited->argument));
                 }
                 /* TODO duplicate extension instances */
                 inherited->data = c_ext->data;

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -93,7 +93,7 @@ xml_print_ns(struct xmlpr_ctx *ctx, const char *ns, const char *new_prefix, uint
 
     /* and added into namespaces */
     if (new_prefix) {
-        new_prefix = lydict_insert(ctx->ctx, new_prefix, 0);
+        LY_CHECK_RET(lydict_insert(ctx->ctx, new_prefix, 0, &new_prefix), NULL);
     }
     LY_CHECK_RET(ly_set_add(&ctx->prefix, (void *)new_prefix, LY_SET_OPT_USEASLIST, NULL), NULL);
     LY_CHECK_RET(ly_set_add(&ctx->ns, (void *)ns, LY_SET_OPT_USEASLIST, &i), NULL);

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -894,7 +894,7 @@ void lyd_free_meta_siblings(struct lyd_meta *meta);
  * @param[in] ctx Context where the attributes were created.
  * @param[in] attr Attribute to free.
  */
-void ly_free_attr_single(const struct ly_ctx *ctx, struct lyd_attr *attr);
+void lyd_free_attr_single(const struct ly_ctx *ctx, struct lyd_attr *attr);
 
 /**
  * @brief Free the attribute with any following attributes.
@@ -902,7 +902,7 @@ void ly_free_attr_single(const struct ly_ctx *ctx, struct lyd_attr *attr);
  * @param[in] ctx Context where the attributes were created.
  * @param[in] attr First attribute to free.
  */
-void ly_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr);
+void lyd_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr);
 
 /**
  * @brief Check type restrictions applicable to the particular leaf/leaf-list with the given string @p value.

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -77,7 +77,7 @@ lyd_free_meta_siblings(struct lyd_meta *meta)
 }
 
 static void
-ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, ly_bool siblings)
+lyd_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, ly_bool siblings)
 {
     struct lyd_attr *iter;
     LY_ARRAY_COUNT_TYPE u;
@@ -128,15 +128,15 @@ ly_free_attr(const struct ly_ctx *ctx, struct lyd_attr *attr, ly_bool siblings)
 }
 
 API void
-ly_free_attr_single(const struct ly_ctx *ctx, struct lyd_attr *attr)
+lyd_free_attr_single(const struct ly_ctx *ctx, struct lyd_attr *attr)
 {
-    ly_free_attr(ctx, attr, 0);
+    lyd_free_attr(ctx, attr, 0);
 }
 
 API void
-ly_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr)
+lyd_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr)
 {
-    ly_free_attr(ctx, attr, 1);
+    lyd_free_attr(ctx, attr, 1);
 }
 
 void
@@ -197,7 +197,7 @@ lyd_free_subtree(struct lyd_node *node, ly_bool top)
     }
 
     if (!node->schema) {
-        ly_free_attr_siblings(LYD_CTX(node), opaq->attr);
+        lyd_free_attr_siblings(LYD_CTX(node), opaq->attr);
     } else {
         /* free the node's metadata */
         lyd_free_meta_siblings(node->meta);

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -280,7 +280,7 @@ lyd_any_copy_value(struct lyd_node *trg, const union lyd_any_value *value, LYD_A
     case LYD_ANYDATA_XML:
     case LYD_ANYDATA_JSON:
         if (value->str) {
-            t->value.str = lydict_insert(LYD_CTX(trg), value->str, 0);
+            LY_CHECK_RET(lydict_insert(LYD_CTX(trg), value->str, 0, &t->value.str));
         }
         break;
     case LYD_ANYDATA_LYB:

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1016,7 +1016,7 @@ lys_create_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_
     /* make sure that the newest revision is at position 0 */
     lysp_sort_revisions(mod->parsed->revs);
     if (mod->parsed->revs) {
-        mod->revision = lydict_insert(ctx, mod->parsed->revs[0].date, 0);
+        LY_CHECK_GOTO(ret = lydict_insert(ctx, mod->parsed->revs[0].date, 0, &mod->revision), error);
     }
 
     /* decide the latest revision */

--- a/src/xml.c
+++ b/src/xml.c
@@ -1111,8 +1111,8 @@ lyxml_get_prefixes(struct lyxml_ctx *xmlctx, const char *value, size_t value_len
                     }
                     if (!p) {
                         LY_ARRAY_NEW_GOTO(xmlctx->ctx, prefixes, p, ret, error);
-                        p->id = lydict_insert(xmlctx->ctx, start, len);
-                        p->module_ns = lydict_insert(xmlctx->ctx, ns->uri, 0);
+                        LY_CHECK_GOTO(ret = lydict_insert(xmlctx->ctx, start, len, &p->id), error);
+                        LY_CHECK_GOTO(ret = lydict_insert(xmlctx->ctx, ns->uri, 0, &p->module_ns), error);
                     } /* else the prefix already present */
                 }
             }

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -2678,7 +2678,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr, size_t expr_len, ly_
     /* init lyxp_expr structure */
     ret = calloc(1, sizeof *ret);
     LY_CHECK_ERR_GOTO(!ret, LOGMEM(ctx), error);
-    ret->expr = lydict_insert(ctx, expr, expr_len);
+    LY_CHECK_GOTO(lydict_insert(ctx, expr, expr_len, &ret->expr), error);
     LY_CHECK_ERR_GOTO(!ret->expr, LOGMEM(ctx), error);
     ret->used = 0;
     ret->size = LYXP_EXPR_SIZE_START;
@@ -2978,7 +2978,7 @@ lyxp_expr_dup(const struct ly_ctx *ctx, const struct lyxp_expr *exp)
 
     dup->used = exp->used;
     dup->size = exp->used;
-    dup->expr = lydict_insert(ctx, exp->expr, 0);
+    LY_CHECK_GOTO(lydict_insert(ctx, exp->expr, 0, &dup->expr), error);
 
     return dup;
 
@@ -7001,7 +7001,7 @@ eval_name_test_with_predicate(struct lyxp_expr *exp, uint16_t *tok_idx, ly_bool 
     if (!scnode && moveto_mod) {
         /* we are not able to match based on a schema node and not all the modules match,
          * use dictionary for efficient comparison */
-        ncname_dict = lydict_insert(set->ctx, ncname, ncname_len);
+        LY_CHECK_GOTO(rc = lydict_insert(set->ctx, ncname, ncname_len, &ncname_dict), cleanup);
     }
 
 moveto:

--- a/tests/utests/schema/test_parser_yin.c
+++ b/tests/utests/schema/test_parser_yin.c
@@ -1630,9 +1630,10 @@ test_modifier_elem(void **state)
 {
     struct test_parser_yin_state *st = *state;
     const char *data;
-    const char *pat = lydict_insert(st->ctx, "\006pattern", 8);
+    const char *pat;
     struct lysp_ext_instance *exts = NULL;
 
+    assert_int_equal(LY_SUCCESS, lydict_insert(st->ctx, "\006pattern", 8, &pat));
     data = ELEMENT_WRAPPER_START "<modifier value=\"invert-match\">" EXT_SUBELEM "</modifier>" ELEMENT_WRAPPER_END;
     assert_int_equal(test_element_helper(st, data, &pat, NULL, &exts), LY_SUCCESS);
     assert_string_equal(pat, "\x015pattern");
@@ -1643,7 +1644,7 @@ test_modifier_elem(void **state)
     exts = NULL;
     FREE_STRING(st->ctx, pat);
 
-    pat = lydict_insert(st->ctx, "\006pattern", 8);
+    assert_int_equal(LY_SUCCESS, lydict_insert(st->ctx, "\006pattern", 8, &pat));
     data = ELEMENT_WRAPPER_START "<modifier value=\"invert\" />" ELEMENT_WRAPPER_END;
     assert_int_equal(test_element_helper(st, data, &pat, NULL, NULL), LY_EVALID);
     logbuf_assert("Invalid value \"invert\" of \"value\" attribute in \"modifier\" element. Only valid value is \"invert-match\". Line number 1.");

--- a/tests/utests/test_hash_table.c
+++ b/tests/utests/test_hash_table.c
@@ -73,12 +73,12 @@ test_invalid_arguments(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0, &ctx));
 
-    assert_null(lydict_insert(NULL, NULL, 0));
+    assert_int_equal(LY_EINVAL, lydict_insert(NULL, NULL, 0, NULL));
     logbuf_assert("Invalid argument ctx (lydict_insert()).");
 
-    assert_null(lydict_insert_zc(NULL, NULL));
+    assert_int_equal(LY_EINVAL, lydict_insert_zc(NULL, NULL, NULL));
     logbuf_assert("Invalid argument ctx (lydict_insert_zc()).");
-    assert_null(lydict_insert_zc(ctx, NULL));
+    assert_int_equal(LY_EINVAL, lydict_insert_zc(ctx, NULL, NULL));
     logbuf_assert("Invalid argument value (lydict_insert_zc()).");
 
     ly_ctx_destroy(ctx, NULL);
@@ -89,19 +89,20 @@ test_dict_hit(void **state)
 {
     (void) state; /* unused */
 
-    const char *str1, *str2;
+    const char *str1, *str2, *str3;
     struct ly_ctx *ctx;
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0, &ctx));
 
     /* insert 2 strings, one of them repeatedly */
-    str1 = lydict_insert(ctx, "test1", 0);
+    assert_int_equal(LY_SUCCESS, lydict_insert(ctx, "test1", 0, &str1));
     assert_non_null(str1);
     /* via zerocopy we have to get the same pointer as provided */
     assert_non_null(str2 = strdup("test2"));
-    assert_true(str2 == lydict_insert_zc(ctx, (char *)str2));
+    assert_int_equal(LY_SUCCESS, lydict_insert_zc(ctx, (char *)str2, &str3));
+    assert_ptr_equal(str2, str3);
     /* here we get the same pointer as in case the string was inserted first time */
-    str2 = lydict_insert(ctx, "test1", 0);
+    assert_int_equal(LY_SUCCESS, lydict_insert(ctx, "test1", 0, &str2));
     assert_non_null(str2);
     assert_ptr_equal(str1, str2);
 


### PR DESCRIPTION
Change API functions manipulating with libyang dictionary to return
LY_ERR value as a primary indicator of the result and the value from the
dictionary is returned via optional output parameter.