### PR TITLE
Refactor preompiled structures

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -608,12 +608,12 @@ ylib_feature(struct lyd_node *parent, const struct lys_module *cur_mod)
         return LY_SUCCESS;
     }
 
-    LY_ARRAY_FOR(cur_mod->compiled->features, i) {
-        if (!(cur_mod->compiled->features[i].flags & LYS_FENABLED)) {
+    LY_ARRAY_FOR(cur_mod->features, i) {
+        if (!(cur_mod->features[i].flags & LYS_FENABLED)) {
             continue;
         }
 
-        LY_CHECK_RET(lyd_new_term(parent, NULL, "feature", cur_mod->compiled->features[i].name, NULL));
+        LY_CHECK_RET(lyd_new_term(parent, NULL, "feature", cur_mod->features[i].name, NULL));
     }
 
     return LY_SUCCESS;

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -1236,11 +1236,8 @@ ly_type_store_identityref(const struct ly_ctx *ctx, struct lysc_type *type, cons
         rc = asprintf(&errmsg, "Invalid identityref \"%.*s\" value - unable to map prefix to YANG schema.", (int)value_len, value);
         goto error;
     }
-    if (mod->compiled) {
-        identities = mod->compiled->identities;
-    } else {
-        identities = mod->dis_identities;
-    }
+
+    identities = mod->identities;
     LY_ARRAY_FOR(identities, u) {
         ident = &identities[u]; /* shortcut */
         if (!ly_strncmp(ident->name, id_name, id_len)) {

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -2351,8 +2351,8 @@ yang_print_compiled(struct ly_out *out, const struct lys_module *module, uint32_
         yprc_extension_instances(ctx, LYEXT_SUBSTMT_SELF, 0, module->compiled->exts, NULL, 0);
     }
 
-    LY_ARRAY_FOR(modc->features, u) {
-        yprc_feature(ctx, &modc->features[u]);
+    LY_ARRAY_FOR(module->features, u) {
+        yprc_feature(ctx, &module->features[u]);
     }
 
     LY_ARRAY_FOR(modc->identities, u) {

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -2355,8 +2355,8 @@ yang_print_compiled(struct ly_out *out, const struct lys_module *module, uint32_
         yprc_feature(ctx, &module->features[u]);
     }
 
-    LY_ARRAY_FOR(modc->identities, u) {
-        yprc_identity(ctx, &modc->identities[u]);
+    LY_ARRAY_FOR(module->identities, u) {
+        yprc_identity(ctx, &module->identities[u]);
     }
 
     if (!(ctx->options & LYS_PRINT_NO_SUBSTMT)) {

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -574,7 +574,7 @@ lys_feature_change(const struct lys_module *mod, const char *name, ly_bool value
                mod->name);
         return LY_EINVAL;
     }
-    if (!mod->compiled->features) {
+    if (!mod->features) {
         if (all) {
             /* no feature to enable */
             return LY_SUCCESS;
@@ -587,8 +587,8 @@ lys_feature_change(const struct lys_module *mod, const char *name, ly_bool value
     changed_count = 0;
 
 run:
-    for (disabled_count = u = 0; u < LY_ARRAY_COUNT(mod->compiled->features); ++u) {
-        f = &mod->compiled->features[u];
+    for (disabled_count = u = 0; u < LY_ARRAY_COUNT(mod->features); ++u) {
+        f = &mod->features[u];
         if (all || !strcmp(f->name, name)) {
             if ((value && (f->flags & LYS_FENABLED)) || (!value && !(f->flags & LYS_FENABLED))) {
                 if (all) {
@@ -648,11 +648,11 @@ next:
         if (changed_count == changed->count) {
             /* no change in last run -> not able to enable all ... */
             /* ... print errors */
-            for (u = 0; disabled_count && u < LY_ARRAY_COUNT(mod->compiled->features); ++u) {
-                if (!(mod->compiled->features[u].flags & LYS_FENABLED)) {
+            for (u = 0; disabled_count && u < LY_ARRAY_COUNT(mod->features); ++u) {
+                if (!(mod->features[u].flags & LYS_FENABLED)) {
                     LOGERR(ctx, LY_EDENIED,
                            "Feature \"%s\" cannot be enabled since it is disabled by its if-feature condition(s).",
-                           mod->compiled->features[u].name);
+                           mod->features[u].name);
                     --disabled_count;
                 }
             }
@@ -738,15 +738,13 @@ API LY_ERR
 lys_feature_value(const struct lys_module *module, const char *feature)
 {
     struct lysc_feature *f = NULL;
-    struct lysc_module *mod;
     LY_ARRAY_COUNT_TYPE u;
 
     LY_CHECK_ARG_RET(NULL, module, module->compiled, feature, -1);
-    mod = module->compiled;
 
     /* search for the specified feature */
-    LY_ARRAY_FOR(mod->features, u) {
-        f = &mod->features[u];
+    LY_ARRAY_FOR(module->features, u) {
+        f = &module->features[u];
         if (!strcmp(f->name, feature)) {
             break;
         }
@@ -1121,7 +1119,7 @@ lys_create_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_
 
     if (!mod->implemented) {
         /* pre-compile features and identities of the module */
-        LY_CHECK_GOTO(ret = lys_feature_precompile(NULL, ctx, mod, mod->parsed->features, &mod->dis_features), error);
+        LY_CHECK_GOTO(ret = lys_feature_precompile(NULL, ctx, mod, mod->parsed->features, &mod->features), error);
         LY_CHECK_GOTO(ret = lys_identity_precompile(NULL, ctx, mod, mod->parsed->identities, &mod->dis_identities), error);
     }
 
@@ -1142,7 +1140,7 @@ finish_parsing:
         /* pre-compile features and identities of any submodules */
         LY_ARRAY_FOR(mod->parsed->includes, u) {
             LY_CHECK_GOTO(ret = lys_feature_precompile(NULL, ctx, mod, mod->parsed->includes[u].submodule->features,
-                                                       &mod->dis_features), error);
+                                                       &mod->features), error);
             LY_CHECK_GOTO(ret = lys_identity_precompile(NULL, ctx, mod, mod->parsed->includes[u].submodule->identities,
                                                         &mod->dis_identities), error);
         }

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1120,7 +1120,7 @@ lys_create_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_
     if (!mod->implemented) {
         /* pre-compile features and identities of the module */
         LY_CHECK_GOTO(ret = lys_feature_precompile(NULL, ctx, mod, mod->parsed->features, &mod->features), error);
-        LY_CHECK_GOTO(ret = lys_identity_precompile(NULL, ctx, mod, mod->parsed->identities, &mod->dis_identities), error);
+        LY_CHECK_GOTO(ret = lys_identity_precompile(NULL, ctx, mod, mod->parsed->identities, &mod->identities), error);
     }
 
     if (latest) {
@@ -1142,7 +1142,7 @@ finish_parsing:
             LY_CHECK_GOTO(ret = lys_feature_precompile(NULL, ctx, mod, mod->parsed->includes[u].submodule->features,
                                                        &mod->features), error);
             LY_CHECK_GOTO(ret = lys_identity_precompile(NULL, ctx, mod, mod->parsed->includes[u].submodule->identities,
-                                                        &mod->dis_identities), error);
+                                                        &mod->identities), error);
         }
     }
 

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1644,7 +1644,6 @@ struct lysc_node_anydata {
 struct lysc_module {
     struct lys_module *mod;          /**< covering module structure */
 
-    struct lysc_ident *identities;   /**< list of identities ([sized array](@ref sizedarrays)) */
     struct lysc_node *data;          /**< list of module's top-level data nodes (linked list) */
     struct lysc_action *rpcs;        /**< list of RPCs ([sized array](@ref sizedarrays)) */
     struct lysc_notif *notifs;       /**< list of notifications ([sized array](@ref sizedarrays)) */
@@ -1834,10 +1833,12 @@ struct lys_module {
                                           from if-feature statements of the compiled schemas and their proper use in case
                                           the module became implemented in future (no matter if implicitly via augment/deviate
                                           or explicitly via ::lys_set_implemented()). */
-    struct lysc_ident *dis_identities;/**< List of pre-compiled identities in a non-implemented module ([sized array](@ref sizedarrays))
-                                          These identities cannot be instantiated in data (in identityrefs) until
-                                          the module is implemented but can be linked by identities in implemented
-                                          modules. */
+    struct lysc_ident *identities;   /**< List of compiled identities of the module ([sized array](@ref sizedarrays))
+                                          Identities are outside the compiled tree to allow their linkage to the identities from
+                                          the implemented modules. This avoids problems when the module became implemented in
+                                          future (no matter if implicitly via augment/deviate or explicitly via
+                                          ::lys_set_implemented()). Note that if the module is not implemented (compiled), the
+                                          identities cannot be instantiated in data (in identityrefs). */
     uint8_t implemented;             /**< flag if the module is implemented, not just imported. The module is implemented if
                                           the flag has non-zero value. Specific values are used internally:
                                           1 - implemented module

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1644,7 +1644,6 @@ struct lysc_node_anydata {
 struct lysc_module {
     struct lys_module *mod;          /**< covering module structure */
 
-    struct lysc_feature *features;   /**< list of feature definitions ([sized array](@ref sizedarrays)) */
     struct lysc_ident *identities;   /**< list of identities ([sized array](@ref sizedarrays)) */
     struct lysc_node *data;          /**< list of module's top-level data nodes (linked list) */
     struct lysc_action *rpcs;        /**< list of RPCs ([sized array](@ref sizedarrays)) */
@@ -1828,12 +1827,13 @@ struct lys_module {
     struct lysp_module *parsed;      /**< Simply parsed (unresolved) YANG schema tree */
     struct lysc_module *compiled;    /**< Compiled and fully validated YANG schema tree for data parsing.
                                           Available only for implemented modules. */
-    struct lysc_feature *dis_features;/**< List of pre-compiled features in a non implemented module ([sized array](@ref sizedarrays)).
-                                          These features are always disabled and cannot be enabled until the module
-                                          is implemented. The features are present in this form to allow their linkage
+    struct lysc_feature *features;   /**< List of compiled features of the module ([sized array](@ref sizedarrays)).
+                                          Features are outside the compiled tree since they are needed even the module is not
+                                          compiled. In such a case, the features are always disabled and cannot be enabled until
+                                          the module is implemented. The features are present in this form to allow their linkage
                                           from if-feature statements of the compiled schemas and their proper use in case
                                           the module became implemented in future (no matter if implicitly via augment/deviate
-                                          or explicitly via ly_ctx_module_implement()). */
+                                          or explicitly via ::lys_set_implemented()). */
     struct lysc_ident *dis_identities;/**< List of pre-compiled identities in a non-implemented module ([sized array](@ref sizedarrays))
                                           These identities cannot be instantiated in data (in identityrefs) until
                                           the module is implemented but can be linked by identities in implemented

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -830,7 +830,6 @@ lysc_module_free_(struct lysc_module *module)
     LY_CHECK_ARG_RET(NULL, module, );
     ctx = module->mod->ctx;
 
-    FREE_ARRAY(ctx, module->features, lysc_feature_free);
     FREE_ARRAY(ctx, module->identities, lysc_ident_free);
 
     LY_LIST_FOR_SAFE(module->data, node_next, node) {
@@ -864,7 +863,7 @@ lys_module_free(struct lys_module *module, void (*private_destructor)(const stru
     }
 
     lysc_module_free(module->compiled, private_destructor);
-    FREE_ARRAY(module->ctx, module->dis_features, lysc_feature_free);
+    FREE_ARRAY(module->ctx, module->features, lysc_feature_free);
     FREE_ARRAY(module->ctx, module->dis_identities, lysc_ident_free);
     lysp_module_free(module->parsed);
 

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -830,8 +830,6 @@ lysc_module_free_(struct lysc_module *module)
     LY_CHECK_ARG_RET(NULL, module, );
     ctx = module->mod->ctx;
 
-    FREE_ARRAY(ctx, module->identities, lysc_ident_free);
-
     LY_LIST_FOR_SAFE(module->data, node_next, node) {
         lysc_node_free(ctx, node);
     }
@@ -864,7 +862,7 @@ lys_module_free(struct lys_module *module, void (*private_destructor)(const stru
 
     lysc_module_free(module->compiled, private_destructor);
     FREE_ARRAY(module->ctx, module->features, lysc_feature_free);
-    FREE_ARRAY(module->ctx, module->dis_identities, lysc_ident_free);
+    FREE_ARRAY(module->ctx, module->identities, lysc_ident_free);
     lysp_module_free(module->parsed);
 
     FREE_STRING(module->ctx, module->name);

--- a/tests/utests/schema/test_schema_stmts.c
+++ b/tests/utests/schema/test_schema_stmts.c
@@ -224,26 +224,26 @@ test_feature(void **state)
                    "feature f7 {if-feature \"(f2 and f3) or (not f1)\";}\n"
                    "feature f8 {if-feature \"f1 or f2 or f3 or orfeature or andfeature\";}\n"
                    "feature f9 {if-feature \"not not f1\";}", mod);
-    assert_non_null(mod->compiled->features);
-    assert_int_equal(9, LY_ARRAY_COUNT(mod->compiled->features));
+    assert_non_null(mod->features);
+    assert_int_equal(9, LY_ARRAY_COUNT(mod->features));
 
     /* all features are disabled by default */
-    LY_ARRAY_FOR(mod->compiled->features, struct lysc_feature, f) {
+    LY_ARRAY_FOR(mod->features, struct lysc_feature, f) {
         assert_int_equal(LY_ENOT, lysc_feature_value(f));
     }
     /* enable f1 */
     assert_int_equal(LY_SUCCESS, lys_feature_enable(mod, "f1"));
-    f1 = &mod->compiled->features[0];
+    f1 = &mod->features[0];
     assert_int_equal(LY_SUCCESS, lysc_feature_value(f1));
 
     /* enable orfeature */
-    f = &mod->compiled->features[3];
+    f = &mod->features[3];
     assert_int_equal(LY_ENOT, lysc_feature_value(f));
     assert_int_equal(LY_SUCCESS, lys_feature_enable(mod, "orfeature"));
     assert_int_equal(LY_SUCCESS, lysc_feature_value(f));
 
     /* enable andfeature - no possible since f2 is disabled */
-    f = &mod->compiled->features[4];
+    f = &mod->features[4];
     assert_int_equal(LY_ENOT, lysc_feature_value(f));
     assert_int_equal(LY_EDENIED, lys_feature_enable(mod, "andfeature"));
     logbuf_assert("Feature \"andfeature\" cannot be enabled since it is disabled by its if-feature condition(s).");
@@ -255,7 +255,7 @@ test_feature(void **state)
     assert_int_equal(LY_SUCCESS, lysc_feature_value(f));
 
     /* f1 is enabled, so f6 cannot be enabled */
-    f = &mod->compiled->features[5];
+    f = &mod->features[5];
     assert_int_equal(LY_ENOT, lysc_feature_value(f));
     assert_int_equal(LY_EDENIED, lys_feature_enable(mod, "f6"));
     logbuf_assert("Feature \"f6\" cannot be enabled since it is disabled by its if-feature condition(s).");
@@ -265,24 +265,24 @@ test_feature(void **state)
     assert_int_equal(LY_SUCCESS, lysc_feature_value(f1));
     assert_int_equal(LY_SUCCESS, lys_feature_disable(mod, "f1"));
     assert_int_equal(LY_ENOT, lysc_feature_value(f1));
-    assert_int_equal(LY_ENOT, lysc_feature_value(&mod->compiled->features[4]));
+    assert_int_equal(LY_ENOT, lysc_feature_value(&mod->features[4]));
     /* while orfeature is stille enabled */
-    assert_int_equal(LY_SUCCESS, lysc_feature_value(&mod->compiled->features[3]));
+    assert_int_equal(LY_SUCCESS, lysc_feature_value(&mod->features[3]));
     /* and finally f6 can be enabled */
     assert_int_equal(LY_SUCCESS, lys_feature_enable(mod, "f6"));
-    assert_int_equal(LY_SUCCESS, lysc_feature_value(&mod->compiled->features[5]));
+    assert_int_equal(LY_SUCCESS, lysc_feature_value(&mod->features[5]));
 
     /* complex evaluation of f7: f1 and f3 are disabled, while f2 is enabled */
-    assert_int_equal(LY_SUCCESS, lysc_iffeature_value(&mod->compiled->features[6].iffeatures[0]));
+    assert_int_equal(LY_SUCCESS, lysc_iffeature_value(&mod->features[6].iffeatures[0]));
     /* long evaluation of f8 to need to reallocate internal stack for operators */
-    assert_int_equal(LY_SUCCESS, lysc_iffeature_value(&mod->compiled->features[7].iffeatures[0]));
+    assert_int_equal(LY_SUCCESS, lysc_iffeature_value(&mod->features[7].iffeatures[0]));
 
     /* double negation of disabled f1 -> disabled */
-    assert_int_equal(LY_ENOT, lysc_iffeature_value(&mod->compiled->features[8].iffeatures[0]));
+    assert_int_equal(LY_ENOT, lysc_iffeature_value(&mod->features[8].iffeatures[0]));
 
     /* disable all features */
     assert_int_equal(LY_SUCCESS, lys_feature_disable(mod, "*"));
-    LY_ARRAY_FOR(mod->compiled->features, struct lysc_feature, f) {
+    LY_ARRAY_FOR(mod->features, struct lysc_feature, f) {
         assert_int_equal(LY_ENOT, lys_feature_value(mod, f->name));
     }
     /* re-setting already set feature */
@@ -300,19 +300,18 @@ test_feature(void **state)
     assert_int_equal(LY_ENOT, lys_feature_value(mod, "f2"));
 
     TEST_SCHEMA_OK(ctx, 0, 0, "b", "feature f1 {if-feature f2;}feature f2;", mod);
-    assert_non_null(mod->compiled);
-    assert_non_null(mod->compiled->features);
-    assert_int_equal(2, LY_ARRAY_COUNT(mod->compiled->features));
-    assert_non_null(mod->compiled->features[0].iffeatures);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->features[0].iffeatures));
-    assert_non_null(mod->compiled->features[0].iffeatures[0].features);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->features[0].iffeatures[0].features));
-    assert_ptr_equal(&mod->compiled->features[1], mod->compiled->features[0].iffeatures[0].features[0]);
-    assert_non_null(mod->compiled->features);
-    assert_int_equal(2, LY_ARRAY_COUNT(mod->compiled->features));
-    assert_non_null(mod->compiled->features[1].depfeatures);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->features[1].depfeatures));
-    assert_ptr_equal(&mod->compiled->features[0], mod->compiled->features[1].depfeatures[0]);
+    assert_non_null(mod->features);
+    assert_int_equal(2, LY_ARRAY_COUNT(mod->features));
+    assert_non_null(mod->features[0].iffeatures);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->features[0].iffeatures));
+    assert_non_null(mod->features[0].iffeatures[0].features);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->features[0].iffeatures[0].features));
+    assert_ptr_equal(&mod->features[1], mod->features[0].iffeatures[0].features[0]);
+    assert_non_null(mod->features);
+    assert_int_equal(2, LY_ARRAY_COUNT(mod->features));
+    assert_non_null(mod->features[1].depfeatures);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->features[1].depfeatures));
+    assert_ptr_equal(&mod->features[0], mod->features[1].depfeatures[0]);
 
     /* invalid reference */
     assert_int_equal(LY_ENOTFOUND, lys_feature_enable(mod, "xxx"));

--- a/tests/utests/schema/test_schema_stmts.c
+++ b/tests/utests/schema/test_schema_stmts.c
@@ -96,26 +96,25 @@ test_identity(void **state)
                    "identity b1; identity b2; identity b3 {base b1; base b:b2; base a:a1;}"
                    "identity b4 {base b:b1; base b3;}", mod);
     assert_non_null(mod_imp->compiled);
-    assert_non_null(mod_imp->compiled->identities);
-    assert_non_null(mod->compiled);
-    assert_non_null(mod->compiled->identities);
-    assert_non_null(mod_imp->compiled->identities[0].derived);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod_imp->compiled->identities[0].derived));
-    assert_ptr_equal(mod_imp->compiled->identities[0].derived[0], &mod->compiled->identities[2]);
-    assert_non_null(mod->compiled->identities[0].derived);
-    assert_int_equal(2, LY_ARRAY_COUNT(mod->compiled->identities[0].derived));
-    assert_ptr_equal(mod->compiled->identities[0].derived[0], &mod->compiled->identities[2]);
-    assert_ptr_equal(mod->compiled->identities[0].derived[1], &mod->compiled->identities[3]);
-    assert_non_null(mod->compiled->identities[1].derived);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->identities[1].derived));
-    assert_ptr_equal(mod->compiled->identities[1].derived[0], &mod->compiled->identities[2]);
-    assert_non_null(mod->compiled->identities[2].derived);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->identities[2].derived));
-    assert_ptr_equal(mod->compiled->identities[2].derived[0], &mod->compiled->identities[3]);
+    assert_non_null(mod_imp->identities);
+    assert_non_null(mod->identities);
+    assert_non_null(mod_imp->identities[0].derived);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod_imp->identities[0].derived));
+    assert_ptr_equal(mod_imp->identities[0].derived[0], &mod->identities[2]);
+    assert_non_null(mod->identities[0].derived);
+    assert_int_equal(2, LY_ARRAY_COUNT(mod->identities[0].derived));
+    assert_ptr_equal(mod->identities[0].derived[0], &mod->identities[2]);
+    assert_ptr_equal(mod->identities[0].derived[1], &mod->identities[3]);
+    assert_non_null(mod->identities[1].derived);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->identities[1].derived));
+    assert_ptr_equal(mod->identities[1].derived[0], &mod->identities[2]);
+    assert_non_null(mod->identities[2].derived);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->identities[2].derived));
+    assert_ptr_equal(mod->identities[2].derived[0], &mod->identities[3]);
 
     TEST_SCHEMA_OK(ctx, 1, 0, "c", "identity c2 {base c1;} identity c1;", mod);
-    assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->identities[1].derived));
-    assert_ptr_equal(mod->compiled->identities[1].derived[0], &mod->compiled->identities[0]);
+    assert_int_equal(1, LY_ARRAY_COUNT(mod->identities[1].derived));
+    assert_ptr_equal(mod->identities[1].derived[0], &mod->identities[0]);
 
     TEST_SCHEMA_ERR(ctx, 0, 0, "inv", "identity i1;identity i1;", "Duplicate identifier \"i1\" of identity statement. /inv:{identity='i1'}");
 

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -127,16 +127,16 @@ test_module(void **state)
     assert_string_equal("urn:test", mod->ns);
     assert_string_equal("t", mod->prefix);
     /* features */
-    assert_non_null(mod->compiled->features);
-    assert_int_equal(2, LY_ARRAY_COUNT(mod->compiled->features));
-    f = &mod->compiled->features[1];
+    assert_non_null(mod->features);
+    assert_int_equal(2, LY_ARRAY_COUNT(mod->features));
+    f = &mod->features[1];
     assert_non_null(f->iffeatures);
     assert_int_equal(1, LY_ARRAY_COUNT(f->iffeatures));
     iff = &f->iffeatures[0];
     assert_non_null(iff->expr);
     assert_non_null(iff->features);
     assert_int_equal(1, LY_ARRAY_COUNT(iff->features));
-    assert_ptr_equal(&mod->compiled->features[0], iff->features[0]);
+    assert_ptr_equal(&mod->features[0], iff->features[0]);
 
     /* submodules cannot be compiled directly */
     str = "submodule test {belongs-to xxx {prefix x;}}";

--- a/tools/lint/commands.c
+++ b/tools/lint/commands.c
@@ -1259,11 +1259,7 @@ cmd_feature(const char *arg)
 
         printf("%s features:\n", module->name);
 
-        if (module->compiled) {
-            features = module->compiled->features;
-        } else {
-            features = module->dis_features;
-        }
+        features = module->features;
 
         /* get the max len */
         LY_ARRAY_FOR(features, u) {


### PR DESCRIPTION
Do not move features and identities between `lys_module` and `lysc_module`. It is confusing and it is not necessary. The features and identities will be always present in the `lys_module`.