### PR TITLE
libyang2: schema tree BUGFIX lys_compile_unres_xpath when condition null dereference

### DIFF
--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -6958,7 +6958,11 @@ lys_compile_unres_xpath(struct lysc_ctx *ctx, const struct lysc_node *node)
         ret = lyxp_atomize(when[u]->cond, LY_PREF_SCHEMA, when[u]->module, when[u]->context ? when[u]->context : node,
                            when[u]->context ? LYXP_NODE_ELEM : LYXP_NODE_ROOT_CONFIG, &tmp_set, opts);
         if (ret != LY_SUCCESS) {
-            LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid when condition \"%s\".", when[u]->cond->expr);
+	    if (when[u]->cond == NULL) {
+                LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid, when condition shouldn't be NULL");
+	    } else {
+                LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid when condition \"%s\".", when[u]->cond->expr);
+	    }
             goto cleanup;
         }
 


### PR DESCRIPTION
Hello,

this PR fixes a NULL dereference in lys_compile_unres_xpath. The file causing the crash is below:

```
module d00000000 {
	namespace "n";
    prefix d;
    leaf l1 {
        type string;
        when "/l0{k='when']";
    }
}
```

This was found through the fuzz regression tests in #1199. As fuzz regression testing uses the lys_parse_mem fuzz harness for testing, and #1199 contains a fix or the harness to bring it up to date with the new API this issue can't be reproduced with it on the libyang2 branch. However, I've attached an example that can be used to reproduce the issue below.

```
#include <stdio.h>
#include <libyang/libyang.h>

int main(int argc, char **argv) {
	struct ly_ctx *ctx = NULL;
	FILE *f = NULL;
	size_t len = 0;
	int err = 0;
	char *data = NULL;

	if (argc != 2) {
		printf("invalid number of arguments\n");
		return -1;
	}

	ly_log_options(0);
	err = ly_ctx_new(NULL, 0, &ctx);
	if (err != LY_SUCCESS) {
		printf("context fail\n");
		return -1;
	}

	f = fopen(argv[1], "r");
	if (f == NULL) {
		printf("fopen fail\n");
		return -1;
	}

	fseek(f, 0, SEEK_END);
	len = ftell(f);
	fseek(f, 0, SEEK_SET);

	data = malloc(len + 1);
	if (data == NULL) {
		printf("malloc fail\n");
		fclose(f);
		return -1;
	}

	fread(data, len, 1, f);
	data[len] = 0;

	lys_parse_mem(ctx, data, LYS_IN_YANG, NULL);
	fclose(f);
	free(data);

	return 0;
}
```

When reproducing the crash, libyang logging has to be disabled, which I've done with `ly_log_options(0)`. Otherwise the crash doesn't seem to appear.