### PR TITLE
libyang2: schema tree BUGFIX lys_compile_unres_xpath must null dereference

### DIFF
--- a/src/tree_schema_compile.c
+++ b/src/tree_schema_compile.c
@@ -6995,7 +6995,11 @@ check_musts:
     LY_ARRAY_FOR(musts, u) {
         ret = lyxp_atomize(musts[u].cond, LY_PREF_SCHEMA, musts[u].module, node, LYXP_NODE_ELEM, &tmp_set, opts);
         if (ret != LY_SUCCESS) {
-            LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid must restriction \"%s\".", musts[u].cond->expr);
+	    if (musts[u].cond == NULL) {
+                LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid, must restriction shouldn't be NULL");
+	    } else {
+                LOGVAL(ctx->ctx, LY_VLOG_LYSC, node, LYVE_SEMANTICS, "Invalid must restriction \"%s\".", musts[u].cond->expr);
+	    }
             goto cleanup;
         }
 


### PR DESCRIPTION
Hello,

this is similar to #1200. The file causing the crash is below:

```
module d{
	namespace "";
	prefix d;
	leaf f {
		type string;
		must "0e";
		default "";
	}
}
```

To reproduce this, the same example from #1200 can be used:

```
#include <stdio.h>
#include <libyang/libyang.h>

int main(int argc, char **argv) {
	struct ly_ctx *ctx = NULL;
	FILE *f = NULL;
	size_t len = 0;
	int err = 0;
	char *data = NULL;

	if (argc != 2) {
		printf("invalid number of arguments\n");
		return -1;
	}

	ly_log_options(0);
	err = ly_ctx_new(NULL, 0, &ctx);
	if (err != LY_SUCCESS) {
		printf("context fail\n");
		return -1;
	}

	f = fopen(argv[1], "r");
	if (f == NULL) {
		printf("fopen fail\n");
		return -1;
	}

	fseek(f, 0, SEEK_END);
	len = ftell(f);
	fseek(f, 0, SEEK_SET);

	data = malloc(len + 1);
	if (data == NULL) {
		printf("malloc fail\n");
		fclose(f);
		return -1;
	}

	fread(data, len, 1, f);
	data[len] = 0;

	lys_parse_mem(ctx, data, LYS_IN_YANG, NULL);
	fclose(f);
	free(data);

	return 0;
}
```

The issue also only appears when libyang logging is turned off.

Regards,
Juraj