### PR TITLE
libyang2: data BUGFIX handle NULL lydctx received from lyd_parse_*_data

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -331,6 +331,8 @@ lyd_parse_data(const struct ly_ctx *ctx, struct ly_in *in, LYD_FORMAT format, ui
         LOGINT_RET(ctx);
     }
 
+    LY_CHECK_RET(lydctx == NULL, LY_EINVAL);
+
     if (!(parse_options & LYD_PARSE_ONLY)) {
         uint32_t i = 0;
         const struct lys_module *mod;


### PR DESCRIPTION
Hello,

the attached file caused an invalid pointer dereference in libyang2.
[jsoncrash.zip](https://github.com/CESNET/libyang/files/5238770/jsoncrash.zip)

The issue appeared in the cleanup label of lyd_parse_data, in src/tree_data.c:386. There is an attempt to free lydctx, however as it is null, lydctx->free is an invalid read. lydctx is NULL in this case as lyd_parse_json_data called lyd_parse_json_init, which skipped the whole file due to it all being whitespace. Then since it reached the end of the file it returned LY_SUCCESS but never initialized lydctx, so it remained NULL. lyd_parse_json_data checks for either a non 0 return value or lydctx being null after the call to lyd_parse_json_init, which then jumps to cleanup. Due to that I assume that a NULL lydctx being returned is possible, so I've added a NULL check after that call to lyd_parse_json_data. This should also catch a NULL lydctx from the other data tree parsers.

To test the crash, the lyd_parse_mem harness could be used, but it needs some updates, which are in #1199. So this small program can be used instead:

```
#include <stdio.h>
#include <stdlib.h>

#include <libyang/libyang.h>

int main(int argc, char **argv)
{
	struct ly_ctx *ctx = NULL;
	const char *schema_a = "module defs {namespace urn:tests:defs;prefix d;yang-version 1.1;"
		            "identity crypto-alg; identity interface-type; identity ethernet {base interface-type;} identity fast-ethernet {base ethernet;}}";
    const char *schema_b = "module types {namespace urn:tests:types;prefix t;yang-version 1.1; import defs {prefix defs;}"
            "feature f; identity gigabit-ethernet { base defs:ethernet;}"
            "container cont {leaf leaftarget {type empty;}"
                            "list listtarget {key id; max-elements 5;leaf id {type uint8;} leaf value {type string;}}"
                            "leaf-list leaflisttarget {type uint8; max-elements 5;}}"
            "list list {key id; leaf id {type string;} leaf value {type string;} leaf-list targets {type string;}}"
            "list list2 {key \"id value\"; leaf id {type string;} leaf value {type string;}}"
            "list list_inst {key id; leaf id {type instance-identifier {require-instance true;}} leaf value {type string;}}"
            "list list_ident {key id; leaf id {type identityref {base defs:interface-type;}} leaf value {type string;}}"
            "leaf-list leaflisttarget {type string;}"
            "leaf binary {type binary {length 5 {error-message \"This base64 value must be of length 5.\";}}}"
            "leaf binary-norestr {type binary;}"
            "leaf int8 {type int8 {range 10..20;}}"
            "leaf uint8 {type uint8 {range 150..200;}}"
            "leaf int16 {type int16 {range -20..-10;}}"
            "leaf uint16 {type uint16 {range 150..200;}}"
            "leaf int32 {type int32;}"
            "leaf uint32 {type uint32;}"
            "leaf int64 {type int64;}"
            "leaf uint64 {type uint64;}"
            "leaf bits {type bits {bit zero; bit one {if-feature f;} bit two;}}"
            "leaf enums {type enumeration {enum white; enum yellow {if-feature f;}}}"
            "leaf dec64 {type decimal64 {fraction-digits 1; range 1.5..10;}}"
            "leaf dec64-norestr {type decimal64 {fraction-digits 18;}}"
            "leaf str {type string {length 8..10; pattern '[a-z ]*';}}"
            "leaf str-norestr {type string;}"
            "leaf str-utf8 {type string{length 2..5; pattern '€*';}}"
            "leaf bool {type boolean;}"
            "leaf empty {type empty;}"
            "leaf ident {type identityref {base defs:interface-type;}}"
 	    "leaf inst {type instance-identifier {require-instance true;}}"
            "leaf inst-noreq {type instance-identifier {require-instance false;}}"
            "leaf lref {type leafref {path /leaflisttarget; require-instance true;}}"
            "leaf lref2 {type leafref {path \"../list[id = current()/../str-norestr]/targets\"; require-instance true;}}"
            "leaf un1 {type union {"
            "type leafref {path /int8; require-instance true;}"
            "type union { type identityref {base defs:interface-type;} type instance-identifier {require-instance true;} }"
            "type string {length 1..20;}}}}";
    	char *data = NULL;
	FILE *f = NULL;
	size_t len = 0;
	struct lyd_node *tree = NULL;

	if (argc != 2) {
		printf("wrong usage, run as ./test input_path\n");
		return -1;
	}

	LY_ERR err;

	err = ly_ctx_new(NULL, 0, &ctx);
	if (err != LY_SUCCESS) {
		fprintf(stderr, "Failed to create context\n");
		exit(EXIT_FAILURE);
	}

	lys_parse_mem(ctx, schema_a, LYS_IN_YANG, NULL);
	lys_parse_mem(ctx, schema_b, LYS_IN_YANG, NULL);

	f = fopen(argv[1], "r");
	if (!f) {
		return -1;
	}

	fseek(f, 0, SEEK_END);
	len = ftell(f);
	fseek(f, 0, SEEK_SET);

	data = malloc(len + 1);
	if (data == NULL) {
		return -1;
	}
	fread(data, len, 1, f);
	data[len] = 0;

	lyd_parse_data_mem(ctx, data, LYD_JSON, 0, LYD_VALIDATE_PRESENT, &tree);
	ly_ctx_destroy(ctx, NULL);

	free(data);
	fclose(f);

	return 0;
}
```

This fixes the crash, and the tests seem to be passing. However I'm not sure if this is the best fix semantically, so any comments are welcome.

Thanks,
Juraj
