### PR TITLE
fix xml parse error

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -142,10 +142,16 @@ lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *parent, struct lyxml_attr 
 
     /* put attribute into the parent's attributes list */
     if (parent->attr) {
-        /* go to the end of the list */
-        for (a = parent->attr; a->next; a = a->next);
-        /* and append new attribute */
-        a->next = result;
+        if (result->type == LYXML_ATTR_STD) {
+            /* go to the end of the list */
+            for (a = parent->attr; a->next; a = a->next);
+            /* and append new attribute */
+            a->next = result;
+        } else {
+            /* add NS attribute to the head of the list */
+            result->next = parent->attr;
+            parent->attr = result;
+        }
     } else {
         /* add the first attribute in the list */
         parent->attr = result;


### PR DESCRIPTION
1、use  lyd_parse_xml print the rpc_message， get result rpc_node

2、use lyd_find_path get the '/ietf-netconf-nmda:edit-data/config' from the rpc_node, the result config_node

3、the config_node type is LYD_ANYDATA_XML, use lyxml_print_mem print LYD_ANYDATA_XML to str， the result is config_value

4、use lyd_parse_mem  can‘t parse the config_value, the error-info "Invalid attribute "operation"."  Because in lyxml_dup_attr, when parent's attr is exist, add the parent's attr in the end,  casue the result  nc:operation before xmlns:nc define.


rpc_message :
```xml
<edit-data xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-nmda\"><datastore "
    "xmlns:ds=\"urn:ietf:params:xml:ns:yang:ietf-datastores\">ds:running</datastore><config "
    "xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\"><test-node xmlns="xxx" nc:operation="merge">data</test-node></config></edit-data>
```

config_value : 
```xml
<test-node xmlns=\"xxx\" nc:operation="\merge\" xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">data</test-node></config></edit-data>
```