### PR TITLE
add escape character in xml attr-value

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -142,10 +142,16 @@ lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *parent, struct lyxml_attr 
 
     /* put attribute into the parent's attributes list */
     if (parent->attr) {
-        /* go to the end of the list */
-        for (a = parent->attr; a->next; a = a->next);
-        /* and append new attribute */
-        a->next = result;
+        if (result->type == LYXML_ATTR_STD) {
+            /* go to the end of the list */
+            for (a = parent->attr; a->next; a = a->next);
+            /* and append new attribute */
+            a->next = result;
+        } else {
+            /* add NS attribute to the head of the list */
+            result->next = parent->attr;
+            parent->attr = result;
+        }
     } else {
         /* add the first attribute in the list */
         parent->attr = result;

--- a/src/xml.c
+++ b/src/xml.c
@@ -142,16 +142,10 @@ lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *parent, struct lyxml_attr 
 
     /* put attribute into the parent's attributes list */
     if (parent->attr) {
-        if (result->type == LYXML_ATTR_STD) {
-            /* go to the end of the list */
-            for (a = parent->attr; a->next; a = a->next);
-            /* and append new attribute */
-            a->next = result;
-        } else {
-            /* add NS attribute to the head of the list */
-            result->next = parent->attr;
-            parent->attr = result;
-        }
+        /* go to the end of the list */
+        for (a = parent->attr; a->next; a = a->next);
+        /* and append new attribute */
+        a->next = result;
     } else {
         /* add the first attribute in the list */
         parent->attr = result;
@@ -1451,15 +1445,22 @@ dump_elem(struct lyout *out, const struct lyxml_elem *e, int level, int options,
     for (a = e->attr; a; a = a->next) {
         if (a->type == LYXML_ATTR_NS) {
             if (a->name) {
-                size += ly_print(out, " xmlns:%s=\"%s\"", a->name, a->value ? a->value : "");
+                size += ly_print(out, " xmlns:%s=\"", a->name);
             } else {
-                size += ly_print(out, " xmlns=\"%s\"", a->value ? a->value : "");
+                size += ly_print(out, " xmlns=\"");
             }
         } else if (a->ns && a->ns->prefix) {
-            size += ly_print(out, " %s:%s=\"%s\"", a->ns->prefix, a->name, a->value);
+            size += ly_print(out, " %s:%s=\"", a->ns->prefix, a->name);
         } else {
-            size += ly_print(out, " %s=\"%s\"", a->name, a->value);
+            size += ly_print(out, " %s=\"", a->name);
         }
+
+        if (a->value) {
+            size += lyxml_dump_text(out, a->value, LYXML_DATA_ATTR);
+        } else {
+            size += ly_print(out, "&quot;&quot;");
+        }
+        size += ly_print(out, "\"");
     }
 
     /* apply options */


### PR DESCRIPTION
struct lyxml_attr *a, the a->ns->prefix is "yang", a->name is "key", a->value is "[name=\"test\"]",  in dump_elem function process the attributes, the result is `<interface yang:key="[name=\"test\"]">`, this is invalid xml message,it should be `<interface yang:key="[name=&quot;test&quot;]">`