### PR TITLE
fix calculate json-anydata length error， when leaf/leaflist value con… … f0067eb …tains ‘{' or '}'

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -398,22 +398,23 @@ json_get_anydata(struct lyd_node_anydata *any, const char *data)
     do {
         switch (data[len]) {
         case '{':
-            if (skip == 0) {
+            if (!skip) {
                 c++;
             }
             break;
         case '}':
-            if (skip == 0) {
+            if (!skip) {
                 c--;
             }
             break;
         case '\\':
-            if (skip == 1 && data[len + 1]) {
+            /* when parsing a string, ignore escaped quotes to not end it prematurely */
+            if (skip && data[len + 1]) {
                 len++;
             }
             break;
         case '\"':
-            skip = (skip == 1) ? 0 : 1;
+            skip = !skip;
             break;
         default:
             break;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -369,7 +369,7 @@ static unsigned int
 json_get_anydata(struct lyd_node_anydata *any, const char *data)
 {
     struct ly_ctx *ctx = any->schema->module->ctx;
-    unsigned int len = 0, c = 0;
+    unsigned int len = 0, c = 0, skip = 0;
     char *str;
 
     if (data[len] == '"') {
@@ -398,10 +398,22 @@ json_get_anydata(struct lyd_node_anydata *any, const char *data)
     do {
         switch (data[len]) {
         case '{':
-            c++;
+            if (skip == 0) {
+                c++;
+            }
             break;
         case '}':
-            c--;
+            if (skip == 0) {
+                c--;
+            }
+            break;
+        case '\\':
+            if (skip == 1 && data[len + 1]) {
+                len++;
+            }
+            break;
+        case '\"':
+            skip = (skip == 1) ? 0 : 1;
             break;
         default:
             break;

--- a/src/xml.c
+++ b/src/xml.c
@@ -142,10 +142,16 @@ lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *parent, struct lyxml_attr 
 
     /* put attribute into the parent's attributes list */
     if (parent->attr) {
-        /* go to the end of the list */
-        for (a = parent->attr; a->next; a = a->next);
-        /* and append new attribute */
-        a->next = result;
+        if (result->type == LYXML_ATTR_STD) {
+            /* go to the end of the list */
+            for (a = parent->attr; a->next; a = a->next);
+            /* and append new attribute */
+            a->next = result;
+        } else {
+            /* add NS attribute to the head of the list */
+            result->next = parent->attr;
+            parent->attr = result;
+        }
     } else {
         /* add the first attribute in the list */
         parent->attr = result;

--- a/src/xml.c
+++ b/src/xml.c
@@ -142,16 +142,10 @@ lyxml_dup_attr(struct ly_ctx *ctx, struct lyxml_elem *parent, struct lyxml_attr 
 
     /* put attribute into the parent's attributes list */
     if (parent->attr) {
-        if (result->type == LYXML_ATTR_STD) {
-            /* go to the end of the list */
-            for (a = parent->attr; a->next; a = a->next);
-            /* and append new attribute */
-            a->next = result;
-        } else {
-            /* add NS attribute to the head of the list */
-            result->next = parent->attr;
-            parent->attr = result;
-        }
+        /* go to the end of the list */
+        for (a = parent->attr; a->next; a = a->next);
+        /* and append new attribute */
+        a->next = result;
     } else {
         /* add the first attribute in the list */
         parent->attr = result;


### PR DESCRIPTION
rpc-message ： {"ietf-netconf-nmda:edit-data":{"datastore":"ietf-datastores:running","config":{password:"Root{{{{123"}}}

when calculate 'password' len， the result is wrong.

