### PR TITLE
data tree CHANGE move macros to functions to cleanup API

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -98,7 +98,7 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
         diff_parent = match;
 
         /* move down in the diff */
-        siblings = LYD_CHILD_NO_KEYS(match);
+        siblings = lyd_child_no_keys(match);
     }
 
     /* duplicate the subtree (and connect to the diff if possible) */
@@ -591,7 +591,7 @@ lyd_diff_siblings_r(const struct lyd_node *first, const struct lyd_node *second,
 
         /* check descendants, if any, recursively */
         if (match_second) {
-            LY_CHECK_GOTO(lyd_diff_siblings_r(LYD_CHILD_NO_KEYS(iter_first), LYD_CHILD_NO_KEYS(match_second), options,
+            LY_CHECK_GOTO(lyd_diff_siblings_r(lyd_child_no_keys(iter_first), lyd_child_no_keys(match_second), options,
                                               0, diff), cleanup);
         }
 
@@ -909,7 +909,7 @@ lyd_diff_apply_r(struct lyd_node **first_node, struct lyd_node *parent_node, con
             }
         } else {
             /* none operation on nodes without children is redundant and hence forbidden */
-            if (!LYD_CHILD_NO_KEYS(diff_node)) {
+            if (!lyd_child_no_keys(diff_node)) {
                 LOGINT_RET(ctx);
             }
         }
@@ -971,7 +971,7 @@ next_iter_r:
     }
 
     /* apply diff recursively */
-    LY_LIST_FOR(LYD_CHILD_NO_KEYS(diff_node), diff_child) {
+    LY_LIST_FOR(lyd_child_no_keys(diff_node), diff_child) {
         LY_CHECK_RET(lyd_diff_apply_r(lyd_node_children_p(match), match, diff_child, diff_cb, cb_data));
     }
 
@@ -1238,7 +1238,7 @@ lyd_diff_merge_create(struct lyd_node *diff_match, enum lyd_diff_op cur_op, cons
             diff_match->flags |= src_diff->flags & LYD_DEFAULT;
         } else {
             /* but the operation of its children should remain DELETE */
-            LY_LIST_FOR(LYD_CHILD_NO_KEYS(diff_match), child) {
+            LY_LIST_FOR(lyd_child_no_keys(diff_match), child) {
                 LY_CHECK_RET(lyd_diff_change_op(child, LYD_DIFF_OP_DELETE));
             }
         }
@@ -1278,7 +1278,7 @@ lyd_diff_merge_delete(struct lyd_node *diff_match, enum lyd_diff_op cur_op, cons
                                       diff_match->flags & LYD_DEFAULT ? "true" : "false", NULL));
         } else {
             /* keep operation for all descendants (for now) */
-            LY_LIST_FOR(LYD_CHILD_NO_KEYS(diff_match), child) {
+            LY_LIST_FOR(lyd_child_no_keys(diff_match), child) {
                 LY_CHECK_RET(lyd_diff_change_op(child, cur_op));
             }
         }
@@ -1292,8 +1292,8 @@ lyd_diff_merge_delete(struct lyd_node *diff_match, enum lyd_diff_op cur_op, cons
         LY_CHECK_RET(lyd_diff_change_op(diff_match, LYD_DIFF_OP_DELETE));
 
         /* all descendants not in the diff will be deleted and redundant in the diff, so remove them */
-        LY_LIST_FOR_SAFE(LYD_CHILD_NO_KEYS(diff_match), next, child) {
-            if (lyd_find_sibling_first(LYD_CHILD(src_diff), child, NULL) == LY_ENOTFOUND) {
+        LY_LIST_FOR_SAFE(lyd_child_no_keys(diff_match), next, child) {
+            if (lyd_find_sibling_first(lyd_child(src_diff), child, NULL) == LY_ENOTFOUND) {
                 lyd_free_tree(child);
             }
         }
@@ -1323,7 +1323,7 @@ lyd_diff_is_redundant(struct lyd_node *diff)
 
     assert(diff);
 
-    child = LYD_CHILD_NO_KEYS(diff);
+    child = lyd_child_no_keys(diff);
     mod = ly_ctx_get_module_latest(LYD_CTX(diff), "yang");
     assert(mod);
 
@@ -1397,7 +1397,7 @@ lyd_diff_merge_r(const struct lyd_node *src_diff, struct lyd_node *diff_parent, 
     LY_CHECK_RET(lyd_diff_get_op(src_diff, &src_op));
 
     /* find an equal node in the current diff */
-    lyd_diff_find_node(diff_parent ? LYD_CHILD_NO_KEYS(diff_parent) : *diff, src_diff, &diff_node);
+    lyd_diff_find_node(diff_parent ? lyd_child_no_keys(diff_parent) : *diff, src_diff, &diff_node);
 
     if (diff_node) {
         /* get target (current) operation */
@@ -1434,7 +1434,7 @@ lyd_diff_merge_r(const struct lyd_node *src_diff, struct lyd_node *diff_parent, 
         diff_parent = diff_node;
 
         /* merge src_diff recursively */
-        LY_LIST_FOR(LYD_CHILD_NO_KEYS(src_diff), child) {
+        LY_LIST_FOR(lyd_child_no_keys(src_diff), child) {
             LY_CHECK_RET(lyd_diff_merge_r(child, diff_parent, diff_cb, cb_data, diff));
         }
     } else {

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -1848,7 +1848,7 @@ lyd_parse_json_reply(const struct lyd_node *request, struct ly_in *in, struct ly
     if (op_p) {
         *op_p = rep_op;
     }
-    for (tree = rep_op; tree->parent; tree = LYD_PARENT(tree)) {}
+    for (tree = rep_op; tree->parent; tree = lyd_parent(tree)) {}
     if (rpcr_e) {
         /* connect to the operation */
         lyd_insert_node(rpcr_e, NULL, tree);

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -1022,7 +1022,7 @@ lyd_parse_xml_reply(const struct lyd_node *request, struct ly_in *in, struct lyd
     if (op_p) {
         *op_p = rep_op;
     }
-    for (tree = rep_op; tree->parent; tree = LYD_PARENT(tree)) {}
+    for (tree = rep_op; tree->parent; tree = lyd_parent(tree)) {}
     if (rpcr_e) {
         /* connect to the operation */
         lyd_insert_node(rpcr_e, NULL, tree);

--- a/src/path.c
+++ b/src/path.c
@@ -820,7 +820,7 @@ ly_path_eval_partial(const struct ly_path *path, const struct lyd_node *start, L
 
     if (lysc_data_parent(path[0].node)) {
         /* relative path, start from the parent children */
-        start = lyd_node_children(start, 0);
+        start = lyd_child(start);
     } else {
         /* absolute path, start from the first top-level sibling */
         while (start->parent) {
@@ -870,7 +870,7 @@ ly_path_eval_partial(const struct ly_path *path, const struct lyd_node *start, L
         prev_node = node;
 
         /* next path segment, if any */
-        start = lyd_node_children(node, 0);
+        start = lyd_child(node);
     }
 
     if (node) {

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -591,7 +591,7 @@ static LY_ERR
 json_print_inner(struct jsonpr_ctx *ctx, const struct lyd_node *node)
 {
     struct lyd_node *child;
-    struct lyd_node *children = lyd_node_children(node, 0);
+    struct lyd_node *children = lyd_child(node);
     ly_bool has_content = 0;
 
     if (node->meta || children) {
@@ -670,7 +670,7 @@ json_print_leaf_list(struct jsonpr_ctx *ctx, const struct lyd_node *node)
     }
 
     if (node->schema->nodetype == LYS_LIST) {
-        if (!lyd_node_children(node, 0)) {
+        if (!lyd_child(node)) {
             /* empty, e.g. in case of filter */
             ly_print_(ctx->out, "%s%snull", (ctx->level_printed >= ctx->level) ? "," : "", DO_FORMAT ? " " : "");
             LEVEL_PRINTED;

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -929,7 +929,7 @@ lyb_print_subtree(struct ly_out *out, const struct lyd_node *node, struct hash_t
     }
 
     /* recursively write all the descendants */
-    LY_LIST_FOR(lyd_node_children(node, 0), node) {
+    LY_LIST_FOR(lyd_child(node), node) {
         LY_CHECK_RET(lyb_print_subtree(out, node, &child_ht, lybctx));
     }
 

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1777,7 +1777,7 @@ lyd_insert_only_child(struct lyd_node *parent, struct lyd_node *node)
 {
     struct lyd_node_inner *par;
 
-    assert(parent && !lyd_node_children(parent, 0) && !node->next && (node->prev == node));
+    assert(parent && !lyd_child(parent) && !node->next && (node->prev == node));
     assert(!parent->schema || (parent->schema->nodetype & LYD_NODE_INNER));
 
     par = (struct lyd_node_inner *)parent;
@@ -1811,7 +1811,7 @@ lyd_insert_has_keys(const struct lyd_node *list)
     const struct lysc_node *skey = NULL;
 
     assert(list->schema->nodetype == LYS_LIST);
-    key = lyd_node_children(list, 0);
+    key = lyd_child(list);
     while ((skey = lys_getnext(skey, list->schema, NULL, 0)) && (skey->flags & LYS_KEY)) {
         if (!key || (key->schema != skey)) {
             /* key missing */
@@ -2815,7 +2815,7 @@ lyd_merge_sibling_r(struct lyd_node **first_trg, struct lyd_node *parent_trg, co
             match_trg->flags = sibling_src->flags | LYD_NEW;
         } else {
             /* check descendants, recursively */
-            LY_LIST_FOR_SAFE(LYD_CHILD_NO_KEYS(sibling_src), tmp, child_src) {
+            LY_LIST_FOR_SAFE(lyd_child_no_keys(sibling_src), tmp, child_src) {
                 LY_CHECK_RET(lyd_merge_sibling_r(lyd_node_children_p(match_trg), match_trg, &child_src, options));
             }
         }
@@ -2923,7 +2923,7 @@ lyd_path_list_predicate(const struct lyd_node *node, char **buffer, size_t *bufl
     const char *val;
     char quot;
 
-    for (key = lyd_node_children(node, 0); key && (key->schema->flags & LYS_KEY); key = key->next) {
+    for (key = lyd_child(node); key && (key->schema->flags & LYS_KEY); key = key->next) {
         val = LYD_CANON_VALUE(key);
         len = 1 + strlen(key->schema->name) + 2 + strlen(val) + 2;
         LY_CHECK_RET(lyd_path_str_enlarge(buffer, buflen, *bufused + len, is_static));

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -40,27 +40,6 @@ struct lysc_node;
  * Data structures and functions to manipulate and access instance data tree.
  */
 
-/**
- * @brief Macro for getting child pointer of a generic data node.
- *
- * @param[in] node Node whose child pointer to get.
- */
-#define LYD_CHILD(node) ((node)->schema ? (lyd_node_children(node, 0)) : ((struct lyd_node_opaq *)(node))->child)
-
-/**
- * @brief Macro for getting child pointer of a generic data node but skipping its keys in case it is ::LYS_LIST.
- *
- * @param[in] node Node whose child pointer to get.
- */
-#define LYD_CHILD_NO_KEYS(node) ((node)->schema ? (lyd_node_children(node, LYD_CHILDREN_SKIP_KEYS)) : ((struct lyd_node_opaq *)(node))->child)
-
-/**
- * @brief Macro for getting generic parent pointer of a node.
- *
- * @param[in] node Node whose parent pointer to get.
- */
-#define LYD_PARENT(node) ((struct lyd_node *)(node)->parent)
-
 /* *INDENT-OFF* */
 
 /**
@@ -113,7 +92,7 @@ struct lysc_node;
     if (LYD_TREE_DFS_continue) { \
         (LYD_TREE_DFS_next) = NULL; \
     } else { \
-        (LYD_TREE_DFS_next) = lyd_node_children(ELEM, 0); \
+        (LYD_TREE_DFS_next) = lyd_child(ELEM); \
     }\
     if (!(LYD_TREE_DFS_next)) { \
         /* no children */ \
@@ -475,23 +454,37 @@ struct lyd_node_opaq {
 };
 
 /**
- * @defgroup children_options Children traversal options.
- * @ingroup datatree
+ * @brief Get the generic parent pointer of a data node.
+ *
+ * @param[in] node Node whose parent pointer to get.
+ * @return Pointer to the parent node of the @p node.
+ * @return NULL in case of the top-level node or if the @p node is NULL itself.
  */
-
-#define LYD_CHILDREN_SKIP_KEYS  0x01    /**< If list children are returned, skip its keys. */
-
-/** @} children_options */
+struct lyd_node *lyd_parent(const struct lyd_node *node);
 
 /**
- * @brief Get the node's children list if any.
+ * @brief Get the child pointer of a generic data node.
  *
- * Decides the node's type and in case it has a children list, returns it.
- * @param[in] node Node to check.
- * @param[in] options Bitmask of options, see @ref
- * @return Pointer to the first child node (if any) of the \p node.
+ * Decides the node's type and in case it has a children list, returns it. Supports even the opaq nodes (::lyd_node_opaq).
+ *
+ * If you need to skip key children, use ::lyd_child_no_keys().
+ *
+ * @param[in] node Node to use.
+ * @return Pointer to the first child node (if any) of the @p node.
  */
-struct lyd_node *lyd_node_children(const struct lyd_node *node, uint32_t options);
+struct lyd_node *lyd_child(const struct lyd_node *node);
+
+/**
+ * @brief Get the child pointer of a generic data node but skip its keys in case it is ::LYS_LIST.
+ *
+ * Decides the node's type and in case it has a children list, returns it. Supports even the opaq nodes (::lyd_node_opaq).
+ *
+ * If you need to take key children into account, use ::lyd_child().
+ *
+ * @param[in] node Node to use.
+ * @return Pointer to the first child node (if any) of the @p node.
+ */
+struct lyd_node *lyd_child_no_keys(const struct lyd_node *node);
 
 /**
  * @brief Get the owner module of the data node. It is the module of the top-level schema node. Generally,

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -164,7 +164,7 @@ lyd_free_subtree(struct lyd_node *node, ly_bool top)
         opaq = (struct lyd_node_opaq *)node;
 
         /* free the children */
-        children = lyd_node_children(node, 0);
+        children = lyd_child(node);
         LY_LIST_FOR_SAFE(children, next, iter) {
             lyd_free_subtree(iter, 0);
         }
@@ -180,7 +180,7 @@ lyd_free_subtree(struct lyd_node *node, ly_bool top)
         ((struct lyd_node_inner *)node)->children_ht = NULL;
 
         /* free the children */
-        children = lyd_node_children(node, 0);
+        children = lyd_child(node);
         LY_LIST_FOR_SAFE(children, next, iter) {
             lyd_free_subtree(iter, 0);
         }

--- a/src/validation.c
+++ b/src/validation.c
@@ -391,7 +391,7 @@ lyd_validate_autodel_dup(struct lyd_node **first, struct lyd_node *node, struct 
                     /* add into diff */
                     if ((match->schema->nodetype == LYS_CONTAINER) && !(match->schema->flags & LYS_PRESENCE)) {
                         /* we do not want to track NP container changes, but remember any removed children */
-                        LY_LIST_FOR(LYD_CHILD(match), iter) {
+                        LY_LIST_FOR(lyd_child(match), iter) {
                             lyd_val_diff_add(iter, LYD_DIFF_OP_DELETE, diff);
                         }
                     } else {
@@ -553,7 +553,7 @@ lyd_val_uniq_find_leaf(const struct lysc_node_leaf *uniq_leaf, const struct lyd_
 
         /* find iter instance in children */
         assert(iter->nodetype & (LYS_CONTAINER | LYS_LEAF));
-        lyd_find_sibling_val(lyd_node_children(node, 0), iter, NULL, 0, &node);
+        lyd_find_sibling_val(lyd_child(node), iter, NULL, 0, &node);
         --depth;
     }
 
@@ -997,11 +997,11 @@ lyd_validate_final_r(struct lyd_node *first, const struct lysc_node *sparent, co
 
     LY_LIST_FOR(first, node) {
         /* validate all children recursively */
-        LY_CHECK_RET(lyd_validate_final_r(lyd_node_children(node, 0), node->schema, NULL, val_opts, op));
+        LY_CHECK_RET(lyd_validate_final_r(lyd_child(node), node->schema, NULL, val_opts, op));
 
         /* set default for containers */
         if ((node->schema->nodetype == LYS_CONTAINER) && !(node->schema->flags & LYS_PRESENCE)) {
-            LY_LIST_FOR(lyd_node_children(node, 0), next) {
+            LY_LIST_FOR(lyd_child(node), next) {
                 if (!(next->flags & LYD_DEFAULT)) {
                     break;
                 }
@@ -1193,7 +1193,7 @@ lyd_val_op_merge_find(const struct lyd_node *op_tree, const struct lyd_node *op_
         }
 
         /* move tree_iter */
-        tree_iter = lyd_node_children(match, 0);
+        tree_iter = lyd_child(match);
 
         /* move depth */
         --cur_depth;
@@ -1268,7 +1268,7 @@ lyd_validate_op(struct lyd_node *op_tree, const struct lyd_node *tree, LYD_VALID
     LY_CHECK_GOTO(ret = lyd_validate_must(op_node, op), cleanup);
 
     /* final validation of all the descendants */
-    LY_CHECK_GOTO(ret = lyd_validate_final_r(lyd_node_children(op_node, 0), op_node->schema, NULL, 0, op), cleanup);
+    LY_CHECK_GOTO(ret = lyd_validate_final_r(lyd_child(op_node), op_node->schema, NULL, 0, op), cleanup);
 
 cleanup:
     /* restore operation tree */

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -192,7 +192,7 @@ print_set_debug(struct lyxp_set *set)
                 if ((item->node->schema->nodetype == LYS_LIST)
                         && (((struct lyd_node_inner *)item->node)->child->schema->nodetype == LYS_LEAF)) {
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): ELEM %s (1st child val: %s)", i + 1, item->pos,
-                           item->node->schema->name, LYD_CANON_VALUE(lyd_node_children(item->node, 0)));
+                           item->node->schema->name, LYD_CANON_VALUE(lyd_child(item->node)));
                 } else if (((struct lyd_node_inner *)item->node)->schema->nodetype == LYS_LEAFLIST) {
                     LOGDBG(LY_LDGXPATH, "\t%d (pos %u): ELEM %s (val: %s)", i + 1, item->pos,
                            item->node->schema->name, LYD_CANON_VALUE(item->node));
@@ -351,7 +351,7 @@ cast_string_recursive(const struct lyd_node *node, ly_bool fake_cont, enum lyxp_
         strcpy(*str + (*used - 1), "\n");
         ++(*used);
 
-        for (child = lyd_node_children(node, 0); child; child = child->next) {
+        for (child = lyd_child(node); child; child = child->next) {
             rc = cast_string_recursive(child, 0, root_type, indent + 1, str, used, size);
             LY_CHECK_RET(rc);
         }
@@ -5463,7 +5463,7 @@ moveto_node(struct lyxp_set *set, const struct lys_module *mod, const char *ncna
             siblings = set->tree;
         } else {
             /* search in children */
-            siblings = lyd_node_children(set->val.nodes[i].node, 0);
+            siblings = lyd_child(set->val.nodes[i].node);
         }
 
         for (sub = siblings; sub; sub = sub->next) {
@@ -5546,7 +5546,7 @@ moveto_node_hash(struct lyxp_set *set, const struct lysc_node *scnode, const str
             siblings = set->tree;
         } else if (set->val.nodes[i].type == LYXP_NODE_ELEM) {
             /* search in children */
-            siblings = lyd_node_children(set->val.nodes[i].node, 0);
+            siblings = lyd_child(set->val.nodes[i].node);
         }
 
         /* find the node using hashes */
@@ -5734,7 +5734,7 @@ moveto_node_alldesc(struct lyxp_set *set, const struct lys_module *mod, const ch
 
             /* TREE DFS NEXT ELEM */
             /* select element for the next run - children first */
-            next = lyd_node_children(elem, 0);
+            next = lyd_child(elem);
             if (!next) {
 skip_children:
                 /* no children, so try siblings, but only if it's not the start,
@@ -6079,7 +6079,7 @@ moveto_self_add_children_r(const struct lyd_node *parent, uint32_t parent_pos, e
         }
 
         /* add all the children of this node */
-        first = lyd_node_children(parent, 0);
+        first = lyd_child(parent);
         break;
     default:
         LOGINT_RET(parent->schema->module->ctx);

--- a/tests/utests/data/test_diff.c
+++ b/tests/utests/data/test_diff.c
@@ -263,7 +263,7 @@ test_invalid(void **state)
     assert_non_null(st->first);
     st->second = NULL;
 
-    assert_int_equal(lyd_diff_siblings(st->first, lyd_node_children(st->first, 0), 0, &st->diff1), LY_EINVAL);
+    assert_int_equal(lyd_diff_siblings(st->first, lyd_child(st->first), 0, &st->diff1), LY_EINVAL);
 
     assert_int_equal(lyd_diff_siblings(NULL, NULL, 0, NULL), LY_EINVAL);
 }
@@ -375,7 +375,7 @@ test_empty_nested(void **state)
     assert_int_equal(lyd_diff_siblings(NULL, NULL, 0, &st->diff1), LY_SUCCESS);
     assert_null(st->diff1);
 
-    assert_int_equal(lyd_diff_siblings(NULL, lyd_node_children(st->first, 0), 0, &st->diff1), LY_SUCCESS);
+    assert_int_equal(lyd_diff_siblings(NULL, lyd_child(st->first), 0, &st->diff1), LY_SUCCESS);
 
     assert_non_null(st->diff1);
     lyd_print_mem(&st->xml, st->diff1, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);
@@ -386,7 +386,7 @@ test_empty_nested(void **state)
     );
 
     free(st->xml);
-    assert_int_equal(lyd_diff_siblings(lyd_node_children(st->first, 0), NULL, 0, &st->diff2), LY_SUCCESS);
+    assert_int_equal(lyd_diff_siblings(lyd_child(st->first), NULL, 0, &st->diff2), LY_SUCCESS);
 
     assert_non_null(st->diff2);
     lyd_print_mem(&st->xml, st->diff2, LYD_XML, LYD_PRINT_WITHSIBLINGS | LYD_PRINT_SHRINK);

--- a/tests/utests/data/test_lyb.c
+++ b/tests/utests/data/test_lyb.c
@@ -45,7 +45,7 @@ loop_next:
         /* LYD_TREE_DFS_END */
 
         /* select element for the next run - children first */
-        *next = lyd_node_children(*elem, 0);
+        *next = lyd_child(*elem);
         if (!*next) {
             /* no children */
             if (*elem == *start) {

--- a/tests/utests/data/test_merge.c
+++ b/tests/utests/data/test_merge.c
@@ -574,8 +574,8 @@ test_dflt(void **state)
     st->source = NULL;
 
     /* c should be replaced and now be default */
-    assert_string_equal(lyd_node_children(st->target, 0)->prev->schema->name, "c");
-    assert_true(lyd_node_children(st->target, 0)->prev->flags & LYD_DEFAULT);
+    assert_string_equal(lyd_child(st->target)->prev->schema->name, "c");
+    assert_true(lyd_child(st->target)->prev->flags & LYD_DEFAULT);
 }
 
 static void
@@ -612,7 +612,7 @@ test_dflt2(void **state)
     assert_int_equal(lyd_merge_siblings(&st->target, st->source, 0), LY_SUCCESS);
 
     /* c should not be replaced, so c remains not default */
-    assert_false(lyd_node_children(st->target, 0)->flags & LYD_DEFAULT);
+    assert_false(lyd_child(st->target)->flags & LYD_DEFAULT);
 }
 
 static void

--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -647,15 +647,15 @@ test_rpc(void **state)
     /* TODO support generic attributes in JSON ?
     assert_non_null(((struct lyd_node_opaq *)tree)->attr);
     */
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_string_equal(node->schema->name, "edit-config");
-    node = lyd_node_children(node, 0)->next;
+    node = lyd_child(node)->next;
     assert_string_equal(node->schema->name, "config");
 
     node = ((struct lyd_node_any *)node)->value.tree;
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "cp");
-    node = lyd_node_children(node, 0);
+    node = lyd_child(node);
     /* z has no value */
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "z");
@@ -703,7 +703,7 @@ test_action(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "rpc");
     assert_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "action");
     assert_null(((struct lyd_node_opaq *)node)->attr);
@@ -747,7 +747,7 @@ test_notification(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "notification");
     assert_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "eventTime");
     assert_string_equal(((struct lyd_node_opaq *)node)->value, "2037-07-08T00:01:00Z");
@@ -813,7 +813,7 @@ test_reply(void **state)
 
     assert_non_null(op);
     assert_string_equal(op->schema->name, "act");
-    node = lyd_node_children(op, 0);
+    node = lyd_child(op);
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "al");
     assert_true(node->schema->flags & LYS_CONFIG_R);
@@ -821,15 +821,15 @@ test_reply(void **state)
     assert_non_null(tree);
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "rpc-reply");
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "c");
 
     /* TODO print only rpc-reply node and then output subtree */
-    lyd_print_tree(out, lyd_node_children(op, 0), LYD_JSON, LYD_PRINT_SHRINK);
+    lyd_print_tree(out, lyd_child(op), LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, "{\"a:al\":25}");
     ly_out_reset(out);
-    lyd_print_tree(out, lyd_node_children(tree, 0), LYD_JSON, LYD_PRINT_SHRINK);
+    lyd_print_tree(out, lyd_child(tree), LYD_JSON, LYD_PRINT_SHRINK);
     assert_string_equal(str, "{\"a:c\":{\"act\":{\"al\":25}}}");
     ly_out_reset(out);
     lyd_free_all(tree);

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -437,15 +437,15 @@ test_rpc(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "rpc");
     assert_non_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_string_equal(node->schema->name, "edit-config");
-    node = lyd_node_children(node, 0)->next;
+    node = lyd_child(node)->next;
     assert_string_equal(node->schema->name, "config");
 
     node = ((struct lyd_node_any *)node)->value.tree;
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "cp");
-    node = lyd_node_children(node, 0);
+    node = lyd_child(node);
     /* z has no value */
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "z");
@@ -519,7 +519,7 @@ test_action(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "rpc");
     assert_non_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "action");
     assert_null(((struct lyd_node_opaq *)node)->attr);
@@ -580,7 +580,7 @@ test_notification(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "notification");
     assert_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_null(node->schema);
     assert_string_equal(((struct lyd_node_opaq *)node)->name, "eventTime");
     assert_string_equal(((struct lyd_node_opaq *)node)->value, "2037-07-08T00:01:00Z");
@@ -654,7 +654,7 @@ test_reply(void **state)
 
     assert_non_null(op);
     assert_string_equal(op->schema->name, "act");
-    node = lyd_node_children(op, 0);
+    node = lyd_child(op);
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "al");
     assert_true(node->schema->flags & LYS_CONFIG_R);
@@ -663,12 +663,12 @@ test_reply(void **state)
     assert_null(tree->schema);
     assert_string_equal(((struct lyd_node_opaq *)tree)->name, "rpc-reply");
     assert_non_null(((struct lyd_node_opaq *)tree)->attr);
-    node = lyd_node_children(tree, 0);
+    node = lyd_child(tree);
     assert_non_null(node->schema);
     assert_string_equal(node->schema->name, "c");
 
     /* TODO print only rpc-reply node and then output subtree */
-    lyd_print_tree(out, lyd_node_children(op, 0), LYD_XML, LYD_PRINT_SHRINK);
+    lyd_print_tree(out, lyd_child(op), LYD_XML, LYD_PRINT_SHRINK);
     assert_string_equal(str,
         "<al xmlns=\"urn:tests:a\">25</al>");
     ly_out_reset(out);

--- a/tests/utests/data/test_types.c
+++ b/tests/utests/data/test_types.c
@@ -1016,7 +1016,7 @@ test_leafref(void **state)
     TEST_DATA("<str-norestr xmlns=\"urn:tests:types\">y</str-norestr>"
               "<c xmlns=\"urn:tests:leafrefs\"><l><id>x</id><value>x</value><lr1>y</lr1></l></c>", LY_SUCCESS, "");
     assert_int_equal(LYS_CONTAINER, tree->schema->nodetype);
-    leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->next, 0)->prev);
+    leaf = (struct lyd_node_term*)(lyd_child(lyd_child(tree)->next)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr1", leaf->schema->name);
     assert_string_equal("y", leaf->value.canonical);
@@ -1026,7 +1026,7 @@ test_leafref(void **state)
               "<c xmlns=\"urn:tests:leafrefs\"><l><id>y</id><value>y</value></l>"
               "<l><id>x</id><value>x</value><lr2>y</lr2></l></c>", LY_SUCCESS, "");
     assert_int_equal(LYS_CONTAINER, tree->schema->nodetype);
-    leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->prev, 0)->prev);
+    leaf = (struct lyd_node_term*)(lyd_child(lyd_child(tree)->prev)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr2", leaf->schema->name);
     assert_string_equal("y", leaf->value.canonical);
@@ -1037,7 +1037,7 @@ test_leafref(void **state)
               "<c xmlns=\"urn:tests:leafrefs\"><x><x>y</x></x>"
               "<l><id>x</id><value>x</value><lr3>c</lr3></l></c>", LY_SUCCESS, "");
     assert_int_equal(LYS_CONTAINER, tree->schema->nodetype);
-    leaf = (struct lyd_node_term*)(lyd_node_children(lyd_node_children(tree, 0)->prev, 0)->prev);
+    leaf = (struct lyd_node_term*)(lyd_child(lyd_child(tree)->prev)->prev);
     assert_int_equal(LYS_LEAF, leaf->schema->nodetype);
     assert_string_equal("lr3", leaf->schema->name);
     assert_string_equal("c", leaf->value.canonical);

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -492,8 +492,8 @@ test_when(void **state)
     data = "<cont xmlns=\"urn:tests:a\"><a>val</a><b>val_b</b></cont><c xmlns=\"urn:tests:a\">val_c</c>";
     assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
     assert_non_null(tree);
-    assert_string_equal("a", lyd_node_children(tree, 0)->schema->name);
-    assert_int_equal(LYD_WHEN_TRUE, lyd_node_children(tree, 0)->flags);
+    assert_string_equal("a", lyd_child(tree)->schema->name);
+    assert_int_equal(LYD_WHEN_TRUE, lyd_child(tree)->flags);
     assert_string_equal("c", tree->next->schema->name);
     assert_int_equal(LYD_WHEN_TRUE, tree->next->flags);
     lyd_free_all(tree);

--- a/tests/utests/test_xpath.c
+++ b/tests/utests/test_xpath.c
@@ -233,7 +233,7 @@ test_hash(void **state)
 
     node = set->objs[0];
     assert_string_equal(node->schema->name, "l1");
-    node = lyd_node_children(node, 0);
+    node = lyd_child(node);
     assert_string_equal(node->schema->name, "a");
     assert_string_equal(LYD_CANON_VALUE(node), "a3");
 
@@ -245,7 +245,7 @@ test_hash(void **state)
 
     node = set->objs[0];
     assert_string_equal(node->schema->name, "ll");
-    node = lyd_node_children(node, 0);
+    node = lyd_child(node);
     assert_string_equal(node->schema->name, "a");
     assert_string_equal(LYD_CANON_VALUE(node), "val_b");
     node = node->next;


### PR DESCRIPTION
Remove lyd_node_children() since it is just an old duplication of
LYD_CHILD and LYD_CHILD_NO_KEYS macros. As a consequence, these macros
are converted to the functions together with LYD_PARENT (same names, but
lowercase) since they have similar functionality in the API.