### PR TITLE
When in actions and notifications

### DIFF
--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1408,13 +1408,12 @@ struct lysc_action {
     const char *name;                /**< action/RPC name (mandatory) */
     const char *dsc;                 /**< description */
     const char *ref;                 /**< reference */
-
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
     struct lysc_iffeature *iffeatures; /**< list of if-feature expressions ([sized array](@ref sizedarrays)) */
 
     struct lysc_action_inout input;  /**< RPC's/action's input */
     struct lysc_action_inout output; /**< RPC's/action's output */
-
+    struct lysc_when **when;         /**< list of pointers to when statements ([sized array](@ref sizedarrays)) */
     void *priv;                      /** private arbitrary user data, not used by libyang */
 
 };
@@ -1433,10 +1432,9 @@ struct lysc_notif {
     const char *name;                /**< Notification name (mandatory) */
     const char *dsc;                 /**< description */
     const char *ref;                 /**< reference */
-
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
     struct lysc_iffeature *iffeatures; /**< list of if-feature expressions ([sized array](@ref sizedarrays)) */
-
+    struct lysc_when **when;         /**< list of pointers to when statements ([sized array](@ref sizedarrays)) */
     void *priv;                      /** private arbitrary user data, not used by libyang */
 };
 

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -672,6 +672,7 @@ lysc_action_free(struct ly_ctx *ctx, struct lysc_action *action)
     FREE_STRING(ctx, action->ref);
     FREE_ARRAY(ctx, action->iffeatures, lysc_iffeature_free);
     FREE_ARRAY(ctx, action->exts, lysc_ext_instance_free);
+    FREE_ARRAY(ctx, action->when, lysc_when_free);
     FREE_ARRAY(ctx, action->input_exts, lysc_ext_instance_free);
     lysc_action_inout_free(ctx, &action->input);
     FREE_ARRAY(ctx, action->output_exts, lysc_ext_instance_free);
@@ -688,6 +689,7 @@ lysc_notif_free(struct ly_ctx *ctx, struct lysc_notif *notif)
     FREE_STRING(ctx, notif->ref);
     FREE_ARRAY(ctx, notif->iffeatures, lysc_iffeature_free);
     FREE_ARRAY(ctx, notif->exts, lysc_ext_instance_free);
+    FREE_ARRAY(ctx, notif->when, lysc_when_free);
     FREE_ARRAY(ctx, notif->musts, lysc_must_free);
     LY_LIST_FOR_SAFE(notif->data, child_next, child) {
         lysc_node_free(ctx, child);


### PR DESCRIPTION
In YANG 1.1, actions nor notifications do not list `when` as their substatement. However, the when can be de-facto inherited to the actions/notification by augmenting their parent in data tree. Moreover, in future YANG versions, `when` substatement is planned even for actions/notifications.