### PR TITLE
Refresh leaflist flag when adding attrs circularly.

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -715,6 +715,8 @@ store_attrs(struct ly_ctx *ctx, struct attr_cont *attrs, struct lyd_node *first,
 
         if (iter->index) {
             flag_leaflist = 1;
+        } else {
+            flag_leaflist = 0;
         }
 
         LY_TREE_FOR(first, diter) {


### PR DESCRIPTION
In the first cycle, if iter->index is 1, flag_leaflist is set to 1.In the next cycle, flag_leaflist is still 1 although the iter->index is 0.