### PR TITLE
schema CHANGE rename lys_atomize_xpath() and the connected options

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -228,7 +228,7 @@ lys_find_child(const struct lysc_node *parent, const struct lys_module *module, 
 }
 
 API LY_ERR
-lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set)
+lys_find_xpath_atoms(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set)
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyxp_set xp_set;

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1898,30 +1898,35 @@ LY_ERR lysc_iffeature_value(const struct lysc_iffeature *iff);
  */
 LY_ERR lysc_feature_value(const struct lysc_feature *feature);
 
-#define LYXP_SCNODE 0x02        /**< No special tree access modifiers. */
-#define LYXP_SCNODE_SCHEMA 0x04 /**< Apply node access restrictions defined for 'when' and 'must' evaluation. */
-#define LYXP_SCNODE_OUTPUT 0x08 /**< Search RPC/action output nodes instead of input ones. */
+/**
+ * @defgroup findxpathoptions Atomize XPath options
+ * Options to modify behavior of ::lys_find_xpath() and ::lys_find_xpath_atoms() searching for schema nodes in schema tree.
+ * @{
+ */
+#define LYS_FIND_XP_SCHEMA 0x04 /**< Apply node access restrictions defined for 'when' and 'must' evaluation. */
+#define LYS_FIND_XP_OUTPUT 0x08 /**< Search RPC/action output nodes instead of input ones. */
+/*
+ * }@
+ */
 
 /**
  * @brief Get all the schema nodes (atoms) that are required for \p xpath to be evaluated.
  *
  * @param[in] ctx_node XPath schema context node.
  * @param[in] xpath Data XPath expression filtering the matching nodes. ::LYD_JSON format is expected.
- * @param[in] options Whether to apply some node access restrictions, one of the options should always be used.
- * If none is set, ::LYXP_SCNODE is used.
+ * @param[in] options Whether to apply some node access restrictions, see @ref findxpathoptions.
  * @param[out] set Set of found atoms (schema nodes).
  * @return LY_SUCCESS on success, @p set is returned.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lys_atomize_xpath(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set);
+LY_ERR lys_find_xpath_atoms(const struct lysc_node *ctx_node, const char *xpath, uint32_t options, struct ly_set **set);
 
 /**
  * @brief Evaluate an \p xpath expression on schema nodes.
  *
  * @param[in] ctx_node XPath schema context node.
  * @param[in] xpath Data XPath expression filtering the matching nodes. ::LYD_JSON format is expected.
- * @param[in] options Whether to apply some node access restrictions, one of the options should always be used.
- * If none is set, ::LYXP_SCNODE is used.
+ * @param[in] options Whether to apply some node access restrictions, see @ref findxpathoptions.
  * @param[out] set Set of found schema nodes.
  * @return LY_SUCCESS on success, @p set is returned.
  * @return LY_ERR value if an error occurred.

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -292,7 +292,6 @@ const char *lyxp_print_token(enum lyxp_token tok);
 LY_ERR lyxp_eval(struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_PREFIX_FORMAT format, void *prefix_data,
         const struct lyd_node *ctx_node, const struct lyd_node *tree, struct lyxp_set *set, uint32_t options);
 
-#define LYXP_SCHEMA 0x01        /**< Apply data node access restrictions defined for 'when' and 'must' evaluation. */
 
 /**
  * @brief Get all the partial XPath nodes (atoms) that are required for @p exp to be evaluated.
@@ -309,8 +308,12 @@ LY_ERR lyxp_eval(struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_PRE
 LY_ERR lyxp_atomize(struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_PREFIX_FORMAT format, void *prefix_data,
         const struct lysc_node *ctx_scnode, struct lyxp_set *set, uint32_t options);
 
-/* used only internally */
-#define LYXP_SCNODE_ALL 0x0E
+/* used only internally, maps with @ref findxpathoptions */
+#define LYXP_SCHEMA 0x01                      /**< Apply data node access restrictions defined for 'when' and 'must' evaluation. */
+#define LYXP_SCNODE 0x02                      /**< No special tree access modifiers. */
+#define LYXP_SCNODE_SCHEMA LYS_FIND_XP_SCHEMA /**< Apply node access restrictions defined for 'when' and 'must' evaluation. */
+#define LYXP_SCNODE_OUTPUT LYS_FIND_XP_OUTPUT /**< Search RPC/action output nodes instead of input ones. */
+#define LYXP_SCNODE_ALL 0x0E                  /**< mask for all the LYXP_* values */
 
 /**
  * @brief Cast XPath set to another type.

--- a/tests/utests/test_xpath.c
+++ b/tests/utests/test_xpath.c
@@ -370,18 +370,18 @@ test_atomize(void **state)
     mod = ly_ctx_get_module_latest(ctx, "a");
 
     /* some random paths just making sure the API function works */
-    assert_int_equal(LY_SUCCESS, lys_atomize_xpath(mod->compiled->data, "/a:*", 0, &set));
+    assert_int_equal(LY_SUCCESS, lys_find_xpath_atoms(mod->compiled->data, "/a:*", 0, &set));
     assert_int_equal(4, set->count);
 
     ly_set_free(set, NULL);
 
     /* all nodes from all modules (including internal, which can change easily, so check just the test modules) */
-    assert_int_equal(LY_SUCCESS, lys_atomize_xpath(mod->compiled->data, "//.", 0, &set));
+    assert_int_equal(LY_SUCCESS, lys_find_xpath_atoms(mod->compiled->data, "//.", 0, &set));
     assert_in_range(set->count, 16, UINT32_MAX);
 
     ly_set_free(set, NULL);
 
-    assert_int_equal(LY_SUCCESS, lys_atomize_xpath(mod->compiled->data->next->next, "/a:c/ll[a='val1']/ll[a='val2']/b",
+    assert_int_equal(LY_SUCCESS, lys_find_xpath_atoms(mod->compiled->data->next->next, "/a:c/ll[a='val1']/ll[a='val2']/b",
                                                    0, &set));
     assert_int_equal(7, set->count);
 


### PR DESCRIPTION
Unify name of lys_atomize_xpath() with the connected lys_find_xpath().
The function is now named lys_find_xpath_atoms() and the options used in
both functions are LYS_FIND_XP* (thei internally maps to a bigger group
of options LYXP_*).

Unifying all the names should make API usage more easier.