### PR TITLE
Solve the problem of performance degradation after repeated insertion and deletion of hash tables

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -326,6 +326,7 @@ lyht_new(uint32_t size, uint16_t val_size, values_equal_cb val_equal, void *cb_d
 
     ht->used = 0;
     ht->size = size;
+    ht->deleted = 0;
     ht->val_equal = val_equal;
     ht->cb_data = cb_data;
     ht->resize = (uint16_t)resize;
@@ -397,10 +398,10 @@ lyht_resize(struct hash_table *ht, int enlarge)
     old_recs = ht->recs;
     old_size = ht->size;
 
-    if (enlarge) {
+    if (enlarge > 0) {
         /* double the size */
         ht->size <<= 1;
-    } else {
+    } else if (enlarge < 0) {
         /* half the size */
         ht->size >>= 1;
     }
@@ -410,6 +411,7 @@ lyht_resize(struct hash_table *ht, int enlarge)
 
     /* reset used, it will increase again */
     ht->used = 0;
+    ht->deleted = 0;
 
     /* add all the old records into the new records array */
     for (i = 0; i < old_size; ++i) {
@@ -762,6 +764,9 @@ lyht_insert_with_resize_cb(struct hash_table *ht, void *val_p, uint32_t hash,
 
     /* insert it into the returned record */
     assert(rec->hits < 1);
+    if (rec->hits < 0) {
+        --ht->deleted;
+    }
     rec->hash = hash;
     rec->hits = 1;
     memcpy(&rec->val, val_p, ht->rec_size - (sizeof(struct ht_rec) - 1));
@@ -872,6 +877,7 @@ lyht_remove_with_resize_cb(struct hash_table *ht, void *val_p, uint32_t hash, va
     /* check size & shrink if needed */
     ret = 0;
     --ht->used;
+    ++ht->deleted;
     if (ht->resize == 2) {
         r = (ht->used * 100) / ht->size;
         if ((r < LYHT_SHRINK_PERCENTAGE) && (ht->size > LYHT_MIN_SIZE)) {
@@ -880,10 +886,23 @@ lyht_remove_with_resize_cb(struct hash_table *ht, void *val_p, uint32_t hash, va
             }
 
             /* shrink */
-            ret = lyht_resize(ht, 0);
+            ret = lyht_resize(ht, -1);
 
             if (resize_val_equal) {
                 lyht_set_cb(ht, old_val_equal);
+            }
+        } else {
+            if ((ht->size > LYHT_MIN_SIZE) && (ht->size - ht->used - ht->deleted) < (ht->size / 50)) {
+                if (resize_val_equal) {
+                    old_val_equal = lyht_set_cb(ht, resize_val_equal);
+                }
+
+                /* rehash */
+                ret = lyht_resize(ht, 0);
+
+                if (resize_val_equal) {
+                    lyht_set_cb(ht, old_val_equal);
+                }
             }
         }
     }

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -52,6 +52,9 @@ typedef int (*values_equal_cb)(void *val1_p, void *val2_p, int mod, void *cb_dat
 /** when the table is less than this much percent full, it is shrunk (half the size) */
 #define LYHT_SHRINK_PERCENTAGE 25
 
+/** when the table is less than this much percent full, it is rehash */
+#define LYHT_REHASH_PERCENTAGE 2
+
 /** never shrink beyond this size */
 #define LYHT_MIN_SIZE 8
 
@@ -75,7 +78,7 @@ struct ht_rec {
 struct hash_table {
     uint32_t used;        /* number of values stored in the hash table (filled records) */
     uint32_t size;        /* always holds 2^x == size (is power of 2), actually number of records allocated */
-    uint32_t invalid;     /* number of delete records in the hash table, which are invalid */
+    uint32_t invalid;     /* number of invaild records in the hash table (deleted records) */
     values_equal_cb val_equal; /* callback for testing value equivalence */
     void *cb_data;        /* user data callback arbitrary value */
     uint16_t resize;      /* 0 - resizing is disabled, *

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -75,7 +75,7 @@ struct ht_rec {
 struct hash_table {
     uint32_t used;        /* number of values stored in the hash table (filled records) */
     uint32_t size;        /* always holds 2^x == size (is power of 2), actually number of records allocated */
-    uint32_t deleted;     /* number of delete records in the hash table */
+    uint32_t invalid;     /* number of delete records in the hash table, which are invalid */
     values_equal_cb val_equal; /* callback for testing value equivalence */
     void *cb_data;        /* user data callback arbitrary value */
     uint16_t resize;      /* 0 - resizing is disabled, *

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -75,6 +75,7 @@ struct ht_rec {
 struct hash_table {
     uint32_t used;        /* number of values stored in the hash table (filled records) */
     uint32_t size;        /* always holds 2^x == size (is power of 2), actually number of records allocated */
+    uint32_t deleted;     /* number of delete records in the hash table */
     values_equal_cb val_equal; /* callback for testing value equivalence */
     void *cb_data;        /* user data callback arbitrary value */
     uint16_t resize;      /* 0 - resizing is disabled, *


### PR DESCRIPTION
After the hash table is repeatedly inserted and deleted, the status of each record is deleted. When a new record is inserted, the entire hash table will be traversed, resulting in performance degradation.The solution is to count the delete state in the hash table. When deleting records, count the idle state, and re-hash when the idle state is less than 2%.