### PR TITLE
fix calculate key-value length error， when key-value contains quotation. 

### DIFF
--- a/src/resolve.c
+++ b/src/resolve.c
@@ -1112,7 +1112,17 @@ parse_schema_json_predicate(const char *id, const char **mod_name, int *mod_name
             ++parsed;
             ++id;
 
-            if ((ptr = strchr(id, quote)) == NULL) {
+            ptr = id;
+            while (ptr) {
+                if (ptr[0] == quote) {
+                    break;
+                } else if (ptr[0] == '\\') {
+                    ptr += 2;
+                } else {
+                    ++ptr;
+                }
+            }
+            if (!ptr) {
                 return -parsed;
             }
             ret = ptr - id;


### PR DESCRIPTION
When using ly_ctx_get_node to get schema node, if there are double/single quotation in data path,  it will parse error.
ex : id: interface[name="test\"dest"]
the name value is test"dest， in parse_schema_json_predicate function get the value is test