### PR TITLE
libyang2: tests MAINTENANCE fix test_parser_yin ASAN stack overflow

### DIFF
--- a/tests/utests/schema/test_parser_yin.c
+++ b/tests/utests/schema/test_parser_yin.c
@@ -630,7 +630,7 @@ test_yin_parse_content(void **state)
     struct lysp_when *when_p = NULL;
     struct lysp_type_enum pos_enum = {}, val_enum = {};
     struct lysp_type req_type = {}, range_type = {}, len_type = {}, patter_type = {}, enum_type = {};
-    uint8_t config = 0;
+    uint16_t config = 0;
 
     ly_in_new_memory(data, &st->in);
     lyxml_ctx_new(st->ctx, st->in, &st->yin_ctx->xmlctx);


### PR DESCRIPTION
Hello,

this fixes an out of bounds read reported by ASAN in the test_parser_yin unit test. It is not a false positive as config is declared as an uint8_t in the unit test, but yin_parse_config in src/parser_yin.c expects a uint16_t.

Below is the output from ASAN:

```
$ ctest -R utest_parser_yin -V
UpdateCTestConfiguration  from :/home/user/lyfixsan/build/DartConfiguration.tcl
UpdateCTestConfiguration  from :/home/user/lyfixsan/build/DartConfiguration.tcl
Test project /home/user/lyfixsan/build
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 13
    Start 13: utest_parser_yin

13: Test command: /home/user/lyfixsan/build/tests/utest_parser_yin
13: Environment variables:
13:  MALLOC_CHECK_=3
13: Test timeout computed to be: 10000000
13: [==========] Running 66 test(s).
13: [ RUN      ] test_yin_match_keyword
13: [       OK ] test_yin_match_keyword
13: [ RUN      ] test_yin_parse_element_generic
13: [       OK ] test_yin_parse_element_generic
13: [ RUN      ] test_yin_parse_extension_instance
13: [       OK ] test_yin_parse_extension_instance
13: [ RUN      ] test_yin_parse_content
13: =================================================================
13: ==3205==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffe1d747ab0 at pc 0x55b87ad5f93b bp 0x7ffe1d7462f0 sp 0x7ffe1d7462e8
13: READ of size 2 at 0x7ffe1d747ab0 thread T0
13:     #0 0x55b87ad5f93a in yin_parse_config /home/user/lyfixsan/src/parser_yin.c:1810:16
13:     #1 0x55b87ad36b51 in yin_parse_content /home/user/lyfixsan/src/parser_yin.c:3441:23
13:     #2 0x55b87a7782bd in test_yin_parse_content /home/user/lyfixsan/tests/utests/schema/test_parser_yin.c:660:11
13:     #3 0x7f43142d60a1  (/usr/lib/libcmocka.so.0+0x60a1)
13:     #4 0x7f43142d6d3b in _cmocka_run_group_tests (/usr/lib/libcmocka.so.0+0x6d3b)
13:     #5 0x55b87a7599f9 in main /home/user/lyfixsan/tests/utests/schema/test_parser_yin.c:4439:12
13:     #6 0x7f4313f02151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)
13:     #7 0x55b87a67a3ed in _start (/home/user/lyfixsan/build/tests/utest_parser_yin+0x3dc3ed)
13:
13: Address 0x7ffe1d747ab0 is located in stack of thread T0 at offset 1232 in frame
13:     #0 0x55b87a775e6f in test_yin_parse_content /home/user/lyfixsan/tests/utests/schema/test_parser_yin.c:588
13:
13:   This frame has 22 object(s):
13:     [32, 40) 'exts' (line 625)
13:     [64, 72) 'if_features' (line 626)
13:     [96, 104) 'value' (line 627)
13:     [128, 136) 'err_msg' (line 627)
13:     [160, 168) 'app_tag' (line 627)
13:     [192, 200) 'units' (line 627)
13:     [224, 240) 'def' (line 628)
13:     [256, 264) 'ext_def' (line 629)
13:     [288, 296) 'when_p' (line 630)
13:     [320, 376) 'pos_enum' (line 631)
13:     [416, 472) 'val_enum' (line 631)
13:     [512, 616) 'req_type' (line 632)
13:     [656, 760) 'range_type' (line 632)
13:     [800, 904) 'len_type' (line 632)
13:     [944, 1048) 'patter_type' (line 632)
13:     [1088, 1192) 'enum_type' (line 632)
13:     [1232, 1233) 'config' (line 633) <== Memory access at offset 1232 partially overflows this variable
13:     [1248, 1656) 'subelems' (line 641)
13:     [1728, 1736) 'prefix_value' (line 712)
13:     [1760, 1808) 'subelems2' (line 713)
13:     [1840, 1888) 'subelems3' (line 737)
13:     [1920, 1944) 'subelems4' (line 751)
13: HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
13:       (longjmp and C++ exceptions *are* supported)
13: SUMMARY: AddressSanitizer: stack-buffer-overflow /home/user/lyfixsan/src/parser_yin.c:1810:16 in yin_parse_config
13: Shadow bytes around the buggy address:
13:   0x100043ae0f00: 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2 00 00
13:   0x100043ae0f10: 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2
13:   0x100043ae0f20: 00 00 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2
13:   0x100043ae0f30: f2 f2 00 00 00 00 00 00 00 00 00 00 00 00 00 f2
13:   0x100043ae0f40: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00 00 00
13: =>0x100043ae0f50: 00 f2 f2 f2 f2 f2[01]f2 00 00 00 00 00 00 00 00
13:   0x100043ae0f60: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
13:   0x100043ae0f70: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
13:   0x100043ae0f80: 00 00 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2
13:   0x100043ae0f90: f2 f2 f2 f2 f8 f2 f2 f2 f8 f8 f8 f8 f8 f8 f2 f2
13:   0x100043ae0fa0: f2 f2 f8 f8 f8 f8 f8 f8 f2 f2 f2 f2 f8 f8 f8 f3
13: Shadow byte legend (one shadow byte represents 8 application bytes):
13:   Addressable:           00
13:   Partially addressable: 01 02 03 04 05 06 07
13:   Heap left redzone:       fa
13:   Freed heap region:       fd
13:   Stack left redzone:      f1
13:   Stack mid redzone:       f2
13:   Stack right redzone:     f3
13:   Stack after return:      f5
13:   Stack use after scope:   f8
13:   Global redzone:          f9
13:   Global init order:       f6
13:   Poisoned by user:        f7
13:   Container overflow:      fc
13:   Array cookie:            ac
13:   Intra object redzone:    bb
13:   ASan internal:           fe
13:   Left alloca redzone:     ca
13:   Right alloca redzone:    cb
13:   Shadow gap:              cc
13: ==3205==ABORTING
1/1 Test #13: utest_parser_yin .................***Failed    0.08 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   0.08 sec

The following tests FAILED:
	 13 - utest_parser_yin (Failed)
Errors while running CTest
```

For some reason the issue is only detected when compiled with clang, here is what I used to build libyang:
```cmake -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="-fsanitize=address,undefined"  -DENABLE_VALGRIND_TESTS=OFF ..```