### PR TITLE
libyang2: travis FEATURE add test job with ASAN and UBSAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,20 @@ jobs:
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: Test
+      name: Linux with CLang ASAN and UBSAN
+      os: linux
+      compiler: clang
+      before_install:
+        - sudo apt-get update -qq && sudo apt-get install -y valgrind
+        - wget https://cmocka.org/files/1.1/cmocka-1.1.2.tar.xz
+        - tar -xf cmocka-1.1.2.tar.xz
+        - cd cmocka-1.1.2 && mkdir build && cd build && cmake .. && make -j2 && sudo make install && cd ../..
+        - wget https://ftp.pcre.org/pub/pcre/pcre2-10.30.tar.gz
+        - tar -xzf pcre2-10.30.tar.gz
+        - cd pcre2-10.30 && ./configure && make -j2 && sudo -i -- sh -c 'cd /home/travis/build/CESNET/libyang/pcre2-10.30/ && make install' && cd ..
+      script:
+        - mkdir build && cd build && cmake -DCMAKE_C_FLAGS="-fsanitize=address,undefined" -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
+    - stage: Test
       name: ABI check
       os: linux
       compiled: gcc

--- a/tests/fuzz/fuzz_regression_test.c
+++ b/tests/fuzz/fuzz_regression_test.c
@@ -64,5 +64,7 @@ int main(int argc, char **argv)
 		printf("test %s - %s successful\n", argv[1], dir->d_name);
 	}
 
+	closedir(d);
+
 	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Hello,

I've added a test job with ASAN and UBSAN enabled that runs libyang unit tests to detect issues that valgrind might miss.
Valgrind tests are disabled for this build as valgrind can't run with sanitizers enabled.

There seems to be no need to explicitly enable leak sanitizer as it is already included with [ASAN](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer).

There doesn't seem to be any need for enabling memory sanitizer either, as the [wiki](https://github.com/google/sanitizers/wiki/MemorySanitizer) states that it implements a subset of functionality of valgrind.

For reference [here](https://github.com/google/sanitizers/wiki/AddressSanitizerComparisonOfMemoryTools) is a comparison between ASAN and valgrind.