### PR TITLE
C++: Fix bit value printing

### DIFF
--- a/swig/cpp/src/Tree_Data.cpp
+++ b/swig/cpp/src/Tree_Data.cpp
@@ -42,9 +42,14 @@ std::vector<S_Type_Bit> Value::bit() {
     if ((LY_TYPE_BITS != value_type) || (LY_TYPE_BITS != type->base)) {
         throw "wrong type";
     }
-    std::vector<S_Type_Bit> vec(type->info.bits.count);
 
-    for (unsigned int i = 0; i < type->info.bits.count; ++i) {
+    auto bitDefinitions = type;
+    while (bitDefinitions->info.bits.count == 0) {
+        bitDefinitions = &type->der->type;
+    }
+    std::vector<S_Type_Bit> vec(bitDefinitions->info.bits.count);
+
+    for (unsigned int i = 0; i < bitDefinitions->info.bits.count; ++i) {
         if (value.bit[i]) {
             vec[i] = std::make_shared<Type_Bit>(value.bit[i], deleter);
         }


### PR DESCRIPTION
This seems like an easy thing to forget about, so maybe there should be a function that would always give the resolved base type. I'm not sure whether `lyd_leaf_type` does that (the documentation doesn't say that). Anyway, this patch at least unbreaks bit value retrieval. More info here https://github.com/CESNET/libyang/issues/1268 (also example program).