### PR TITLE
Find xpath speedup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,8 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
-set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
-set(CMAKE_C_FLAGS_PACKAGE "-g -O2 -DNDEBUG")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_C_FLAGS_PACKAGE "-g -O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG   "-g -Og")
 
 # options

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1646,12 +1646,6 @@ lyd_make_canonical(const struct lys_node *schema, const char *val_str, int val_s
 
     assert(schema->nodetype & (LYS_LEAF | LYS_LEAFLIST));
 
-    str = strndup(val_str, val_str_len);
-    if (!str) {
-        LOGMEM(schema->module->ctx);
-        return NULL;
-    }
-
     /* parse the value into a fake leaf */
     struct lyd_node_leaf_list *node_leaf_list;
 
@@ -1661,7 +1655,7 @@ lyd_make_canonical(const struct lys_node *schema, const char *val_str, int val_s
     node_leaf_list->schema = (struct lys_node *)schema;
     node_leaf_list->prev = (struct lyd_node *)node_leaf_list;
     node_leaf_list->value_type = ((struct lys_node_leaf *)schema)->type.base;
-    node_leaf_list->value_str = lydict_insert(schema->module->ctx, str ? str : "", 0);
+    node_leaf_list->value_str = lydict_insert(schema->module->ctx, val_str ? val_str : "", val_str_len);
     node_leaf_list->dflt = 0;
 
     if (!lyp_parse_value(&((struct lys_node_leaf *)schema)->type, &node_leaf_list->value_str, NULL, node_leaf_list, NULL, NULL, 0, 0)) {
@@ -1671,7 +1665,6 @@ lyd_make_canonical(const struct lys_node *schema, const char *val_str, int val_s
 
     node = (struct lyd_node *)node_leaf_list;
 
-    free(str);
     if (!node) {
         return NULL;
     }

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -1653,7 +1653,24 @@ lyd_make_canonical(const struct lys_node *schema, const char *val_str, int val_s
     }
 
     /* parse the value into a fake leaf */
-    node = lyd_create_leaf(schema, str, 0, 0);
+    struct lyd_node_leaf_list *node_leaf_list;
+
+    node_leaf_list = calloc(1, sizeof *node_leaf_list);
+    LY_CHECK_ERR_RETURN(!node_leaf_list, LOGMEM(schema->module->ctx), NULL);
+
+    node_leaf_list->schema = (struct lys_node *)schema;
+    node_leaf_list->prev = (struct lyd_node *)node_leaf_list;
+    node_leaf_list->value_type = ((struct lys_node_leaf *)schema)->type.base;
+    node_leaf_list->value_str = lydict_insert(schema->module->ctx, str ? str : "", 0);
+    node_leaf_list->dflt = 0;
+
+    if (!lyp_parse_value(&((struct lys_node_leaf *)schema)->type, &node_leaf_list->value_str, NULL, node_leaf_list, NULL, NULL, 0, 0)) {
+        lyd_free((struct lyd_node *)node_leaf_list);
+        return NULL;
+    }
+
+    node = (struct lyd_node *)node_leaf_list;
+
     free(str);
     if (!node) {
         return NULL;

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -5521,8 +5521,8 @@ moveto_node_check(struct lyd_node *node, enum lyxp_node_type root_type, const ch
             return -1;
         }
     } else {
-        if (strcmp(node_name, "*") && (strncmp(node->schema->name, node_name, node_name_len) ||
-            node->schema->name[node_name_len] != '\0')) {
+        if ((strncmp(node_name, "*", 1) || node_name_len != 1) &&
+            (strncmp(node->schema->name, node_name, node_name_len) || node->schema->name[node_name_len] != '\0')) {
             return -1;
         }
     }

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -5493,15 +5493,17 @@ moveto_snode_root(struct lyxp_set *set, struct lys_node *cur_node, int options)
  *
  * @param[in] node Node to check.
  * @param[in] root_type XPath root node type.
- * @param[in] node_name Node name to move to. Must be in the dictionary!
+ * @param[in] node_name_dict Optional parameter, contains the node name to move to when it is on the string dict.
+ * @param[in] node_name Contains the node name to move to. Used when node_name_dict is NULL (not provided).
+ * @param[in] node_name_len Length of \p node_name.
  * @param[in] moveto_mod Expected module of the node.
  * @param[in] options Whether to apply data node access restrictions defined for 'when' and 'must' evaluation.
  *
  * @return EXIT_SUCCESS on success, EXIT_FAILURE on unresolved when, -1 on error.
  */
 static int
-moveto_node_check(struct lyd_node *node, enum lyxp_node_type root_type, const char *node_name,
-                  struct lys_module *moveto_mod, int options)
+moveto_node_check(struct lyd_node *node, enum lyxp_node_type root_type, const char *node_name_dict,
+                  const char *node_name, int node_name_len, struct lys_module *moveto_mod, int options)
 {
     /* module check */
     if (moveto_mod && (lyd_node_module(node) != moveto_mod)) {
@@ -5514,8 +5516,15 @@ moveto_node_check(struct lyd_node *node, enum lyxp_node_type root_type, const ch
     }
 
     /* name check */
-    if (strcmp(node_name, "*") && !ly_strequal(node->schema->name, node_name, 1)) {
-        return -1;
+    if (node_name_dict) {
+        if (strcmp(node_name_dict, "*") && !ly_strequal(node->schema->name, node_name_dict, 1)) {
+            return -1;
+        }
+    } else {
+        if (strcmp(node_name, "*") && (strncmp(node->schema->name, node_name, node_name_len) ||
+            node->schema->name[node_name_len] != '\0')) {
+            return -1;
+        }
     }
 
     /* when check */
@@ -5581,6 +5590,7 @@ moveto_node(struct lyxp_set *set, struct lyd_node *cur_node, struct lys_module *
             uint16_t qname_len, int options)
 {
     uint32_t i;
+    int comparison_counter = 0;
     int replaced, pref_len, ret;
     const char *ptr, *name_dict = NULL; /* optimalization - so we can do (==) instead (!strncmp(...)) in moveto_node_check() */
     struct lys_module *moveto_mod;
@@ -5621,15 +5631,17 @@ moveto_node(struct lyxp_set *set, struct lyd_node *cur_node, struct lys_module *
         moveto_mod = local_mod;
     }
 
-    /* name */
-    name_dict = lydict_insert(ctx, qname, qname_len);
-
     for (i = 0; i < set->used; ) {
         replaced = 0;
 
         if ((set->val.nodes[i].type == LYXP_NODE_ROOT_CONFIG) || (set->val.nodes[i].type == LYXP_NODE_ROOT)) {
             LY_TREE_FOR(set->val.nodes[i].node, sub) {
-                ret = moveto_node_check(sub, root_type, name_dict, moveto_mod, options);
+                /* avoid using string dict (lydict_insert call) for few node checks */
+                comparison_counter++;
+                if (!name_dict && (comparison_counter > LYXP_MIN_NODE_CHECKS_TO_USE_DICT)) {
+                    name_dict = lydict_insert(ctx, qname, qname_len);
+                }
+                ret = moveto_node_check(sub, root_type, name_dict, qname, qname_len, moveto_mod, options);
                 if (!ret) {
                     /* pos filled later */
                     if (!replaced) {
@@ -5650,7 +5662,12 @@ moveto_node(struct lyxp_set *set, struct lyd_node *cur_node, struct lys_module *
                 && !(set->val.nodes[i].node->schema->nodetype & (LYS_LEAF | LYS_LEAFLIST | LYS_ANYDATA))) {
 
             LY_TREE_FOR(set->val.nodes[i].node->child, sub) {
-                ret = moveto_node_check(sub, root_type, name_dict, moveto_mod, options);
+                /* avoid using string dict (lydict_insert call) for few node checks */
+                comparison_counter++;
+                if (!name_dict && (comparison_counter > LYXP_MIN_NODE_CHECKS_TO_USE_DICT)) {
+                    name_dict = lydict_insert(ctx, qname, qname_len);
+                }
+                ret = moveto_node_check(sub, root_type, name_dict, qname, qname_len, moveto_mod, options);
                 if (!ret) {
                     if (!replaced) {
                         set_replace_node(set, sub, 0, LYXP_NODE_ELEM, i);
@@ -5682,7 +5699,7 @@ moveto_snode(struct lyxp_set *set, struct lys_node *cur_node, struct lys_module 
 {
     int i, orig_used, pref_len, idx, temp_ctx = 0;
     uint32_t mod_idx;
-    const char *ptr, *name_dict = NULL; /* optimalization - so we can do (==) instead (!strncmp(...)) in moveto_node_check() */
+    const char *ptr, *name_dict = NULL; /* optimalization - so we can do (==) instead (!strncmp(...)) in moveto_snode_check() */
     struct lys_module *moveto_mod, *tmp_mod;
     const struct lys_node *sub, *start_parent;
     struct lys_node_augment *last_aug;

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -80,6 +80,18 @@
 #define LYXP_STRING_CAST_SIZE_START 64
 #define LYXP_STRING_CAST_SIZE_STEP 16
 
+/* Number of node checks when it starts being worth using the string dict.
+ * Node checks involves some string comparisons. Consider two ways to compare
+ * strings: one is using the string dict, another is simply comparing the chars
+ * of the strings (like 'strcmp' does). When using the string dict, the hash is
+ * computed using the entire string and after the memory address to that is got,
+ * the pointers are compared (as both strings compared are in the dict). It is
+ * worth using the dict when a lot of string comparisons using the same string
+ * is performed, but to compute just a few, comparing the chars of the strings
+ * is faster.
+ */
+#define LYXP_MIN_NODE_CHECKS_TO_USE_DICT 10
+
 /**
  * @brief Tokens that can be in an XPath expression.
  */


### PR DESCRIPTION
These changes were based on benchmark and flamegraph. The benchmark file "benchmark_lyv1.zip" (the files "frr-filter.yang" and "l1_test.json" are used by program "l1_perf.c") and the interactive flamegraph "l1_perf_2ac5bb59_svg.zip" (needed to zip the SVG file to attach here, maybe Github doesn't accept this format) are attached in this comment. The benchmark program loads module "frr-filter" from yang file, loads a json file with ~550k lines and executes "lyd_find_path" function. The objective is to make the execution of "lyd_find_path" faster.
  
[benchmark_lyv1.zip](https://github.com/CESNET/libyang/files/5534011/benchmark_lyv1.zip)
[l1_perf_2ac5bb59_svg.zip](https://github.com/CESNET/libyang/files/5534026/l1_perf_2ac5bb59_svg.zip)
  
There are 3 changes in this pull request, each in a separated commit.
- The function "lyd_create_leaf", called by "lyd_make_canonical", created a fake node during the execution of "lyd_find_path". Because of this, most of the time spent by this function was in "lyd_hash", "lydict_insert", "lydict_remove", etc. and this was unnecessary, as this node was created to test.
- The function "moveto_node", called by "eval_node_test", used the string dict to improve performance, calling the same functions cited above ("lyd_hash", "lydict_insert", "lydict_remove", etc.). But in fact, in that specific case, it is slower to use the dict (that needs to compute a number from all string characters), it is faster to simply compare strings.
- The option ENABLE_CACHE present on CMake file turned the time of the benchmark program slower, so it was changed to OFF by default.
  
The results are below. The execution time of "lyd_find_path" was cut by ~43%.
  
Results on branch 'devel' at 98fb0d0b:
find 1x (s): 0.097888
same find 10x (s): 0.978431
total prog time (s): 1.337355
total non-find time (s): 0.261036
  
Results on branch 'find_xpath_speedup' at 8fccceba:
find 1x (s): 0.055731
same find 10x (s): 0.557739
total prog time (s): 0.852393
total non-find time (s): 0.238923