### PR TITLE
Fix error for printing json schema for augmented node

### DIFF
--- a/src/printer_json_schema.c
+++ b/src/printer_json_schema.c
@@ -791,7 +791,9 @@ jsons_print_data_(struct lyout *out, const struct lys_module *mod, struct lys_no
             }
             ly_print(out, "}");
         } else {
-            ly_print(out, "\"%s:%s\":{\"nodetype\":\"%s\"}", lys_main_module(node->module)->name, node->name,
+            ly_print(out, "%s\"%s:%s\":{\"nodetype\":\"%s\"}",
+                     (first && (*first)) ? "" : ",",
+                     lys_main_module(node->module)->name, node->name,
                      jsons_nodetype_str(node->nodetype));
             (*first) = 0;
         }


### PR DESCRIPTION
Fix error missing , from printing json schema for augmented node.

#1275
https://github.com/CESNET/libyang/pull/1275#issuecomment-727837336