### PR TITLE
build BUGFIX gcc miss paremeters for compiling program when coverage option is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,9 +85,9 @@ jobs:
         - wget https://ftp.pcre.org/pub/pcre/pcre2-10.30.tar.gz
         - tar -xzf pcre2-10.30.tar.gz
         - cd pcre2-10.30 && ./configure && make -j2 && sudo make install && cd ..
-        - pip install --user codecov && export CFLAGS="-coverage"
+        - pip install --user codecov
       script:
-        - mkdir build && cd build && cmake .. && make -j2 && ctest --output-on-failure && cd -
+        - mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON  ../ && make -j2 && ctest --output-on-failure && cd -
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: Test
@@ -124,4 +124,4 @@ jobs:
         - os: osx
       script:
         - mkdir build && cd build && cmake -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
- 
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
           project:
             name: "CESNET/libyang"
           notification_email: rkrejci@cesnet.cz
-          build_command_prepend: "mkdir build && cd build && cmake .. && make clean"
+          build_command_prepend: "mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make clean"
           build_command: "make"
           branch_pattern: libyang2
       before_install:
@@ -72,7 +72,7 @@ jobs:
         - tar -xzf pcre2-10.30.tar.gz
         - cd pcre2-10.30 && ./configure && make -j2 && sudo -i -- sh -c 'cd /home/travis/build/CESNET/libyang/pcre2-10.30/ && make install' && cd ..
       script:
-        - mkdir build && cd build && cmake .. && make -j2 && ctest --output-on-failure && cd -
+        - mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Debug .. && make -j2 && ctest --output-on-failure && cd -
     - stage: Test
       name: Linux with GCC
       os: linux
@@ -103,7 +103,7 @@ jobs:
         - tar -xzf pcre2-10.30.tar.gz
         - cd pcre2-10.30 && ./configure && make -j2 && sudo -i -- sh -c 'cd /home/travis/build/CESNET/libyang/pcre2-10.30/ && make install' && cd ..
       script:
-        - mkdir build && cd build && cmake -DCMAKE_C_FLAGS="-fsanitize=address,undefined" -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
+        - mkdir build && cd build && cmake -DCMAKE_C_FLAGS="-fsanitize=address,undefined" -DENABLE_BUILD_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
     - stage: Test
       name: ABI check
       os: linux
@@ -123,5 +123,5 @@ jobs:
       allow_failures:
         - os: osx
       script:
-        - mkdir build && cd build && cmake -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
+        - mkdir build && cd build && cmake -DENABLE_BUILD_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF .. && make -j2 && ctest --output-on-failure && cd -
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,11 @@ option(ENABLE_FUZZ_TARGETS "Build target programs suitable for fuzzing with AFL"
 #endif()
 
 if(ENABLE_COVERAGE)
+    if(NOT ENABLE_BUILD_TESTS)
+        message(WARNING "you cannot generage coverage when tests are disabled. Enable test by additing parameter -DENABLE_BUILD_TESTS=ON or run cmake in some debug mode")
+        set(ENABLE_COVERAGE OFF)
+    endif()
+
     find_program(PATH_GCOV NAMES gcov)
     if(NOT PATH_GCOV)
         message(WARNING "'gcov' executable not found! Disabling building code coverage report.")
@@ -353,7 +358,7 @@ if(ENABLE_BUILD_TESTS)
         add_subdirectory(tests)
     else()
         message(STATUS "Disabling tests because of missing CMocka")
-        set(ENABLE_BUILD_TESTS NO)
+        set(ENABLE_BUILD_TESTS OFF)
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ else()
     set(COMPILER_PACKED_ATTR "")
 endif()
 
-set(CMAKE_C_FLAGS                "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_COVERAGE} -Wall -Wextra -Wno-missing-field-initializers -std=c99")
+set(CMAKE_C_FLAGS                "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-missing-field-initializers -std=c99")
 set(CMAKE_C_FLAGS_DEBUG          "-g3 -O0")
 set(CMAKE_C_FLAGS_ABICHECK       "-g -Og")
 
@@ -221,7 +221,7 @@ if(ENABLE_COVERAGE)
     endif()
 
     if(ENABLE_COVERAGE)
-        set(CMAKE_C_FLAGS_COVERAGE "${CMAKE_C_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage -fprofile-arcs -ftest-coverage")
     endif()
 endif()
 

--- a/tools/lint/CMakeLists.txt
+++ b/tools/lint/CMakeLists.txt
@@ -39,18 +39,20 @@ function(add_yanglint_test)
     set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "YANGLINT=${PROJECT_BINARY_DIR}/yanglint")
 endfunction(add_yanglint_test)
 
-# tests of non-interactive mode using shunit2
-find_program(PATH_SHUNIT NAMES shunit2)
-if(NOT PATH_SHUNIT)
-    message(WARNING "'shunit2' not found! The yanglint(1) non-interactive tests will not be available.")
-else()
-    add_yanglint_test(NAME ni_list SCRIPT shunit2/list.sh)
-endif()
+if(ENABLE_BUILD_TESTS)
+    # tests of non-interactive mode using shunit2
+    find_program(PATH_SHUNIT NAMES shunit2)
+    if(NOT PATH_SHUNIT)
+        message(WARNING "'shunit2' not found! The yanglint(1) non-interactive tests will not be available.")
+    else()
+        add_yanglint_test(NAME ni_list SCRIPT shunit2/list.sh)
+    endif()
 
-# tests of interactive mode using expect
-find_program(PATH_EXPECT NAMES expect)
-if(NOT PATH_EXPECT)
-    message(WARNING "'expect' not found! The yanglint(1) interactive tests will not be available.")
-else()
-#    add_yanglint_test(NAME in_list SCRIPT expect/list.exp)
+    # tests of interactive mode using expect
+    find_program(PATH_EXPECT NAMES expect)
+    if(NOT PATH_EXPECT)
+        message(WARNING "'expect' not found! The yanglint(1) interactive tests will not be available.")
+    else()
+#        add_yanglint_test(NAME in_list SCRIPT expect/list.exp)
+    endif()
 endif()


### PR DESCRIPTION
In branch libyang2 is a bug. Command cmake -DENABLE_COVER=ON doesn't add parameters " --coverage -fprofile-arcs -ftest-coverage" into a variable CMAKE_C_FLAGS. These parameters are required for generating coverage.