### PR TITLE
Support a parser option LYD_OPT_NOTIF_FILTER for filtered event notifications resolution

### DIFF
--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -487,7 +487,7 @@ attr_error:
         }
         *act_notif = *result;
     } else if (schema->nodetype == LYS_NOTIF) {
-        if (!(options & LYD_OPT_NOTIF) || *act_notif) {
+        if (!(options & (LYD_OPT_NOTIF | LYD_OPT_NOTIF_FILTER)) || *act_notif) {
             LOGVAL(ctx, LYE_INELEM, LY_VLOG_LYD, (*result), schema->name);
             LOGVAL(ctx, LYE_SPEC, LY_VLOG_PREV, NULL, "Unexpected notification node \"%s\".", schema->name);
             goto unlink_node_error;

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -7995,7 +7995,7 @@ lyd_wd_add(struct lyd_node **root, struct ly_ctx *ctx, const struct lys_module *
                 }
             }
         }
-    } else if (options & LYD_OPT_NOTIF) {
+    } else if (options & (LYD_OPT_NOTIF | LYD_OPT_NOTIF_FILTER)) {
         if (!(*root) || ((*root)->schema->nodetype != LYS_NOTIF)) {
             LOGERR(ctx, LY_EINVAL, "Subtree is not a single notification.");
             return EXIT_FAILURE;


### PR DESCRIPTION
Hi Michal,
There is a failure when I use the function `lyd_parse_xml()` with a  parser  option LYD_OPT_NOTIF_FILTER to parse  xml subtree filter data which represents a filtered event notification data, the error msg is that: 
 ```
libyang[0]: Unknown element "netconf-session-end". (path: /ietf-netconf-notifications:netconf-session-end)
libyang[0]: Unexpected notification node "netconf-session-end". (path: /ietf-netconf-notifications:netconf-session-end)
test: main.c:33: main: Assertion `filter_subtree != NULL' failed.
[1]    11061 abort      ./test
``` 
, then I try to fix this, please review it.

Blow is  my test code:
```
#include <assert.h>

#include "libyang.h"
#define TEST_PATH "/data/libyang_dev/"

int main(void)
{
    const char *data_xml = "<create-subscription xmlns=\"urn:ietf:params:xml:ns:netconf:notification:1.0\"><stream>NETCONF</stream>"
                           "<filter type=\"subtree\"><netconf-session-end xmlns=\"urn:ietf:params:xml:ns:yang:ietf-netconf-notifications\">"
                           "</netconf-session-end></filter><startTime>2019-12-11T06:22:28Z</startTime></create-subscription>";
    struct ly_ctx *ctx = ly_ctx_new(NULL, 0);
    const struct lys_module *mod = NULL;
   
    ly_ctx_set_searchdir(ctx, TEST_PATH);
    mod = lys_parse_path(ctx, TEST_PATH"notifications.yang", LYS_IN_YANG);
    assert(mod != NULL);
    mod = lys_parse_path(ctx, TEST_PATH"../libyang/tests/schema/yang/ietf/ietf-netconf-notifications.yang", LYS_IN_YANG);
    assert(mod != NULL);
    
    struct lyd_node *root = lyd_parse_mem(ctx, data_xml, LYD_XML, LYD_OPT_RPC, NULL);
    assert(root != NULL);
    struct ly_set *set = lyd_find_path(root, "/notifications:create-subscription/filter");
    assert(set != NULL);
    struct lyd_node *anydata_node = *set->set.d;
    struct lyd_node_anydata *filter_anydata = (struct lyd_node_anydata *)anydata_node;
    const struct lyd_node *filter_subtree = NULL;
    int opt = LYD_OPT_TRUSTED | LYD_OPT_OBSOLETE | LYD_OPT_NOTIF_FILTER;
    if (filter_anydata->value_type == LYD_ANYDATA_XML) {
        filter_subtree = lyd_parse_xml(ctx, &(filter_anydata->value.xml), opt, NULL);
    }    
    assert(filter_subtree != NULL);
	
    lyd_free_withsiblings(root);
    ly_ctx_destroy(ctx, NULL);
    return 0;
}

```
test module is as follows:

[notifications.yang.txt](https://github.com/CESNET/libyang/files/5596666/notifications.yang.txt)
