### PR TITLE
Failure caused by calloc(0) when parser yin format for type bits and enum

### DIFF
--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -673,7 +673,7 @@ fill_yin_type(struct lys_module *module, struct lys_node *parent, struct lyxml_e
             }
         }
 
-        type->info.bits.bit = calloc(type->info.bits.count, sizeof *type->info.bits.bit);
+        type->info.bits.bit = calloc((type->info.bits.count ? type->info.bits.count : 1), sizeof *type->info.bits.bit);
         LY_CHECK_ERR_GOTO(!type->info.bits.bit, LOGMEM(ctx), error);
 
         p = 0;
@@ -968,7 +968,7 @@ fill_yin_type(struct lys_module *module, struct lys_node *parent, struct lyxml_e
             }
         }
 
-        type->info.enums.enm = calloc(type->info.enums.count, sizeof *type->info.enums.enm);
+        type->info.enums.enm = calloc((type->info.enums.count ? type->info.enums.count : 1), sizeof *type->info.enums.enm);
         LY_CHECK_ERR_GOTO(!type->info.enums.enm, LOGMEM(ctx), error);
 
         v = 0;


### PR DESCRIPTION
Hi Michal,

As described in man page for [calloc](https://linux.die.net/man/3/calloc)

> The calloc() function allocates memory for an array of nmemb elements of size bytes each and returns a pointer to the allocated memory. The memory is set to zero. If nmemb or size is 0, then calloc() returns either NULL, or a unique pointer value that can later be successfully passed to free().

There  may be  a failure caused by `calloc(0)`  when  parser yin format for the type enum  `myEnums` or the bits  `myBits` in function `fill_yin_type`.

```c
        type->info.bits.bit = calloc(type->info.bits.count, sizeof *type->info.bits.bit);
        LY_CHECK_ERR_GOTO(!type->info.bits.bit, LOGMEM(ctx), error);
```

In the code above, if `calloc` returns 0 in some systems, then the parser goes to error!

I use the yin module `mod.yin`, as follows:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<module name="mod"
        xmlns="urn:ietf:params:xml:ns:yang:yin:1"
        xmlns:eb="urn:cesnet:enum-bits">
  <yang-version value="1.1"/>
  <namespace uri="urn:cesnet:enum-bits"/>
  <prefix value="eb"/>
  <typedef name="myBits">
    <type name="bits">
      <bit name="one"/>
      <bit name="two"/>
      <bit name="three"/>
    </type>
  </typedef>
  <typedef name="myEnums">
    <type name="enumeration">
      <enum name="foo"/>
      <enum name="bar"/>
    </type>
  </typedef>
  <leaf name="lb">
    <type name="myBits"/>
    <default value="one"/>
  </leaf>
  <leaf name="le">
    <type name="myEnums"/>
    <default value="bar"/>
  </leaf>
</module>
```