### PR TITLE
Libyang2 logging

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -159,6 +159,8 @@ size_t LY_VCODE_INSTREXP_len(const char *str);
 #define LY_VCODE_INVAL_MINMAX   LYVE_SEMANTICS, "Invalid combination of min-elements and max-elements: min value %u is bigger than the max value %u."
 #define LY_VCODE_CIRC_WHEN      LYVE_SEMANTICS, "When condition of \"%s\" includes a self-reference (referenced by when of \"%s\")."
 #define LY_VCODE_DUMMY_WHEN     LYVE_SEMANTICS, "When condition of \"%s\" is accessing its own conditional node."
+#define LY_VCODE_NAME_COL       LYVE_SEMANTICS, "Name collision between %s of name \"%s\"."
+#define LY_VCODE_NAME2_COL      LYVE_SEMANTICS, "Name collision between %s and %s of name \"%s\"."
 
 #define LY_VCODE_INSTMT         LYVE_SYNTAX_YANG, "Invalid keyword \"%s\"."
 #define LY_VCODE_INCHILDSTMT    LYVE_SYNTAX_YANG, "Invalid keyword \"%s\" as a child of \"%s\"."
@@ -185,7 +187,6 @@ size_t LY_VCODE_INSTREXP_len(const char *str);
 #define LY_VCODE_UNEXP_ATTR     LYVE_SYNTAX_YIN, "Unexpected attribute \"%.*s\" of \"%s\" element."
 #define LY_VCODE_MAND_SUBELEM   LYVE_SYNTAX_YIN, "Missing mandatory sub-element \"%s\" of \"%s\" element."
 #define LY_VCODE_FIRT_SUBELEM   LYVE_SYNTAX_YIN, "Sub-element \"%s\" of \"%s\" element must be defined as it's first sub-element."
-#define LY_VCODE_NAME_COL       LYVE_SYNTAX_YIN, "Name collision between module and submodule of name \"%s\"."
 #define LY_VCODE_SUBELEM_REDEF  LYVE_SYNTAX_YIN, "Redefinition of \"%s\" sub-element in \"%s\" element."
 
 #define LY_VCODE_XP_EOE         LYVE_XPATH, "Unterminated string delimited with %c (%.15s)."

--- a/src/common.h
+++ b/src/common.h
@@ -58,15 +58,6 @@ struct lys_module;
  * Logger
  *****************************************************************************/
 
-enum LY_VLOG_ELEM {
-    LY_VLOG_NONE = 0,
-    LY_VLOG_LINE, /* line number (uint64_t*) */
-    LY_VLOG_LYSC, /* struct lysc_node* */
-    LY_VLOG_LYD,  /* struct lyd_node* */
-    LY_VLOG_STR,  /* const char* */
-    LY_VLOG_PREV  /* use exact same previous path */
-};
-
 extern THREAD_LOCAL enum int_log_opts log_opt;
 extern volatile LY_LOG_LEVEL ly_ll;
 extern volatile uint32_t ly_log_opts;
@@ -98,12 +89,10 @@ void ly_log(const struct ly_ctx *ctx, LY_LOG_LEVEL level, LY_ERR no, const char 
  * @brief Print Validation error and store it into the context (if provided).
  *
  * @param[in] ctx libyang context to store the error record. If not provided, the error is just printed.
- * @param[in] elem_type Type of the data in @p elem variable.
- * @param[in] elem Object to provide more information about the place where the error appeared.
  * @param[in] code Validation error code.
  * @param[in] format Format string to print.
  */
-void ly_vlog(const struct ly_ctx *ctx, enum LY_VLOG_ELEM elem_type, const void *elem, LY_VECODE code, const char *format, ...);
+void ly_vlog(const struct ly_ctx *ctx, LY_VECODE code, const char *format, ...);
 
 /**
  * @brief Logger's location data setter.
@@ -178,7 +167,10 @@ void ly_log_dbg(uint32_t group, const char *format, ...);
 #define LOGMEM(CTX) LOGERR(CTX, LY_EMEM, "Memory allocation failed (%s()).", __func__)
 #define LOGINT(CTX) LOGERR(CTX, LY_EINT, "Internal error (%s:%d).", __FILE__, __LINE__)
 #define LOGARG(CTX, ARG) LOGERR(CTX, LY_EINVAL, "Invalid argument %s (%s()).", #ARG, __func__)
-#define LOGVAL(CTX, ELEM_TYPE, ELEM, CODE, ...) ly_vlog(CTX, ELEM_TYPE, ELEM, CODE, ##__VA_ARGS__)
+#define LOGVAL(CTX, CODE, ...) ly_vlog(CTX, CODE, ##__VA_ARGS__)
+#define LOGVAL_LINE(CTX, LINE, CODE, ...) \
+    ly_log_location(CTX, NULL, NULL, NULL, NULL, LINE, 0); \
+    ly_vlog(CTX, CODE, ##__VA_ARGS__)
 
 #define LOGMEM_RET(CTX) LOGMEM(CTX); return LY_EMEM
 #define LOGINT_RET(CTX) LOGINT(CTX); return LY_EINT
@@ -225,8 +217,6 @@ size_t LY_VCODE_INSTREXP_len(const char *str);
 #define LY_VCODE_TRAILING_SUBMOD LYVE_SYNTAX, "Trailing garbage \"%.*s%s\" after submodule, expected end-of-input."
 
 #define LY_VCODE_INVAL_MINMAX   LYVE_SEMANTICS, "Invalid combination of min-elements and max-elements: min value %u is bigger than the max value %u."
-#define LY_VCODE_CIRC_WHEN      LYVE_SEMANTICS, "When condition of \"%s\" includes a self-reference (referenced by when of \"%s\")."
-#define LY_VCODE_DUMMY_WHEN     LYVE_SEMANTICS, "When condition of \"%s\" is accessing its own conditional node."
 #define LY_VCODE_NAME_COL       LYVE_SEMANTICS, "Name collision between %s of name \"%s\"."
 #define LY_VCODE_NAME2_COL      LYVE_SEMANTICS, "Name collision between %s and %s of name \"%s\"."
 

--- a/src/in.c
+++ b/src/in.c
@@ -349,12 +349,6 @@ ly_in_read(struct ly_in *in, void *buf, size_t count)
         return LY_EDENIED;
     }
 
-    for (size_t i = 0; i < count; i++) {
-        if (in->current[i] == '\n') {
-            LY_IN_NEW_LINE(in);
-        }
-    }
-
     memcpy(buf, in->current, count);
     in->current += count;
     return LY_SUCCESS;
@@ -372,12 +366,6 @@ ly_in_skip(struct ly_in *in, size_t count)
     if (in->length && (in->length - (in->current - in->start) < count)) {
         /* EOF */
         return LY_EDENIED;
-    }
-
-    for (size_t i = 0; i < count; i++) {
-        if (in->current[i] == '\n') {
-            LY_IN_NEW_LINE(in);
-        }
     }
 
     in->current += count;

--- a/src/in_internal.h
+++ b/src/in_internal.h
@@ -35,7 +35,15 @@ struct ly_in {
             char *filepath; /**< stored original filepath */
         } fpath;            /**< filepath structure for LY_IN_FILEPATH */
     } method;               /**< type-specific information about the output */
+    uint64_t line;          /**< current line of the input */
 };
+
+/**
+ * @brief Increment line counter.
+ * @param[in] IN The input handler.
+ */
+#define LY_IN_NEW_LINE(IN) \
+    (IN)->line++
 
 /**
  * @brief Read bytes from an input.

--- a/src/in_internal.h
+++ b/src/in_internal.h
@@ -48,6 +48,9 @@ struct ly_in {
 /**
  * @brief Read bytes from an input.
  *
+ * Does not count new lines, which is expected from the caller who has better idea about
+ * the content of the read data and can better optimize counting.
+ *
  * @param[in] in Input structure.
  * @param[in] buf Destination buffer.
  * @param[in] count Number of bytes to read.
@@ -58,6 +61,9 @@ LY_ERR ly_in_read(struct ly_in *in, void *buf, size_t count);
 
 /**
  * @brief Just skip bytes in an input.
+ *
+ * Does not count new lines, which is expected from the caller who has better idea about
+ * the content of the skipped data and can better optimize counting.
  *
  * @param[in] in Input structure.
  * @param[in] count Number of bytes to skip.

--- a/src/json.c
+++ b/src/json.c
@@ -71,6 +71,9 @@ skip_ws(struct lyjson_ctx *jsonctx)
 {
     /* skip leading whitespaces */
     while (*jsonctx->in->current != '\0' && is_jsonws(*jsonctx->in->current)) {
+        if (*jsonctx->in->current == '\n') {
+            LY_IN_NEW_LINE(jsonctx->in);
+        }
         ly_in_skip(jsonctx->in, 1);
     }
     if (*jsonctx->in->current == '\0') {

--- a/src/json.h
+++ b/src/json.h
@@ -52,7 +52,6 @@ enum LYJSON_PARSER_STATUS {
 
 struct lyjson_ctx {
     const struct ly_ctx *ctx;
-    uint64_t line;          /* current line */
     struct ly_in *in;       /* input structure */
 
     struct ly_set status;   /* stack of LYJSON_PARSER_STATUS values corresponding to the JSON items being processed */

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -25,7 +25,6 @@
 #include "in_internal.h"
 #include "json.h"
 #include "log.h"
-#include "parser_data.h"
 #include "parser_internal.h"
 #include "set.h"
 #include "tree.h"
@@ -1300,7 +1299,7 @@ lyd_parse_json_init(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_o
 {
     LY_ERR ret = LY_SUCCESS;
     struct lyd_json_ctx *lydctx;
-    size_t i, line = 1;
+    size_t i;
 
     assert(lydctx_p);
     assert(status);
@@ -1316,7 +1315,7 @@ lyd_parse_json_init(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_o
     for (i = 0; in->current[i] != '\0' && is_jsonws(in->current[i]); i++) {
         if (in->current[i] == '\n') {
             /* new line */
-            line++;
+            LY_IN_NEW_LINE(in);
         }
     }
 
@@ -1327,7 +1326,7 @@ lyd_parse_json_init(const struct ly_ctx *ctx, struct ly_in *in, uint32_t parse_o
         return LY_SUCCESS;
     } else {
         /* expecting top-level object */
-        LOGVAL(ctx, LY_VLOG_LINE, &line, LYVE_SYNTAX_JSON, "Expected top-level JSON object, but %s found.",
+        LOGVAL(ctx, LY_VLOG_LINE, &in->line, LYVE_SYNTAX_JSON, "Expected top-level JSON object, but %s found.",
                 lyjson_token2str(*status));
         *lydctx_p = NULL;
         lyd_json_ctx_free((struct lyd_ctx *)lydctx);
@@ -1503,7 +1502,7 @@ lyd_parse_json_notif(const struct ly_ctx *ctx, struct ly_in *in, struct lyd_node
         ret = LY_EVALID;
         goto cleanup;
     } else if (lydctx->jsonctx->in->current[0] && (lyjson_ctx_status(lydctx->jsonctx, 0) != LYJSON_OBJECT_CLOSED)) {
-        LOGVAL(ctx, LY_VLOG_LINE, &lydctx->jsonctx->line, LYVE_SYNTAX, "Unexpected sibling element of \"%s\".",
+        LOGVAL(ctx, LY_VLOG_LINE, &lydctx->jsonctx->in->line, LYVE_SYNTAX, "Unexpected sibling element of \"%s\".",
                 tree->schema->name);
         ret = LY_EVALID;
         goto cleanup;
@@ -1647,7 +1646,7 @@ parse_content:
         ret = LY_EVALID;
         goto cleanup;
     } else if (lydctx->jsonctx->in->current[0] && (lyjson_ctx_status(lydctx->jsonctx, 0) != LYJSON_OBJECT_CLOSED)) {
-        LOGVAL(ctx, LY_VLOG_LINE, &lydctx->jsonctx->line, LYVE_SYNTAX, "Unexpected sibling element of \"%s\".",
+        LOGVAL(ctx, LY_VLOG_LINE, &lydctx->jsonctx->in->line, LYVE_SYNTAX, "Unexpected sibling element of \"%s\".",
                 tree->schema->name);
         ret = LY_EVALID;
         goto cleanup;

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -803,9 +803,8 @@ next_entry:
     ret = lyjson_ctx_next(lydctx->jsonctx, NULL);
     LY_CHECK_GOTO(ret, cleanup);
 
-cleanup:
-    LOG_LOCBACK(ctx, 1, 0, 0, 0);
-    return ret;
+    /* success */
+    goto cleanup;
 
 representation_error:
     LOGVAL(ctx, LYVE_SYNTAX_JSON,
@@ -814,7 +813,10 @@ representation_error:
             expected, lyjson_token2str(status), in_parent ? "" : "name");
 
     ret = LY_EVALID;
-    goto cleanup;
+
+cleanup:
+    LOG_LOCBACK(ctx, 1, 0, 0, 0);
+    return ret;
 }
 
 /**
@@ -1290,9 +1292,8 @@ lydjson_subtree_r(struct lyd_json_ctx *lydctx, struct lyd_node_inner *parent, st
     /* finally connect the parsed node */
     lydjson_maintain_children(parent, first_p, &node);
 
-cleanup:
-    lyd_free_tree(node);
-    return ret;
+    /* success */
+    goto cleanup;
 
 representation_error:
     LOG_LOCSET(ctx, NULL, (const struct lyd_node *)parent, NULL, NULL);
@@ -1300,7 +1301,10 @@ representation_error:
             lys_nodetype2str(snode->nodetype), snode->name, expected, lyjson_token2str(status));
     LOG_LOCBACK(ctx, 0, parent ? 1 : 0, 0, 0);
     ret = LY_EVALID;
-    goto cleanup;
+
+cleanup:
+    lyd_free_tree(node);
+    return ret;
 }
 
 /**

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -652,10 +652,10 @@ lyb_parse_schema_hash(struct lyd_lyb_ctx *lybctx, const struct lysc_node *sparen
 
     if (!sibling && (lybctx->parse_options & LYD_PARSE_STRICT)) {
         if (mod) {
-            LOGVAL(lybctx->lybctx->ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Failed to find matching hash for a top-level node"
+            LOGVAL(lybctx->lybctx->ctx, LYVE_REFERENCE, "Failed to find matching hash for a top-level node"
                     " from \"%s\".", mod->name);
         } else {
-            LOGVAL(lybctx->lybctx->ctx, LY_VLOG_LYSC, sparent, LYVE_REFERENCE, "Failed to find matching hash for a child node"
+            LOGVAL(lybctx->lybctx->ctx, LYVE_REFERENCE, "Failed to find matching hash for a child node"
                     " of \"%s\".", sparent->name);
         }
         return LY_EVALID;
@@ -1050,7 +1050,7 @@ lyd_parse_lyb_(const struct ly_ctx *ctx, struct lyd_node_inner **parent, struct 
     if (data_type == (LYD_INTOPT_RPC | LYD_INTOPT_REPLY)) {
         /* make sure we have parsed some operation */
         if (!lybctx->op_node) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_DATA, "Missing the \"rpc\"/\"action\" node.");
+            LOGVAL(ctx, LYVE_DATA, "Missing the \"rpc\"/\"action\" node.");
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -1063,7 +1063,7 @@ lyd_parse_lyb_(const struct ly_ctx *ctx, struct lyd_node_inner **parent, struct 
     } else if (data_type == LYD_INTOPT_NOTIF) {
         /* make sure we have parsed some notification */
         if (!lybctx->op_node) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_DATA, "Missing the \"notification\" node.");
+            LOGVAL(ctx, LYVE_DATA, "Missing the \"notification\" node.");
             ret = LY_EVALID;
             goto cleanup;
         }

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -22,6 +22,7 @@
 #include "common.h"
 #include "dict.h"
 #include "in.h"
+#include "in_internal.h"
 #include "log.h"
 #include "parser_schema.h"
 #include "path.h"
@@ -126,7 +127,7 @@ lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, L
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -170,7 +171,7 @@ lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -213,7 +214,7 @@ lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -265,7 +266,7 @@ lysp_stmt_status(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint1
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -302,7 +303,7 @@ lysp_stmt_restr(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum l
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -416,7 +417,7 @@ lysp_stmt_type_enum_value_pos(struct lys_parser_ctx *ctx, const struct lysp_stmt
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -464,7 +465,7 @@ lysp_stmt_type_enum(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, en
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -548,7 +549,7 @@ lysp_stmt_type_fracdigits(struct lys_parser_ctx *ctx, const struct lysp_stmt *st
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -599,7 +600,7 @@ lysp_stmt_type_reqinstance(struct lys_parser_ctx *ctx, const struct lysp_stmt *s
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -656,7 +657,7 @@ lysp_stmt_type_pattern_modifier(struct lys_parser_ctx *ctx, const struct lysp_st
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -704,7 +705,7 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {
@@ -762,7 +763,7 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
     for (child = stmt->child; child; child = child->next) {
         struct ly_in *in;
         LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(NULL, in);
+        enum ly_stmt kw = lysp_match_kw(in, NULL);
         ly_in_free(in, 0);
 
         switch (kw) {

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -845,8 +845,8 @@ lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt
 
     pctx.format = LYS_IN_YANG;
     pctx.parsed_mod = ctx->pmod;
-    pctx.pos_type = LY_VLOG_STR;
-    pctx.path = ctx->path;
+
+    LOG_LOCSET(ctx->ctx, NULL, NULL, ctx->path, NULL);
 
     switch (kw) {
     case LY_STMT_STATUS:
@@ -865,5 +865,6 @@ lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt
         return LY_EINT;
     }
 
+    LOG_LOCBACK(ctx->ctx, 0, 0, 1, 0);
     return ret;
 }

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -4477,7 +4477,6 @@ yang_parse_submodule(struct lys_yang_parser_ctx **context, struct ly_ctx *ly_ctx
     LY_CHECK_ERR_RET(!(*context), LOGMEM(ly_ctx), LY_EMEM);
     (*context)->format = LYS_IN_YANG;
     (*context)->unres = main_ctx->unres;
-    (*context)->pos_type = LY_VLOG_LINE;
     (*context)->in = in;
 
     mod_p = calloc(1, sizeof *mod_p);
@@ -4485,6 +4484,8 @@ yang_parse_submodule(struct lys_yang_parser_ctx **context, struct ly_ctx *ly_ctx
     mod_p->mod = main_ctx->parsed_mod->mod;
     mod_p->parsing = 1;
     (*context)->parsed_mod = (struct lysp_module *)mod_p;
+
+    LOG_LOCINIT(PARSER_CTX(*context), NULL, NULL, NULL, in);
 
     /* map the typedefs and groupings list from main context to the submodule's context */
     memcpy(&(*context)->tpdfs_nodes, &main_ctx->tpdfs_nodes, sizeof main_ctx->tpdfs_nodes);
@@ -4525,6 +4526,7 @@ yang_parse_submodule(struct lys_yang_parser_ctx **context, struct ly_ctx *ly_ctx
     *submod = mod_p;
 
 cleanup:
+    LOG_LOCBACK(PARSER_CTX(*context), 0, 0, 0, 1);
     if (ret) {
         lysp_module_free((struct lysp_module *)mod_p);
         yang_parser_ctx_free(*context);
@@ -4548,7 +4550,6 @@ yang_parse_module(struct lys_yang_parser_ctx **context, struct ly_in *in, struct
     LY_CHECK_ERR_RET(!(*context), LOGMEM(mod->ctx), LY_EMEM);
     (*context)->format = LYS_IN_YANG;
     (*context)->unres = unres;
-    (*context)->pos_type = LY_VLOG_LINE;
     (*context)->in = in;
 
     mod_p = calloc(1, sizeof *mod_p);
@@ -4556,6 +4557,8 @@ yang_parse_module(struct lys_yang_parser_ctx **context, struct ly_in *in, struct
     mod_p->mod = mod;
     mod_p->parsing = 1;
     (*context)->parsed_mod = mod_p;
+
+    LOG_LOCINIT(PARSER_CTX(*context), NULL, NULL, NULL, in);
 
     /* skip redundant but valid characters at the beginning */
     ret = skip_redundant_chars(*context);
@@ -4592,6 +4595,7 @@ yang_parse_module(struct lys_yang_parser_ctx **context, struct ly_in *in, struct
     mod->parsed = mod_p;
 
 cleanup:
+    LOG_LOCBACK(PARSER_CTX(*context), 0, 0, 0, 1);
     if (ret) {
         lysp_module_free(mod_p);
         yang_parser_ctx_free(*context);

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -1076,7 +1076,7 @@ parse_include(struct lys_yang_parser_ctx *ctx, const char *module_name, struct l
     /* submodules share the namespace with the module names, so there must not be
      * a module of the same name in the context, no need for revision matching */
     if (!strcmp(module_name, inc->name) || ly_ctx_get_module_latest(PARSER_CTX(ctx), inc->name)) {
-        LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Name collision between module and submodule of name \"%s\".", inc->name);
+        LOGVAL_PARSER(ctx, LY_VCODE_NAME2_COL, "module", "submodule", inc->name);
         return LY_EVALID;
     }
 
@@ -4219,7 +4219,7 @@ checks:
      * a submodule of the same name in the context, no need for revision matching */
     dup = ly_ctx_get_submodule(PARSER_CTX(ctx), NULL, mod->mod->name, NULL);
     if (dup) {
-        LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Name collision between module and submodule of name \"%s\".", mod->mod->name);
+        LOGVAL_PARSER(ctx, LY_VCODE_NAME2_COL, "module", "submodule", mod->mod->name);
         return LY_EVALID;
     }
 
@@ -4424,7 +4424,7 @@ checks:
     dup = ly_ctx_get_submodule(PARSER_CTX(ctx), NULL, submod->name, NULL);
     /* main modules may have different revisions */
     if (dup && strcmp(dup->mod->name, submod->mod->name)) {
-        LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Name collision between submodules of name \"%s\".", dup->name);
+        LOGVAL_PARSER(ctx, LY_VCODE_NAME_COL, "submodules", dup->name);
         return LY_EVALID;
     }
 

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -1747,7 +1747,7 @@ yin_parse_include(struct lys_yin_parser_ctx *ctx, struct include_meta *inc_meta)
     /* submodules share the namespace with the module names, so there must not be
      * a module of the same name in the context, no need for revision matching */
     if (!strcmp(inc_meta->name, inc->name) || ly_ctx_get_module_latest(ctx->xmlctx->ctx, inc->name)) {
-        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_NAME_COL, inc->name);
+        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_NAME2_COL, "module", "submodule", inc->name);
         return LY_EVALID;
     }
 
@@ -3700,7 +3700,7 @@ yin_parse_mod(struct lys_yin_parser_ctx *ctx, struct lysp_module *mod)
      * a submodule of the same name in the context, no need for revision matching */
     dup = ly_ctx_get_submodule(ctx->xmlctx->ctx, NULL, mod->mod->name, NULL);
     if (dup) {
-        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LYVE_SYNTAX_YANG, "Name collision between module and submodule of name \"%s\".", mod->mod->name);
+        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_NAME2_COL, "module", "submodule", mod->mod->name);
         return LY_EVALID;
     }
 
@@ -3768,7 +3768,7 @@ yin_parse_submod(struct lys_yin_parser_ctx *ctx, struct lysp_submodule *submod)
      * a submodule of the same name in the context, no need for revision matching */
     dup = ly_ctx_get_submodule(ctx->xmlctx->ctx, NULL, submod->name, NULL);
     if (dup && strcmp(dup->mod->name, submod->mod->name)) {
-        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LYVE_SYNTAX_YANG, "Name collision between submodules of name \"%s\".", dup->name);
+        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_NAME_COL, "submodules", dup->name);
         return LY_EVALID;
     }
 

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -189,7 +189,7 @@ yin_match_keyword(struct lys_yin_parser_ctx *ctx, const char *name, size_t name_
 
     LY_CHECK_RET(ly_in_new_memory(name, &in), LY_STMT_NONE);
     start = in->current;
-    kw = lysp_match_kw(NULL, in);
+    kw = lysp_match_kw(in, NULL);
     name = in->current;
     ly_in_free(in, 0);
 
@@ -3818,9 +3818,6 @@ yin_parse_submodule(struct lys_yin_parser_ctx **yin_ctx, struct ly_ctx *ctx, str
 
     /* skip possible trailing whitespaces at end of the input */
     while (isspace(in->current[0])) {
-        if (in->current[0] == '\n') {
-            (*yin_ctx)->xmlctx->line++;
-        }
         ly_in_skip(in, 1);
     }
     if (in->current[0]) {
@@ -3881,9 +3878,6 @@ yin_parse_module(struct lys_yin_parser_ctx **yin_ctx, struct ly_in *in, struct l
 
     /* skip possible trailing whitespaces at end of the input */
     while (isspace(in->current[0])) {
-        if (in->current[0] == '\n') {
-            (*yin_ctx)->xmlctx->line++;
-        }
         ly_in_skip(in, 1);
     }
     if (in->current[0]) {

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -3818,6 +3818,9 @@ yin_parse_submodule(struct lys_yin_parser_ctx **yin_ctx, struct ly_ctx *ctx, str
 
     /* skip possible trailing whitespaces at end of the input */
     while (isspace(in->current[0])) {
+        if (in->current[0] == '\n') {
+            LY_IN_NEW_LINE(in);
+        }
         ly_in_skip(in, 1);
     }
     if (in->current[0]) {
@@ -3878,6 +3881,9 @@ yin_parse_module(struct lys_yin_parser_ctx **yin_ctx, struct ly_in *in, struct l
 
     /* skip possible trailing whitespaces at end of the input */
     while (isspace(in->current[0])) {
+        if (in->current[0] == '\n') {
+            LY_IN_NEW_LINE(in);
+        }
         ly_in_skip(in, 1);
     }
     if (in->current[0]) {

--- a/src/schema_compile_amend.c
+++ b/src/schema_compile_amend.c
@@ -51,7 +51,7 @@ lys_nodeid_check(struct lysc_ctx *ctx, const char *nodeid, ly_bool abs, struct l
     /* parse */
     ret = lyxp_expr_parse(ctx->ctx, nodeid, strlen(nodeid), 0, &e);
     if (ret) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Invalid %s value \"%s\" - invalid syntax.",
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid %s value \"%s\" - invalid syntax.",
                 nodeid_type, nodeid);
         ret = LY_EVALID;
         goto cleanup;
@@ -63,7 +63,7 @@ lys_nodeid_check(struct lysc_ctx *ctx, const char *nodeid, ly_bool abs, struct l
     } else {
         /* descendant schema nodeid */
         if (e->tokens[0] != LYXP_TOKEN_NAMETEST) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid %s value \"%s\" - name test expected instead of \"%.*s\".",
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid %s value \"%s\" - name test expected instead of \"%.*s\".",
                     nodeid_type, nodeid, e->tok_len[0], e->expr + e->tok_pos[0]);
             ret = LY_EVALID;
             goto cleanup;
@@ -74,17 +74,17 @@ lys_nodeid_check(struct lysc_ctx *ctx, const char *nodeid, ly_bool abs, struct l
     /* check all the tokens */
     for ( ; i < e->used; i += 2) {
         if (e->tokens[i] != LYXP_TOKEN_OPER_PATH) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid %s value \"%s\" - \"/\" expected instead of \"%.*s\".",
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid %s value \"%s\" - \"/\" expected instead of \"%.*s\".",
                     nodeid_type, nodeid, e->tok_len[i], e->expr + e->tok_pos[i]);
             ret = LY_EVALID;
             goto cleanup;
         } else if (e->used == i + 1) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid %s value \"%s\" - unexpected end of expression.", nodeid_type, e->expr);
             ret = LY_EVALID;
             goto cleanup;
         } else if (e->tokens[i + 1] != LYXP_TOKEN_NAMETEST) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid %s value \"%s\" - name test expected instead of \"%.*s\".",
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid %s value \"%s\" - name test expected instead of \"%.*s\".",
                     nodeid_type, nodeid, e->tok_len[i + 1], e->expr + e->tok_pos[i + 1]);
             ret = LY_EVALID;
             goto cleanup;
@@ -652,14 +652,14 @@ cleanup:
 }
 
 #define AMEND_WRONG_NODETYPE(AMEND_STR, OP_STR, PROPERTY) \
-    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid %s of %s node - it is not possible to %s \"%s\" property.", \
+    LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid %s of %s node - it is not possible to %s \"%s\" property.", \
             AMEND_STR, lys_nodetype2str(target->nodetype), OP_STR, PROPERTY);\
     ret = LY_EVALID; \
     goto cleanup;
 
 #define AMEND_CHECK_CARDINALITY(ARRAY, MAX, AMEND_STR, PROPERTY) \
     if (LY_ARRAY_COUNT(ARRAY) > MAX) { \
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Invalid %s of %s with too many (%"LY_PRI_ARRAY_COUNT_TYPE") %s properties.", \
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Invalid %s of %s with too many (%"LY_PRI_ARRAY_COUNT_TYPE") %s properties.", \
                AMEND_STR, lys_nodetype2str(target->nodetype), LY_ARRAY_COUNT(ARRAY), PROPERTY); \
         ret = LY_EVALID; \
         goto cleanup; \
@@ -693,7 +693,7 @@ lys_apply_refine(struct lysc_ctx *ctx, struct lysp_refine *rfn, struct lysp_node
             break;
         case LYS_LEAFLIST:
             if (rfn->dflts[0].mod->version < LYS_VERSION_1_1) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "Invalid refine of default in leaf-list - the default statement is allowed only in YANG 1.1 modules.");
                 ret = LY_EVALID;
                 goto cleanup;
@@ -870,8 +870,7 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysp_deviate_add *d, struct l
 
 #define DEV_CHECK_NONPRESENCE(TYPE, MEMBER, PROPERTY, VALUEMEMBER) \
     if (((TYPE)target)->MEMBER) { \
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, \
-                "Invalid deviation adding \"%s\" property which already exists (with value \"%s\").", \
+        LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid deviation adding \"%s\" property which already exists (with value \"%s\").", \
                 PROPERTY, ((TYPE)target)->VALUEMEMBER); \
         ret = LY_EVALID; \
         goto cleanup; \
@@ -976,7 +975,7 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysp_deviate_add *d, struct l
         }
 
         if (target->flags & LYS_CONFIG_MASK) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid deviation adding \"config\" property which already exists (with value \"config %s\").",
                     target->flags & LYS_CONFIG_W ? "true" : "false");
             ret = LY_EVALID;
@@ -999,7 +998,7 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysp_deviate_add *d, struct l
         }
 
         if (target->flags & LYS_MAND_MASK) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid deviation adding \"mandatory\" property which already exists (with value \"mandatory %s\").",
                     target->flags & LYS_MAND_TRUE ? "true" : "false");
             ret = LY_EVALID;
@@ -1023,7 +1022,7 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysp_deviate_add *d, struct l
         }
 
         if (target->flags & LYS_SET_MIN) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid deviation adding \"min-elements\" property which already exists (with value \"%u\").", *num);
             ret = LY_EVALID;
             goto cleanup;
@@ -1047,11 +1046,11 @@ lys_apply_deviate_add(struct lysc_ctx *ctx, struct lysp_deviate_add *d, struct l
 
         if (target->flags & LYS_SET_MAX) {
             if (*num) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid deviation adding \"max-elements\" property which already exists (with value \"%u\").",
                         *num);
             } else {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid deviation adding \"max-elements\" property which already exists (with value \"unbounded\").");
             }
             ret = LY_EVALID;
@@ -1091,7 +1090,7 @@ lys_apply_deviate_delete(struct lysc_ctx *ctx, struct lysp_deviate_del *d, struc
             } \
         } \
         if (!found) { \
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, \
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, \
                     "Invalid deviation deleting \"%s\" property \"%s\" which does not match any of the target's property values.", \
                     PROPERTY, d->DEV_ARRAY[u]DEV_MEMBER); \
             ret = LY_EVALID; \
@@ -1108,11 +1107,11 @@ lys_apply_deviate_delete(struct lysc_ctx *ctx, struct lysp_deviate_del *d, struc
 
 #define DEV_CHECK_PRESENCE_VALUE(TYPE, MEMBER, DEVTYPE, PROPERTY, VALUE) \
     if (!((TYPE)target)->MEMBER) { \
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DEV_NOT_PRESENT, DEVTYPE, PROPERTY, VALUE); \
+        LOGVAL(ctx->ctx, LY_VCODE_DEV_NOT_PRESENT, DEVTYPE, PROPERTY, VALUE); \
         ret = LY_EVALID; \
         goto cleanup; \
     } else if (strcmp(((TYPE)target)->MEMBER, VALUE)) { \
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, \
+        LOGVAL(ctx->ctx, LYVE_REFERENCE, \
                 "Invalid deviation deleting \"%s\" property \"%s\" which does not match the target's property value \"%s\".", \
                 PROPERTY, VALUE, ((TYPE)target)->MEMBER); \
         ret = LY_EVALID; \
@@ -1218,7 +1217,7 @@ lys_apply_deviate_replace(struct lysc_ctx *ctx, struct lysp_deviate_rpl *d, stru
 
 #define DEV_CHECK_PRESENCE(TYPE, MEMBER, DEVTYPE, PROPERTY, VALUE) \
     if (!((TYPE)target)->MEMBER) { \
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DEV_NOT_PRESENT, DEVTYPE, PROPERTY, VALUE); \
+        LOGVAL(ctx->ctx, LY_VCODE_DEV_NOT_PRESENT, DEVTYPE, PROPERTY, VALUE); \
         ret = LY_EVALID; \
         goto cleanup; \
     }
@@ -1288,8 +1287,8 @@ lys_apply_deviate_replace(struct lysc_ctx *ctx, struct lysp_deviate_rpl *d, stru
         }
 
         if (!(target->flags & LYS_CONFIG_MASK)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DEV_NOT_PRESENT,
-                    "replacing", "config", d->flags & LYS_CONFIG_W ? "config true" : "config false");
+            LOGVAL(ctx->ctx, LY_VCODE_DEV_NOT_PRESENT, "replacing", "config",
+                    d->flags & LYS_CONFIG_W ? "config true" : "config false");
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -1311,8 +1310,8 @@ lys_apply_deviate_replace(struct lysc_ctx *ctx, struct lysp_deviate_rpl *d, stru
         }
 
         if (!(target->flags & LYS_MAND_MASK)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DEV_NOT_PRESENT,
-                    "replacing", "mandatory", d->flags & LYS_MAND_TRUE ? "mandatory true" : "mandatory false");
+            LOGVAL(ctx->ctx, LY_VCODE_DEV_NOT_PRESENT, "replacing", "mandatory",
+                    d->flags & LYS_MAND_TRUE ? "mandatory true" : "mandatory false");
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -1335,8 +1334,7 @@ lys_apply_deviate_replace(struct lysc_ctx *ctx, struct lysp_deviate_rpl *d, stru
         }
 
         if (!(target->flags & LYS_SET_MIN)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
-                    "Invalid deviation replacing \"min-elements\" property which is not present.");
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid deviation replacing \"min-elements\" property which is not present.");
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -1358,8 +1356,7 @@ lys_apply_deviate_replace(struct lysc_ctx *ctx, struct lysp_deviate_rpl *d, stru
         }
 
         if (!(target->flags & LYS_SET_MAX)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
-                    "Invalid deviation replacing \"max-elements\" property which is not present.");
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid deviation replacing \"max-elements\" property which is not present.");
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -1393,7 +1390,7 @@ lys_schema_node_get_module(const struct ly_ctx *ctx, const char *nametest, size_
     if (ptr) {
         target_mod = ly_resolve_prefix(ctx, nametest, ptr - nametest, LY_PREF_SCHEMA, (void *)mod);
         if (!target_mod) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE,
+            LOGVAL(ctx, LYVE_REFERENCE,
                     "Invalid absolute-schema-nodeid nametest \"%.*s\" - prefix \"%.*s\" not defined in module \"%s\".",
                     nametest_len, nametest, ptr - nametest, nametest, LYSP_MODULE_NAME(mod));
             return NULL;
@@ -1802,7 +1799,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, struct lys
     uint32_t i, opt_prev = ctx->options;
 
     if (!(target->nodetype & (LYS_CONTAINER | LYS_LIST | LYS_CHOICE | LYS_CASE | LYS_INPUT | LYS_OUTPUT | LYS_NOTIF))) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Augment's %s-schema-nodeid \"%s\" refers to a %s node which is not an allowed augment's target.",
                 aug_p->nodeid[0] == '/' ? "absolute" : "descendant", aug_p->nodeid, lys_nodetype2str(target->nodetype));
         ret = LY_EVALID;
@@ -1822,7 +1819,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, struct lys
         if (((pnode->nodetype == LYS_CASE) && (target->nodetype != LYS_CHOICE)) ||
                 ((pnode->nodetype & (LYS_RPC | LYS_ACTION | LYS_NOTIF)) && !(target->nodetype & (LYS_CONTAINER | LYS_LIST))) ||
                 ((pnode->nodetype == LYS_USES) && (target->nodetype == LYS_CHOICE))) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid augment of %s node which is not allowed to contain %s node \"%s\".",
                     lys_nodetype2str(target->nodetype), lys_nodetype2str(pnode->nodetype), pnode->name);
             ret = LY_EVALID;
@@ -1857,7 +1854,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, struct lys
             if (!allow_mandatory && (node->flags & LYS_CONFIG_W) && (node->flags & LYS_MAND_TRUE)) {
                 node->flags &= ~LYS_MAND_TRUE;
                 lys_compile_mandatory_parents(target, 0);
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "Invalid augment adding mandatory node \"%s\" without making it conditional via when statement.", node->name);
                 ret = LY_EVALID;
                 goto cleanup;
@@ -1899,7 +1896,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, struct lys
 
     if (aug_p->actions) {
         if (!actions) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid augment of %s node which is not allowed to contain RPC/action node \"%s\".",
                     lys_nodetype2str(target->nodetype), aug_p->actions[0].name);
             ret = LY_EVALID;
@@ -1920,7 +1917,7 @@ lys_compile_augment(struct lysc_ctx *ctx, struct lysp_augment *aug_p, struct lys
     }
     if (aug_p->notifs) {
         if (!notifs) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid augment of %s node which is not allowed to contain notification node \"%s\".",
                     lys_nodetype2str(target->nodetype), aug_p->notifs[0].name);
             ret = LY_EVALID;
@@ -2184,7 +2181,7 @@ lys_precompile_own_deviations(struct lysc_ctx *ctx)
             }
         }
         if (not_supported && (LY_ARRAY_COUNT(dev->devs) > 1)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                     "Multiple deviations of \"%s\" with one of them being \"not-supported\".", dev->nodeid->expr);
             return LY_EVALID;
         }

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2515,7 +2515,7 @@ lys_compile_node_leaflist(struct lysc_ctx *ctx, struct lysp_node *pnode, struct 
     /* checks */
     if ((llist->flags & LYS_SET_DFLT) && (llist->flags & LYS_MAND_TRUE)) {
         LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
-                "Invalid mandatory leaf-list with default value(s).");
+                "The default statement is present on leaf-list with a nonzero min-elements.");
         return LY_EVALID;
     }
 

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -376,7 +376,7 @@ range_part_check_value_syntax(struct lysc_ctx *ctx, LY_DATA_TYPE basetype, uint8
 decimal:
         assert(frdigits);
         if (fraction && (*len - 1 - fraction > frdigits)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+            LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                     "Range boundary \"%.*s\" of decimal64 type exceeds defined number (%u) of fraction digits.",
                     *len, value, frdigits);
             return LY_EINVAL;
@@ -578,15 +578,15 @@ range_part_minmax(struct lysc_ctx *ctx, struct lysc_range_part *part, ly_bool ma
 
 finalize:
     if (ret == LY_EDENIED) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                 "Invalid %s restriction - value \"%s\" does not fit the type limitations.",
                 length_restr ? "length" : "range", valcopy ? valcopy : *value);
     } else if (ret == LY_EVALID) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                 "Invalid %s restriction - invalid value \"%s\".",
                 length_restr ? "length" : "range", valcopy ? valcopy : *value);
     } else if (ret == LY_EEXIST) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                 "Invalid %s restriction - values are not in ascending order (%s).",
                 length_restr ? "length" : "range",
                 (valcopy && basetype != LY_TYPE_DEC64) ? valcopy : value ? *value : max ? "max" : "min");
@@ -628,12 +628,12 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
             ++expr;
         } else if (*expr == '\0') {
             if (range_expected) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s restriction - unexpected end of the expression after \"..\" (%s).",
                         length_restr ? "length" : "range", range_p->arg);
                 goto cleanup;
             } else if (!parts || (parts_done == LY_ARRAY_COUNT(parts))) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s restriction - unexpected end of the expression (%s).",
                         length_restr ? "length" : "range", range_p->arg);
                 goto cleanup;
@@ -643,7 +643,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
         } else if (!strncmp(expr, "min", ly_strlen_const("min"))) {
             if (parts) {
                 /* min cannot be used elsewhere than in the first part */
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s restriction - unexpected data before min keyword (%.*s).", length_restr ? "length" : "range",
                         expr - range_p->arg.str, range_p->arg.str);
                 goto cleanup;
@@ -655,7 +655,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
             part->max_64 = part->min_64;
         } else if (*expr == '|') {
             if (!parts || range_expected) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s restriction - unexpected beginning of the expression (%s).", length_restr ? "length" : "range", expr);
                 goto cleanup;
             }
@@ -668,7 +668,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
                 expr++;
             }
             if (!parts || (LY_ARRAY_COUNT(parts) == parts_done)) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s restriction - unexpected \"..\" without a lower bound.", length_restr ? "length" : "range");
                 goto cleanup;
             }
@@ -694,7 +694,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
                 expr++;
             }
             if (*expr != '\0') {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Invalid %s restriction - unexpected data after max keyword (%s).",
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid %s restriction - unexpected data after max keyword (%s).",
                         length_restr ? "length" : "range", expr);
                 goto cleanup;
             }
@@ -709,7 +709,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
                 part->min_64 = part->max_64;
             }
         } else {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Invalid %s restriction - unexpected data (%s).",
+            LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid %s restriction - unexpected data (%s).",
                     length_restr ? "length" : "range", expr);
             goto cleanup;
         }
@@ -797,7 +797,7 @@ lys_compile_type_range(struct lysc_ctx *ctx, struct lysp_restr *range_p, LY_DATA
         }
         if (u != parts_done) {
 baseerror:
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+            LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                     "Invalid %s restriction - the derived restriction (%s) is not equally or more limiting.",
                     length_restr ? "length" : "range", range_p->arg);
             goto cleanup;
@@ -838,7 +838,7 @@ cleanup:
 }
 
 LY_ERR
-lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *log_path, const char *pattern, pcre2_code **code)
+lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *pattern, pcre2_code **code)
 {
     size_t idx, idx2, start, end, size, brack;
     char *perl_regex, *ptr;
@@ -995,8 +995,7 @@ lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *log_path, const c
 
         ptr = strchr(ptr, '}');
         if (!ptr) {
-            LOGVAL(ctx, LY_VLOG_STR, log_path, LY_VCODE_INREGEXP,
-                    pattern, perl_regex + start + 2, "unterminated character property");
+            LOGVAL(ctx, LY_VCODE_INREGEXP, pattern, perl_regex + start + 2, "unterminated character property");
             free(perl_regex);
             return LY_EVALID;
         }
@@ -1016,8 +1015,7 @@ lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *log_path, const c
             }
         }
         if (!ublock2urange[idx][0]) {
-            LOGVAL(ctx, LY_VLOG_STR, log_path, LY_VCODE_INREGEXP,
-                    pattern, perl_regex + start + 5, "unknown block name");
+            LOGVAL(ctx, LY_VCODE_INREGEXP, pattern, perl_regex + start + 5, "unknown block name");
             free(perl_regex);
             return LY_EVALID;
         }
@@ -1048,7 +1046,7 @@ lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *log_path, const c
     if (!code_local) {
         PCRE2_UCHAR err_msg[LY_PCRE2_MSG_LIMIT] = {0};
         pcre2_get_error_message(err_code, err_msg, LY_PCRE2_MSG_LIMIT);
-        LOGVAL(ctx, LY_VLOG_STR, log_path, LY_VCODE_INREGEXP, pattern, perl_regex + err_offset, err_msg);
+        LOGVAL(ctx, LY_VCODE_INREGEXP, pattern, perl_regex + err_offset, err_msg);
         free(perl_regex);
         return LY_EVALID;
     }
@@ -1093,7 +1091,7 @@ lys_compile_type_patterns(struct lysc_ctx *ctx, struct lysp_restr *patterns_p,
         *pattern = calloc(1, sizeof **pattern);
         ++(*pattern)->refcount;
 
-        ret = lys_compile_type_pattern_check(ctx->ctx, ctx->path, &patterns_p[u].arg.str[1], &(*pattern)->code);
+        ret = lys_compile_type_pattern_check(ctx->ctx, &patterns_p[u].arg.str[1], &(*pattern)->code);
         LY_CHECK_RET(ret);
 
         if (patterns_p[u].arg.str[0] == LYSP_RESTR_PATTERN_NACK) {
@@ -1166,7 +1164,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
     ly_bool enabled;
 
     if (base_enums && (ctx->pmod->version < LYS_VERSION_1_1)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "%s type can be subtyped only in YANG 1.1 modules.",
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "%s type can be subtyped only in YANG 1.1 modules.",
                 basetype == LY_TYPE_ENUM ? "Enumeration" : "Bits");
         return LY_EVALID;
     }
@@ -1181,7 +1179,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
                 }
             }
             if (v == LY_ARRAY_COUNT(base_enums)) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                         "Invalid %s - derived type adds new item \"%s\".",
                         basetype == LY_TYPE_ENUM ? "enumeration" : "bits", enums_p[u].name);
                 return LY_EVALID;
@@ -1196,7 +1194,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
                 /* check collision with other values */
                 LY_ARRAY_FOR(*enums, v) {
                     if (cur_val == (*enums)[v].value) {
-                        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                                 "Invalid enumeration - value %d collide in items \"%s\" and \"%s\".",
                                 cur_val, enums_p[u].name, (*enums)[v].name);
                         return LY_EVALID;
@@ -1210,7 +1208,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
                 if (u == 0) {
                     cur_val = 0;
                 } else if (highest_value == INT32_MAX) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid enumeration - it is not possible to auto-assign enum value for "
                             "\"%s\" since the highest value is already 2147483647.", enums_p[u].name);
                     return LY_EVALID;
@@ -1230,7 +1228,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
                 /* check collision with other values */
                 LY_ARRAY_FOR(*enums, v) {
                     if (cur_pos == (*enums)[v].position) {
-                        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                                 "Invalid bits - position %u collide in items \"%s\" and \"%s\".",
                                 cur_pos, enums_p[u].name, (*enums)[v].name);
                         return LY_EVALID;
@@ -1245,7 +1243,7 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
                     cur_pos = 0;
                 } else if (highest_position == UINT32_MAX) {
                     /* counter overflow */
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid bits - it is not possible to auto-assign bit position for "
                             "\"%s\" since the highest value is already 4294967295.", enums_p[u].name);
                     return LY_EVALID;
@@ -1264,14 +1262,14 @@ lys_compile_type_enums(struct lysc_ctx *ctx, struct lysp_type_enum *enums_p, LY_
         if (base_enums) {
             if (basetype == LY_TYPE_ENUM) {
                 if (cur_val != base_enums[match].value) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid enumeration - value of the item \"%s\" has changed from %d to %d in the derived type.",
                             enums_p[u].name, base_enums[match].value, cur_val);
                     return LY_EVALID;
                 }
             } else {
                 if (cur_pos != base_enums[match].position) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid bits - position of the item \"%s\" has changed from %u to %u in the derived type.",
                             enums_p[u].name, base_enums[match].position, cur_pos);
                     return LY_EVALID;
@@ -1436,9 +1434,9 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (!base && !type_p->flags) {
             /* type derived from bits built-in type must contain at least one bit */
             if (tpdfname) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "bit", "bits type ", tpdfname);
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "bit", "bits type ", tpdfname);
             } else {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "bit", "bits type", "");
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "bit", "bits type", "");
             }
             return LY_EVALID;
         }
@@ -1450,9 +1448,9 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (!base) {
             if (!type_p->fraction_digits) {
                 if (tpdfname) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "fraction-digits", "decimal64 type ", tpdfname);
+                    LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "fraction-digits", "decimal64 type ", tpdfname);
                 } else {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "fraction-digits", "decimal64 type", "");
+                    LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "fraction-digits", "decimal64 type", "");
                 }
                 return LY_EVALID;
             }
@@ -1461,11 +1459,11 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
             if (type_p->fraction_digits) {
                 /* fraction digits is prohibited in types not directly derived from built-in decimal64 */
                 if (tpdfname) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid fraction-digits substatement for type \"%s\" not directly derived from decimal64 built-in type.",
                             tpdfname);
                 } else {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid fraction-digits substatement for type not directly derived from decimal64 built-in type.");
                 }
                 return LY_EVALID;
@@ -1516,9 +1514,9 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (!base && !type_p->flags) {
             /* type derived from enumerations built-in type must contain at least one enum */
             if (tpdfname) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "enum", "enumeration type ", tpdfname);
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "enum", "enumeration type ", tpdfname);
             } else {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "enum", "enumeration type", "");
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "enum", "enumeration type", "");
             }
             return LY_EVALID;
         }
@@ -1550,11 +1548,11 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
             if (base) {
                 /* only the directly derived identityrefs can contain base specification */
                 if (tpdfname) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid base substatement for the type \"%s\" not directly derived from identityref built-in type.",
                             tpdfname);
                 } else {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid base substatement for the type not directly derived from identityref built-in type.");
                 }
                 return LY_EVALID;
@@ -1565,9 +1563,9 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (!base && !type_p->flags) {
             /* type derived from identityref built-in type must contain at least one base */
             if (tpdfname) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "base", "identityref type ", tpdfname);
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "base", "identityref type ", tpdfname);
             } else {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "base", "identityref type", "");
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "base", "identityref type", "");
             }
             return LY_EVALID;
         }
@@ -1579,10 +1577,10 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (type_p->flags & LYS_SET_REQINST) {
             if (context_mod->version < LYS_VERSION_1_1) {
                 if (tpdfname) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                    LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                             "Leafref type \"%s\" can be restricted by require-instance statement only in YANG 1.1 modules.", tpdfname);
                 } else {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                    LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                             "Leafref type can be restricted by require-instance statement only in YANG 1.1 modules.");
                 }
                 return LY_EVALID;
@@ -1603,10 +1601,10 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
             LY_CHECK_RET(lyxp_expr_dup(ctx->ctx, ((struct lysc_type_leafref *)base)->path, &lref->path));
             LY_CHECK_RET(lysc_prefixes_dup(((struct lysc_type_leafref *)base)->prefixes, &lref->prefixes));
         } else if (tpdfname) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "path", "leafref type ", tpdfname);
+            LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "path", "leafref type ", tpdfname);
             return LY_EVALID;
         } else {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "path", "leafref type", "");
+            LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "path", "leafref type", "");
             return LY_EVALID;
         }
         lref->cur_mod = type_p->pmod->mod;
@@ -1628,11 +1626,11 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
             if (base) {
                 /* only the directly derived union can contain types specification */
                 if (tpdfname) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid type substatement for the type \"%s\" not directly derived from union built-in type.",
                             tpdfname);
                 } else {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG,
                             "Invalid type substatement for the type not directly derived from union built-in type.");
                 }
                 return LY_EVALID;
@@ -1645,9 +1643,9 @@ lys_compile_type_(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_
         if (!base && !type_p->flags) {
             /* type derived from union built-in type must contain at least one type */
             if (tpdfname) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "type", "union type ", tpdfname);
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "type", "union type ", tpdfname);
             } else {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_MISSCHILDSTMT, "type", "union type", "");
+                LOGVAL(ctx->ctx, LY_VCODE_MISSCHILDSTMT, "type", "union type", "");
             }
             return LY_EVALID;
         }
@@ -1790,7 +1788,7 @@ lys_compile_type(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_t
             /* local part */
             tctx_iter = (struct type_context *)tpdf_chain.objs[u];
             if ((tctx_iter->mod == tctx->mod) && (tctx_iter->node == tctx->node) && (tctx_iter->tpdf == tctx->tpdf)) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid \"%s\" type reference - circular chain of types detected.", tctx->tpdf->name);
                 free(tctx);
                 ret = LY_EVALID;
@@ -1801,7 +1799,7 @@ lys_compile_type(struct lysc_ctx *ctx, struct lysp_node *context_pnode, uint16_t
             /* global part for unions corner case */
             tctx_iter = (struct type_context *)ctx->tpdf_chain.objs[u];
             if ((tctx_iter->mod == tctx->mod) && (tctx_iter->node == tctx->node) && (tctx_iter->tpdf == tctx->tpdf)) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid \"%s\" type reference - circular chain of types detected.", tctx->tpdf->name);
                 free(tctx);
                 ret = LY_EVALID;
@@ -1865,14 +1863,14 @@ preparenext:
         *type = calloc(1, sizeof(struct lysc_type_num));
         break;
     case LY_TYPE_UNKNOWN:
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Referenced type \"%s\" not found.", tctx_prev ? tctx_prev->tpdf->type.name : type_p->name);
         ret = LY_EVALID;
         goto cleanup;
     }
     LY_CHECK_ERR_GOTO(!(*type), LOGMEM(ctx->ctx), cleanup);
     if (~type_substmt_map[basetype] & type_p->flags) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Invalid type restrictions for %s type.",
+        LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid type restrictions for %s type.",
                 ly_data_type2str[basetype]);
         free(*type);
         (*type) = NULL;
@@ -1900,12 +1898,12 @@ preparenext:
 
         ++(*type)->refcount;
         if (~type_substmt_map[basetype] & tctx->tpdf->type.flags) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SYNTAX_YANG, "Invalid type \"%s\" restriction(s) for %s type.",
+            LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid type \"%s\" restriction(s) for %s type.",
                     tctx->tpdf->name, ly_data_type2str[basetype]);
             ret = LY_EVALID;
             goto cleanup;
         } else if ((basetype == LY_TYPE_EMPTY) && tctx->tpdf->dflt.str) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                     "Invalid type \"%s\" - \"empty\" type must not have a default value (%s).",
                     tctx->tpdf->name, tctx->tpdf->dflt.str);
             ret = LY_EVALID;
@@ -1987,11 +1985,11 @@ lys_compile_status(struct lysc_ctx *ctx, uint16_t *node_flags, uint16_t parent_f
         /* check status compatibility with the parent */
         if ((parent_flags & LYS_STATUS_MASK) > ((*node_flags) & LYS_STATUS_MASK)) {
             if ((*node_flags) & LYS_STATUS_CURR) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "A \"current\" status is in conflict with the parent's \"%s\" status.",
                         (parent_flags & LYS_STATUS_DEPRC) ? "deprecated" : "obsolete");
             } else { /* LYS_STATUS_DEPRC */
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "A \"deprecated\" status is in conflict with the parent's \"obsolete\" status.");
             }
             return LY_EVALID;
@@ -2029,7 +2027,7 @@ lys_compile_node_uniqness(struct lysc_ctx *ctx, const struct lysc_node *parent, 
         assert(parent->nodetype == LYS_CHOICE);
         LY_LIST_FOR(lysc_node_children(parent, 0), iter) {
             if (CHECK_NODE(iter, exclude, name)) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DUPIDENT, name, "case");
+                LOGVAL(ctx->ctx, LY_VCODE_DUPIDENT, name, "case");
                 return LY_EEXIST;
             }
         }
@@ -2083,7 +2081,7 @@ lys_compile_node_uniqness(struct lysc_ctx *ctx, const struct lysc_node *parent, 
     return LY_SUCCESS;
 
 error:
-    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LY_VCODE_DUPIDENT, name, "data definition/RPC/action/notification");
+    LOGVAL(ctx->ctx, LY_VCODE_DUPIDENT, name, "data definition/RPC/action/notification");
     return LY_EEXIST;
 
 #undef CHECK_NODE
@@ -2119,7 +2117,7 @@ lys_compile_action(struct lysc_ctx *ctx, struct lysp_action *action_p, struct ly
     LY_CHECK_GOTO(ret = lys_compile_node_uniqness(ctx, parent, action_p->name, (struct lysc_node *)action), cleanup);
 
     if (ctx->options & (LYS_COMPILE_RPC_MASK | LYS_COMPILE_NOTIFICATION)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Action \"%s\" is placed inside %s.", action_p->name,
                 ctx->options & LYS_COMPILE_RPC_MASK ? "another RPC/action" : "notification");
         ret = LY_EVALID;
@@ -2256,7 +2254,7 @@ lys_compile_notif(struct lysc_ctx *ctx, struct lysp_notif *notif_p, struct lysc_
     LY_CHECK_GOTO(ret = lys_compile_node_uniqness(ctx, parent, notif_p->name, (struct lysc_node *)notif), cleanup);
 
     if (ctx->options & (LYS_COMPILE_RPC_MASK | LYS_COMPILE_NOTIFICATION)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Notification \"%s\" is placed inside %s.", notif_p->name,
                 ctx->options & LYS_COMPILE_RPC_MASK ? "RPC/action" : "another notification");
         ret = LY_EVALID;
@@ -2408,7 +2406,7 @@ lys_compile_node_type(struct lysc_ctx *ctx, struct lysp_node *context_node, stru
         }
     } else if (leaf->type->basetype == LY_TYPE_EMPTY) {
         if ((leaf->nodetype == LYS_LEAFLIST) && (ctx->pmod->version < LYS_VERSION_1_1)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                     "Leaf-list of type \"empty\" is allowed only in YANG 1.1 modules.");
             return LY_EVALID;
         }
@@ -2455,7 +2453,7 @@ lys_compile_node_leaf(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc
 
     /* checks */
     if ((leaf->flags & LYS_SET_DFLT) && (leaf->flags & LYS_MAND_TRUE)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Invalid mandatory leaf with a default value.");
         return LY_EVALID;
     }
@@ -2497,7 +2495,7 @@ lys_compile_node_leaflist(struct lysc_ctx *ctx, struct lysp_node *pnode, struct 
     /* store/update default values */
     if (llist_p->dflts) {
         if (ctx->pmod->version < LYS_VERSION_1_1) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                     "Leaf-list default values are allowed only in YANG 1.1 modules.");
             return LY_EVALID;
         }
@@ -2514,13 +2512,12 @@ lys_compile_node_leaflist(struct lysc_ctx *ctx, struct lysp_node *pnode, struct 
 
     /* checks */
     if ((llist->flags & LYS_SET_DFLT) && (llist->flags & LYS_MAND_TRUE)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
-                "The default statement is present on leaf-list with a nonzero min-elements.");
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "The default statement is present on leaf-list with a nonzero min-elements.");
         return LY_EVALID;
     }
 
     if (llist->min > llist->max) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Leaf-list min-elements %u is bigger than max-elements %u.",
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Leaf-list min-elements %u is bigger than max-elements %u.",
                 llist->min, llist->max);
         return LY_EVALID;
     }
@@ -2555,7 +2552,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
         nodeid_type = "descendant";
 
         if (*id == '/') {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid descendant-schema-nodeid value \"%.*s\" - absolute-schema-nodeid used.",
                     nodeid_len ? nodeid_len : strlen(nodeid), nodeid);
             return LY_EVALID;
@@ -2565,7 +2562,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
         nodeid_type = "absolute";
 
         if (*id != '/') {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid absolute-schema-nodeid value \"%.*s\" - missing starting \"/\".",
                     nodeid_len ? nodeid_len : strlen(nodeid), nodeid);
             return LY_EVALID;
@@ -2579,7 +2576,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
             if (!mod) {
                 /* module must always be found */
                 assert(prefix);
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid %s-schema-nodeid value \"%.*s\" - prefix \"%.*s\" not defined in module \"%s\".",
                         nodeid_type, id - nodeid, nodeid, prefix_len, prefix, LYSP_MODULE_NAME(ctx->pmod));
                 return LY_ENOTFOUND;
@@ -2607,7 +2604,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
         if (ctx_node && (ctx_node->nodetype & (LYS_RPC | LYS_ACTION))) {
             /* move through input/output manually */
             if (mod != ctx_node->module) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Invalid %s-schema-nodeid value \"%.*s\" - target node not found.", nodeid_type, id - nodeid, nodeid);
                 return LY_ENOTFOUND;
             }
@@ -2626,7 +2623,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
             getnext_extra_flag = 0;
         }
         if (!ctx_node) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid %s-schema-nodeid value \"%.*s\" - target node not found.", nodeid_type, id - nodeid, nodeid);
             return LY_ENOTFOUND;
         }
@@ -2644,7 +2641,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
             break;
         }
         if (*id != '/') {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid %s-schema-nodeid value \"%.*s\" - missing \"/\" as node-identifier separator.",
                     nodeid_type, id - nodeid + 1, nodeid);
             return LY_EVALID;
@@ -2658,7 +2655,7 @@ lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size_t node
             return LY_EDENIED;
         }
     } else {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Invalid %s-schema-nodeid value \"%.*s\" - unexpected end of expression.",
                 nodeid_type, nodeid_len ? nodeid_len : strlen(nodeid), nodeid);
     }
@@ -2706,13 +2703,13 @@ lys_compile_node_list_unique(struct lysc_ctx *ctx, struct lysp_qname *uniques, s
                     LY_PREF_SCHEMA, (void *)uniques[v].mod, LYS_LEAF, (const struct lysc_node **)key, &flags);
             if (ret != LY_SUCCESS) {
                 if (ret == LY_EDENIED) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                    LOGVAL(ctx->ctx, LYVE_REFERENCE,
                             "Unique's descendant-schema-nodeid \"%.*s\" refers to %s node instead of a leaf.",
                             len, keystr, lys_nodetype2str((*key)->nodetype));
                 }
                 return LY_EVALID;
             } else if (flags) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+                LOGVAL(ctx->ctx, LYVE_REFERENCE,
                         "Unique's descendant-schema-nodeid \"%.*s\" refers into %s node.",
                         len, keystr, flags & LYS_COMPILE_NOTIFICATION ? "notification" : "RPC/action");
                 return LY_EVALID;
@@ -2721,7 +2718,7 @@ lys_compile_node_list_unique(struct lysc_ctx *ctx, struct lysp_qname *uniques, s
             /* all referenced leafs must be of the same config type */
             if ((config != -1) && ((((*key)->flags & LYS_CONFIG_W) && (config == 0)) ||
                     (((*key)->flags & LYS_CONFIG_R) && (config == 1)))) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "Unique statement \"%s\" refers to leaves with different config type.", uniques[v].str);
                 return LY_EVALID;
             } else if ((*key)->flags & LYS_CONFIG_W) {
@@ -2733,7 +2730,7 @@ lys_compile_node_list_unique(struct lysc_ctx *ctx, struct lysp_qname *uniques, s
             /* we forbid referencing nested lists because it is unspecified what instance of such a list to use */
             for (parent = (*key)->parent; parent != (struct lysc_node *)list; parent = parent->parent) {
                 if (parent->nodetype == LYS_LIST) {
-                    LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                    LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                             "Unique statement \"%s\" refers to a leaf in nested list \"%s\".", uniques[v].str, parent->name);
                     return LY_EVALID;
                 }
@@ -2792,7 +2789,7 @@ lys_compile_node_list(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc
 
     /* keys */
     if ((list->flags & LYS_CONFIG_W) && (!list_p->key || !list_p->key[0])) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Missing key in list representing configuration data.");
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Missing key in list representing configuration data.");
         return LY_EVALID;
     }
 
@@ -2816,33 +2813,33 @@ lys_compile_node_list(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc
         /* key node must be present */
         key = (struct lysc_node_leaf *)lys_find_child(node, node->module, keystr, len, LYS_LEAF, LYS_GETNEXT_NOCHOICE);
         if (!key) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "The list's key \"%.*s\" not found.", len, keystr);
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "The list's key \"%.*s\" not found.", len, keystr);
             return LY_EVALID;
         }
         /* keys must be unique */
         if (key->flags & LYS_KEY) {
             /* the node was already marked as a key */
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Duplicated key identifier \"%.*s\".", len, keystr);
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Duplicated key identifier \"%.*s\".", len, keystr);
             return LY_EVALID;
         }
 
         lysc_update_path(ctx, (struct lysc_node *)list, key->name);
         /* key must have the same config flag as the list itself */
         if ((list->flags & LYS_CONFIG_MASK) != (key->flags & LYS_CONFIG_MASK)) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Key of the configuration list must not be status leaf.");
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Key of the configuration list must not be status leaf.");
             return LY_EVALID;
         }
         if (ctx->pmod->version < LYS_VERSION_1_1) {
             /* YANG 1.0 denies key to be of empty type */
             if (key->type->basetype == LY_TYPE_EMPTY) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "List's key cannot be of \"empty\" type until it is in YANG 1.1 module.");
                 return LY_EVALID;
             }
         } else {
             /* when and if-feature are illegal on list keys */
             if (key->when) {
-                LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+                LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                         "List's key must not have any \"when\" statement.");
                 return LY_EVALID;
             }
@@ -2916,7 +2913,7 @@ lys_compile_node_list(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc
 
     /* checks */
     if (list->min > list->max) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "List min-elements %u is bigger than max-elements %u.",
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "List min-elements %u is bigger than max-elements %u.",
                 list->min, list->max);
         return LY_EVALID;
     }
@@ -2955,7 +2952,7 @@ lys_compile_node_choice_dflt(struct lysc_ctx *ctx, struct lysp_qname *dflt, stru
     if (prefix) {
         mod = ly_resolve_prefix(ctx->ctx, prefix, prefix_len, LY_PREF_SCHEMA, (void *)dflt->mod);
         if (!mod) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Default case prefix \"%.*s\" not found "
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Default case prefix \"%.*s\" not found "
                     "in imports of \"%s\".", prefix_len, prefix, LYSP_MODULE_NAME(dflt->mod));
             return LY_EVALID;
         }
@@ -2965,7 +2962,7 @@ lys_compile_node_choice_dflt(struct lysc_ctx *ctx, struct lysp_qname *dflt, stru
 
     ch->dflt = (struct lysc_node_case *)lys_find_child(node, mod, name, 0, LYS_CASE, LYS_GETNEXT_WITHCASE);
     if (!ch->dflt) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Default case \"%s\" not found.", dflt->str);
         return LY_EVALID;
     }
@@ -2976,14 +2973,14 @@ lys_compile_node_choice_dflt(struct lysc_ctx *ctx, struct lysp_qname *dflt, stru
             break;
         }
         if (iter->flags & LYS_MAND_TRUE) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+            LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                     "Mandatory node \"%s\" under the default case \"%s\".", iter->name, dflt->str);
             return LY_EVALID;
         }
     }
 
     if (ch->flags & LYS_MAND_TRUE) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS, "Invalid mandatory choice with a default case.");
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Invalid mandatory choice with a default case.");
         return LY_EVALID;
     }
 
@@ -3310,7 +3307,7 @@ lys_compile_uses_find_grouping(struct lysc_ctx *ctx, struct lysp_node_uses *uses
         /* foreign module, find it first */
         mod = ly_resolve_prefix(ctx->ctx, prefix, prefix_len, LY_PREF_SCHEMA, ctx->pmod);
         if (!mod) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+            LOGVAL(ctx->ctx, LYVE_REFERENCE,
                     "Invalid prefix used for grouping reference.", uses_p->name);
             return LY_EVALID;
         }
@@ -3345,7 +3342,7 @@ lys_compile_uses_find_grouping(struct lysc_ctx *ctx, struct lysp_node_uses *uses
         }
     }
     if (!found) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Grouping \"%s\" referenced by a uses statement not found.", uses_p->name);
         return LY_EVALID;
     }
@@ -3394,7 +3391,7 @@ lys_compile_uses(struct lysc_ctx *ctx, struct lysp_node_uses *uses_p, struct lys
     LY_CHECK_RET(ly_set_add(&ctx->groupings, (void *)grp, 0, NULL));
     if (grp_stack_count == ctx->groupings.count) {
         /* the target grouping is already in the stack, so we are already inside it -> circular dependency */
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Grouping \"%s\" references itself through a uses statement.", grp->name);
         return LY_EVALID;
     }
@@ -3436,7 +3433,7 @@ lys_compile_uses(struct lysc_ctx *ctx, struct lysp_node_uses *uses_p, struct lys
     if (grp->actions) {
         actions = parent ? lysc_node_actions_p(parent) : &ctx->cur_mod->compiled->rpcs;
         if (!actions) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid child %s \"%s\" of uses parent %s \"%s\" node.",
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid child %s \"%s\" of uses parent %s \"%s\" node.",
                     grp->actions[0].name, lys_nodetype2str(grp->actions[0].nodetype), parent->name,
                     lys_nodetype2str(parent->nodetype));
             ret = LY_EVALID;
@@ -3458,7 +3455,7 @@ lys_compile_uses(struct lysc_ctx *ctx, struct lysp_node_uses *uses_p, struct lys
     if (grp->notifs) {
         notifs = parent ? lysc_node_notifs_p(parent) : &ctx->cur_mod->compiled->notifs;
         if (!notifs) {
-            LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE, "Invalid child %s \"%s\" of uses parent %s \"%s\" node.",
+            LOGVAL(ctx->ctx, LYVE_REFERENCE, "Invalid child %s \"%s\" of uses parent %s \"%s\" node.",
                     grp->notifs[0].name, lys_nodetype2str(grp->notifs[0].nodetype), parent->name,
                     lys_nodetype2str(parent->nodetype));
             ret = LY_EVALID;
@@ -3478,7 +3475,7 @@ lys_compile_uses(struct lysc_ctx *ctx, struct lysp_node_uses *uses_p, struct lys
 
     /* check that all augments were applied */
     for (i = 0; i < ctx->uses_augs.count; ++i) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Augment target node \"%s\" in grouping \"%s\" was not found.",
                 ((struct lysc_augment *)ctx->uses_augs.objs[i])->nodeid->expr, grp->name);
         ret = LY_ENOTFOUND;
@@ -3487,7 +3484,7 @@ lys_compile_uses(struct lysc_ctx *ctx, struct lysp_node_uses *uses_p, struct lys
 
     /* check that all refines were applied */
     for (i = 0; i < ctx->uses_rfns.count; ++i) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_REFERENCE,
+        LOGVAL(ctx->ctx, LYVE_REFERENCE,
                 "Refine(s) target node \"%s\" in grouping \"%s\" was not found.",
                 ((struct lysc_refine *)ctx->uses_rfns.objs[i])->nodeid->expr, grp->name);
         ret = LY_ENOTFOUND;
@@ -3652,7 +3649,7 @@ lys_compile_config(struct lysc_ctx *ctx, struct lysc_node *node, struct lysc_nod
     }
 
     if (parent && (parent->flags & LYS_CONFIG_R) && (node->flags & LYS_CONFIG_W)) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_SEMANTICS,
+        LOGVAL(ctx->ctx, LYVE_SEMANTICS,
                 "Configuration node cannot be child of any state data node.");
         return LY_EVALID;
     }
@@ -3802,7 +3799,7 @@ error:
 cleanup:
     ctx->options = prev_opts;
     if (ret && dev_pnode) {
-        LOGVAL(ctx->ctx, LY_VLOG_STR, ctx->path, LYVE_OTHER, "Compilation of a deviated and/or refined node failed.");
+        LOGVAL(ctx->ctx, LYVE_OTHER, "Compilation of a deviated and/or refined node failed.");
     }
     lysp_dev_node_free(ctx->ctx, dev_pnode);
     lysc_update_path(ctx, NULL, NULL);

--- a/src/schema_compile_node.h
+++ b/src/schema_compile_node.h
@@ -54,12 +54,11 @@ LY_ERR lys_compile_when(struct lysc_ctx *ctx, struct lysp_when *when_p, uint16_t
  * @brief Checks pattern syntax.
  *
  * @param[in] ctx Context.
- * @param[in] log_path Path for logging errors.
  * @param[in] pattern Pattern to check.
  * @param[in,out] pcre2_code Compiled PCRE2 pattern. If NULL, the compiled information used to validate pattern are freed.
  * @return LY_ERR value - LY_SUCCESS, LY_EMEM, LY_EVALID.
  */
-LY_ERR lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *log_path, const char *pattern, pcre2_code **code);
+LY_ERR lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *pattern, pcre2_code **code);
 
 /**
  * @brief Compile information about the leaf/leaf-list's type.

--- a/src/schema_features.c
+++ b/src/schema_features.c
@@ -299,8 +299,7 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
             uint64_t spaces;
             for (spaces = 0; c[i + op_len + spaces] && isspace(c[i + op_len + spaces]); spaces++) {}
             if (c[i + op_len + spaces] == '\0') {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
-                        "Invalid value \"%s\" of if-feature - unexpected end of expression.", qname->str);
+                LOGVAL(ctx, LYVE_SYNTAX_YANG, "Invalid value \"%s\" of if-feature - unexpected end of expression.", qname->str);
                 return LY_EVALID;
             } else if (!isspace(c[i + op_len])) {
                 /* feature name starting with the not/and/or */
@@ -316,7 +315,7 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
                 }
             } else { /* and, or */
                 if (f_exp != f_size) {
-                    LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
+                    LOGVAL(ctx, LYVE_SYNTAX_YANG,
                             "Invalid value \"%s\" of if-feature - missing feature/expression before \"%.*s\" operation.",
                             qname->str, op_len, &c[i]);
                     return LY_EVALID;
@@ -343,14 +342,12 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
     }
     if (j) {
         /* not matching count of ( and ) */
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
-                "Invalid value \"%s\" of if-feature - non-matching opening and closing parentheses.", qname->str);
+        LOGVAL(ctx, LYVE_SYNTAX_YANG, "Invalid value \"%s\" of if-feature - non-matching opening and closing parentheses.", qname->str);
         return LY_EVALID;
     }
     if (f_exp != f_size) {
         /* features do not match the needed arguments for the logical operations */
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
-                "Invalid value \"%s\" of if-feature - number of features in expression does not match "
+        LOGVAL(ctx, LYVE_SYNTAX_YANG, "Invalid value \"%s\" of if-feature - number of features in expression does not match "
                 "the required number of operands for the operations.", qname->str);
         return LY_EVALID;
     }
@@ -358,8 +355,7 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
     if (checkversion || (expr_size > 1)) {
         /* check that we have 1.1 module */
         if (qname->mod->version != LYS_VERSION_1_1) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
-                    "Invalid value \"%s\" of if-feature - YANG 1.1 expression in YANG 1.0 module.", qname->str);
+            LOGVAL(ctx, LYVE_SYNTAX_YANG, "Invalid value \"%s\" of if-feature - YANG 1.1 expression in YANG 1.0 module.", qname->str);
             return LY_EVALID;
         }
     }
@@ -427,7 +423,7 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
             /* now get the link to the feature definition */
             f = lysp_feature_find(qname->mod, &c[i], j - i, 1);
             if (!f) {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
+                LOGVAL(ctx, LYVE_SYNTAX_YANG,
                         "Invalid value \"%s\" of if-feature - unable to find feature \"%.*s\".", qname->str, j - i, &c[i]);
                 rc = LY_EVALID;
                 goto error;
@@ -444,8 +440,7 @@ lys_compile_iffeature(const struct ly_ctx *ctx, struct lysp_qname *qname, struct
 
     if (++expr_size || ++f_size) {
         /* not all expected operators and operands found */
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_SYNTAX_YANG,
-                "Invalid value \"%s\" of if-feature - processing error.", qname->str);
+        LOGVAL(ctx, LYVE_SYNTAX_YANG, "Invalid value \"%s\" of if-feature - processing error.", qname->str);
         rc = LY_EINT;
     } else {
         rc = LY_SUCCESS;
@@ -636,8 +631,7 @@ lys_compile_feature_circular_check(const struct ly_ctx *ctx, struct lysp_feature
 
     for (u = 0; u < LY_ARRAY_COUNT(depfeatures); ++u) {
         if (feature == depfeatures[u]) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Feature \"%s\" is indirectly referenced from itself.",
-                    feature->name);
+            LOGVAL(ctx, LYVE_REFERENCE, "Feature \"%s\" is indirectly referenced from itself.", feature->name);
             ret = LY_EVALID;
             goto cleanup;
         }
@@ -649,8 +643,7 @@ lys_compile_feature_circular_check(const struct ly_ctx *ctx, struct lysp_feature
         drv = recursion.objs[v];
         for (u = 0; u < LY_ARRAY_COUNT(drv->depfeatures); ++u) {
             if (feature == drv->depfeatures[u]) {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Feature \"%s\" is indirectly referenced from itself.",
-                        feature->name);
+                LOGVAL(ctx, LYVE_REFERENCE, "Feature \"%s\" is indirectly referenced from itself.", feature->name);
                 ret = LY_EVALID;
                 goto cleanup;
             }
@@ -686,8 +679,7 @@ lys_compile_feature_iffeatures(struct lysp_module *pmod)
             LY_ARRAY_FOR(f->iffeatures_c[u].features, v) {
                 /* check for circular dependency - direct reference first,... */
                 if (f == f->iffeatures_c[u].features[v]) {
-                    LOGVAL(pmod->mod->ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Feature \"%s\" is referenced from itself.",
-                            f->name);
+                    LOGVAL(pmod->mod->ctx, LYVE_REFERENCE, "Feature \"%s\" is referenced from itself.", f->name);
                     return LY_EVALID;
                 }
                 /* ... and indirect circular reference */

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -56,7 +56,7 @@ static LY_ERR lyd_find_sibling_schema(const struct lyd_node *siblings, const str
 LY_ERR
 lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct lysc_type *type, const char *value,
         size_t value_len, ly_bool *dynamic, LY_PREFIX_FORMAT format, void *prefix_data, uint32_t hints,
-        const struct lysc_node *ctx_node, ly_bool *incomplete, enum LY_VLOG_ELEM log_elem_type, const void *log_elem)
+        const struct lysc_node *ctx_node, ly_bool *incomplete)
 {
     LY_ERR ret;
     struct ly_err_item *err = NULL;
@@ -73,10 +73,10 @@ lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct ly
         }
     } else if (ret) {
         if (err) {
-            LOGVAL(ctx, log_elem_type, log_elem, err->vecode, err->msg);
+            LOGVAL(ctx, err->vecode, err->msg);
             ly_err_free(err);
         } else {
-            LOGVAL(ctx, log_elem_type, log_elem, LYVE_OTHER, "Storing value \"%.*s\" failed.", (int)value_len, value);
+            LOGVAL(ctx, LYVE_OTHER, "Storing value \"%.*s\" failed.", (int)value_len, value);
         }
         return ret;
     }
@@ -89,7 +89,7 @@ lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct ly
 
 LY_ERR
 lyd_value_validate_incomplete(const struct ly_ctx *ctx, const struct lysc_type *type, struct lyd_value *val,
-        const struct lyd_node *ctx_node, const struct lyd_node *tree, enum LY_VLOG_ELEM log_elem_type, const void *log_elem)
+        const struct lyd_node *ctx_node, const struct lyd_node *tree)
 {
     LY_ERR ret;
     struct ly_err_item *err = NULL;
@@ -99,10 +99,10 @@ lyd_value_validate_incomplete(const struct ly_ctx *ctx, const struct lysc_type *
     ret = type->plugin->validate(ctx, type, ctx_node, tree, val, &err);
     if (ret) {
         if (err) {
-            LOGVAL(ctx, log_elem_type, log_elem, err->vecode, err->msg);
+            LOGVAL(ctx, err->vecode, err->msg);
             ly_err_free(err);
         } else {
-            LOGVAL(ctx, log_elem_type, log_elem, LYVE_OTHER, "Resolving value \"%s\" failed.", val->canonical);
+            LOGVAL(ctx, LYVE_OTHER, "Resolving value \"%s\" failed.", val->canonical);
         }
         return ret;
     }
@@ -136,7 +136,9 @@ _lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, cons
     } else if (rc && err) {
         if (ctx) {
             /* log only in case the ctx was provided as input parameter */
-            LOGVAL(ctx, LY_VLOG_STR, err->path, err->vecode, err->msg);
+            LOG_LOCSET(ctx, NULL, NULL, err->path, NULL);
+            LOGVAL(ctx, err->vecode, err->msg);
+            LOG_LOCBACK(ctx, 0, 0, 1, 0);
         }
         ly_err_free(err);
     }
@@ -179,7 +181,9 @@ lyd_value_validate(const struct ly_ctx *ctx, const struct lyd_node_term *node, c
     if (rc) {
         if (err) {
             if (ctx) {
-                LOGVAL(ctx, LY_VLOG_LYD, node, err->vecode, err->msg);
+                LOG_LOCSET(ctx, NULL, (const struct lyd_node *)node, NULL, NULL);
+                LOGVAL(ctx, err->vecode, err->msg);
+                LOG_LOCBACK(ctx, 0, 1, 0, 0);
             }
             ly_err_free(err);
         }
@@ -215,8 +219,9 @@ lyd_value_compare(const struct lyd_node_term *node, const char *value, size_t va
     type = ((struct lysc_node_leaf *)node->schema)->type;
 
     /* store the value */
-    ret = lyd_value_store(ctx, &val, type, value, value_len, NULL, LY_PREF_JSON, NULL, LYD_HINT_DATA, node->schema,
-            NULL, LY_VLOG_LYSC, node->schema);
+    LOG_LOCSET(ctx, node->schema, (const struct lyd_node *)node, NULL, NULL);
+    ret = lyd_value_store(ctx, &val, type, value, value_len, NULL, LY_PREF_JSON, NULL, LYD_HINT_DATA, node->schema, NULL);
+    LOG_LOCBACK(ctx, 1, 1, 0, 0);
     LY_CHECK_RET(ret);
 
     /* compare values */
@@ -533,8 +538,10 @@ lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_
     term->prev = (struct lyd_node *)term;
     term->flags = LYD_NEW;
 
+    LOG_LOCSET(schema->module->ctx, schema, NULL, NULL, NULL);
     ret = lyd_value_store(schema->module->ctx, &term->value, ((struct lysc_node_leaf *)term->schema)->type, value,
-            value_len, dynamic, format, prefix_data, hints, schema, incomplete, LY_VLOG_LYSC, schema);
+            value_len, dynamic, format, prefix_data, hints, schema, incomplete);
+    LOG_LOCBACK(schema->module->ctx, 1, 0, 0, 0);
     LY_CHECK_ERR_RET(ret, free(term), ret);
     lyd_hash((struct lyd_node *)term);
 
@@ -610,6 +617,8 @@ lyd_create_list(const struct lysc_node *schema, const struct ly_path_predicate *
     /* create list */
     LY_CHECK_GOTO(ret = lyd_create_inner(schema, &list), cleanup);
 
+    LOG_LOCSET(schema->module->ctx, NULL, list, NULL, NULL);
+
     /* create and insert all the keys */
     LY_ARRAY_FOR(predicates, u) {
         LY_CHECK_GOTO(ret = lyd_create_term2(predicates[u].key, &predicates[u].value, &key), cleanup);
@@ -624,6 +633,7 @@ lyd_create_list(const struct lysc_node *schema, const struct ly_path_predicate *
     list = NULL;
 
 cleanup:
+    LOG_LOCBACK(schema->module->ctx, 0, 1, 0, 0);
     lyd_free_tree(list);
     return ret;
 }
@@ -637,6 +647,8 @@ lyd_create_list2(const struct lysc_node *schema, const char *keys, size_t keys_l
     enum ly_path_pred_type pred_type = 0;
     struct ly_path_predicate *predicates = NULL;
 
+    LOG_LOCSET(schema->module->ctx, schema, NULL, NULL, NULL);
+
     /* parse keys */
     LY_CHECK_GOTO(ret = ly_path_parse_predicate(schema->module->ctx, NULL, keys, keys_len, LY_PATH_PREFIX_OPTIONAL,
             LY_PATH_PRED_KEYS, &expr), cleanup);
@@ -649,6 +661,7 @@ lyd_create_list2(const struct lysc_node *schema, const char *keys, size_t keys_l
     LY_CHECK_GOTO(ret = lyd_create_list(schema, predicates, node), cleanup);
 
 cleanup:
+    LOG_LOCBACK(schema->module->ctx, 1, 0, 0, 0);
     lyxp_expr_free(schema->module->ctx, expr);
     ly_path_predicates_free(schema->module->ctx, pred_type, predicates);
     return ret;
@@ -1150,8 +1163,10 @@ lyd_change_term(struct lyd_node *term, const char *val_str)
     type = ((struct lysc_node_leaf *)term->schema)->type;
 
     /* parse the new value */
+    LOG_LOCSET(LYD_CTX(term), term->schema, term, NULL, NULL);
     ret = lyd_value_store(LYD_CTX(term), &val, type, val_str, strlen(val_str), NULL, LY_PREF_JSON, NULL, LYD_HINT_DATA,
-            term->schema, NULL, LY_VLOG_LYD, term);
+            term->schema, NULL);
+    LOG_LOCBACK(LYD_CTX(term), term->schema ? 1 : 0, 1, 0, 0);
     LY_CHECK_GOTO(ret, cleanup);
 
     /* compare original and new value */
@@ -1291,8 +1306,10 @@ lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *pat
     schema = p[LY_ARRAY_COUNT(p) - 1].node;
     if ((schema->nodetype == LYS_LIST) && (p[LY_ARRAY_COUNT(p) - 1].pred_type == LY_PATH_PREDTYPE_NONE) &&
             !(options & LYD_NEW_PATH_OPAQ)) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_XPATH, "Predicate missing for %s \"%s\" in path.",
-                lys_nodetype2str(schema->nodetype), schema->name);
+        LOG_LOCSET(ctx, schema, NULL, NULL, NULL);
+        LOGVAL(ctx, LYVE_XPATH, "Predicate missing for %s \"%s\" in path \"%s\".",
+                lys_nodetype2str(schema->nodetype), schema->name, path);
+        LOG_LOCBACK(ctx, 1, 0, 0, 0);
         ret = LY_EINVAL;
         goto cleanup;
     } else if ((schema->nodetype == LYS_LEAFLIST) && (p[LY_ARRAY_COUNT(p) - 1].pred_type == LY_PATH_PREDTYPE_NONE)) {
@@ -1311,7 +1328,7 @@ lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *pat
             LY_ARRAY_NEW_GOTO(ctx, p[LY_ARRAY_COUNT(p) - 1].predicates, pred, ret, cleanup);
 
             ret = lyd_value_store(ctx, &pred->value, ((struct lysc_node_leaflist *)schema)->type, value, strlen(value),
-                    NULL, LY_PREF_JSON, NULL, LYD_HINT_DATA, schema, NULL, LY_VLOG_LYSC, schema);
+                    NULL, LY_PREF_JSON, NULL, LYD_HINT_DATA, schema, NULL);
             LY_CHECK_GOTO(ret, cleanup);
             ++((struct lysc_type *)pred->value.realtype)->refcount;
         } /* else we have opaq flag and the value is not valid, leavne no predicate and then create an opaque node */
@@ -1323,7 +1340,9 @@ lyd_new_path2(struct lyd_node *parent, const struct ly_ctx *ctx, const char *pat
         if (ret == LY_SUCCESS) {
             /* the node exists, are we supposed to update it or is it just a default? */
             if (!(options & LYD_NEW_PATH_UPDATE) && !(node->flags & LYD_DEFAULT)) {
-                LOGERR(ctx, LY_EEXIST, "Path \"%s\" already exists", path);
+                LOG_LOCSET(ctx, NULL, node, NULL, NULL);
+                LOGVAL(ctx, LYVE_REFERENCE, "Path \"%s\" already exists", path);
+                LOG_LOCBACK(ctx, 0, 1, 0, 0);
                 ret = LY_EEXIST;
                 goto cleanup;
             }
@@ -2234,12 +2253,14 @@ lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct ly
         size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, LY_PREFIX_FORMAT format,
         void *prefix_data, uint32_t hints, ly_bool clear_dflt, ly_bool *incomplete)
 {
-    LY_ERR rc;
+    LY_ERR ret = LY_SUCCESS;
     struct lysc_ext_instance *ant = NULL;
     struct lyd_meta *mt, *last;
     LY_ARRAY_COUNT_TYPE u;
 
     assert((parent || meta) && mod);
+
+    LOG_LOCSET(mod->ctx, parent ? parent->schema : NULL, parent, NULL, NULL);
 
     LY_ARRAY_FOR(mod->compiled->exts, u) {
         if ((mod->compiled->exts[u].def->plugin == lyext_plugins_internal[LYEXT_PLUGIN_INTERNAL_ANNOTATION].plugin) &&
@@ -2251,20 +2272,21 @@ lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct ly
     }
     if (!ant) {
         /* attribute is not defined as a metadata annotation (RFC 7952) */
-        LOGERR(mod->ctx, LY_EINVAL, "Annotation definition for attribute \"%s:%.*s\" not found.",
+        LOGVAL(mod->ctx, LYVE_REFERENCE, "Annotation definition for attribute \"%s:%.*s\" not found.",
                 mod->name, name_len, name);
-        return LY_EINVAL;
+        ret = LY_EINVAL;
+        goto cleanup;
     }
 
     mt = calloc(1, sizeof *mt);
-    LY_CHECK_ERR_RET(!mt, LOGMEM(mod->ctx), LY_EMEM);
+    LY_CHECK_ERR_GOTO(!mt, LOGMEM(mod->ctx); ret = LY_EMEM, cleanup);
     mt->parent = parent;
     mt->annotation = ant;
-    rc = lyd_value_store(mod->ctx, &mt->value, ((struct lyext_metadata *)ant->data)->type, value, value_len, dynamic,
-            format, prefix_data, hints, parent ? parent->schema : NULL, incomplete, LY_VLOG_NONE, NULL);
-    LY_CHECK_ERR_RET(rc, free(mt), rc);
-    rc = lydict_insert(mod->ctx, name, name_len, &mt->name);
-    LY_CHECK_ERR_RET(rc, free(mt), rc);
+    ret = lyd_value_store(mod->ctx, &mt->value, ((struct lyext_metadata *)ant->data)->type, value, value_len, dynamic,
+            format, prefix_data, hints, parent ? parent->schema : NULL, incomplete);
+    LY_CHECK_ERR_GOTO(ret, free(mt), cleanup);
+    ret = lydict_insert(mod->ctx, name, name_len, &mt->name);
+    LY_CHECK_ERR_GOTO(ret, free(mt), cleanup);
 
     /* insert as the last attribute */
     if (parent) {
@@ -2277,7 +2299,10 @@ lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct ly
     if (meta) {
         *meta = mt;
     }
-    return LY_SUCCESS;
+
+cleanup:
+    LOG_LOCBACK(mod->ctx, (parent && parent->schema) ? 1 : 0, parent ? 1 : 0, 0, 0);
+    return ret;
 }
 
 void

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -239,7 +239,7 @@ lyd_parse_check_keys(struct lyd_node *node)
     key = lyd_child(node);
     while ((skey = lys_getnext(skey, node->schema, NULL, 0)) && (skey->flags & LYS_KEY)) {
         if (!key || (key->schema != skey)) {
-            LOGVAL(LYD_CTX(node), LY_VLOG_LYD, node, LY_VCODE_NOKEY, skey->name);
+            LOGVAL(LYD_CTX(node), LY_VCODE_NOKEY, skey->name);
             return LY_EVALID;
         }
 

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -316,14 +316,12 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @param[in] hints [Value hints](@ref lydvalhints) from the parser.
  * @param[in] ctx_node Context schema node.
  * @param[out] incomplete Optional, set if the value also needs to be resolved.
- * @param[in] log_elem_type Elem type for logging.
- * @param[in] log_elem Elem for logging.
  * @return LY_SUCCESS on success,
  * @return LY_ERR value on error.
  */
 LY_ERR lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct lysc_type *type, const char *value,
         size_t value_len, ly_bool *dynamic, LY_PREFIX_FORMAT format, void *prefix_data, uint32_t hints,
-        const struct lysc_node *ctx_node, ly_bool *incomplete, enum LY_VLOG_ELEM log_elem_type, const void *log_elem);
+        const struct lysc_node *ctx_node, ly_bool *incomplete);
 
 /**
  * @brief Validate previously incompletely stored value.
@@ -333,13 +331,11 @@ LY_ERR lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const st
  * @param[in,out] val Stored value to resolve.
  * @param[in] ctx_node Context node for the resolution.
  * @param[in] tree Data tree for the resolution.
- * @param[in] log_elem_type Elem type for logging.
- * @param[in] log_elem Elem for logging.
  * @return LY_SUCCESS on success,
  * @return LY_ERR value on error.
  */
 LY_ERR lyd_value_validate_incomplete(const struct ly_ctx *ctx, const struct lysc_type *type, struct lyd_value *val,
-        const struct lyd_node *ctx_node, const struct lyd_node *tree, enum LY_VLOG_ELEM log_elem_type, const void *log_elem);
+        const struct lyd_node *ctx_node, const struct lyd_node *tree);
 
 /* generic function lys_value_validate */
 LY_ERR _lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, const char *value, size_t value_len,

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -1426,20 +1426,29 @@ lysp_find_module(struct ly_ctx *ctx, const struct lysp_module *mod)
 }
 
 enum ly_stmt
-lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
+lysp_match_kw(struct ly_in *in, uint64_t *indent)
 {
 /**
- * @brief Move the INPUT by COUNT items. Also updates the indent value in yang parser context
- * @param[in] CTX yang parser context to update its indent value.
- * @param[in,out] IN input to move
+ * @brief Move the input by COUNT items. Also updates the indent value in yang parser context
  * @param[in] COUNT number of items for which the DATA pointer is supposed to move on.
  *
  * *INDENT-OFF*
  */
-#define MOVE_IN(CTX, IN, COUNT) ly_in_skip(IN, COUNT);if(CTX){(CTX)->indent+=COUNT;}
-#define IF_KW(STR, LEN, STMT) if (!strncmp(in->current, STR, LEN)) {MOVE_IN(ctx, in, LEN);*kw=STMT;}
-#define IF_KW_PREFIX(STR, LEN) if (!strncmp(in->current, STR, LEN)) {MOVE_IN(ctx, in, LEN);
-#define IF_KW_PREFIX_END }
+#define MOVE_IN(COUNT) \
+    ly_in_skip(in, COUNT); \
+    if (indent) { \
+        (*indent)+=COUNT; \
+    }
+#define IF_KW(STR, LEN, STMT) \
+    if (!strncmp(in->current, STR, LEN)) { \
+        MOVE_IN(LEN); \
+        (*kw)=STMT; \
+    }
+#define IF_KW_PREFIX(STR, LEN) \
+    if (!strncmp(in->current, STR, LEN)) { \
+        MOVE_IN(LEN);
+#define IF_KW_PREFIX_END \
+    }
 
     const char *start = in->current;
     enum ly_stmt result = LY_STMT_NONE;
@@ -1447,7 +1456,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
     /* read the keyword itself */
     switch (in->current[0]) {
     case 'a':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("rgument", 7, LY_STMT_ARGUMENT)
         else IF_KW("ugment", 6, LY_STMT_AUGMENT)
         else IF_KW("ction", 5, LY_STMT_ACTION)
@@ -1457,13 +1466,13 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'b':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ase", 3, LY_STMT_BASE)
         else IF_KW("elongs-to", 9, LY_STMT_BELONGS_TO)
         else IF_KW("it", 2, LY_STMT_BIT)
         break;
     case 'c':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ase", 3, LY_STMT_CASE)
         else IF_KW("hoice", 5, LY_STMT_CHOICE)
         else IF_KW_PREFIX("on", 2)
@@ -1475,7 +1484,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'd':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW_PREFIX("e", 1)
             IF_KW("fault", 5, LY_STMT_DEFAULT)
             else IF_KW("scription", 9, LY_STMT_DESCRIPTION)
@@ -1486,7 +1495,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'e':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("num", 3, LY_STMT_ENUM)
         else IF_KW_PREFIX("rror-", 5)
             IF_KW("app-tag", 7, LY_STMT_ERROR_APP_TAG)
@@ -1495,16 +1504,16 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         else IF_KW("xtension", 8, LY_STMT_EXTENSION)
         break;
     case 'f':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("eature", 6, LY_STMT_FEATURE)
         else IF_KW("raction-digits", 14, LY_STMT_FRACTION_DIGITS)
         break;
     case 'g':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("rouping", 7, LY_STMT_GROUPING)
         break;
     case 'i':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("dentity", 7, LY_STMT_IDENTITY)
         else IF_KW("f-feature", 9, LY_STMT_IF_FEATURE)
         else IF_KW("mport", 5, LY_STMT_IMPORT)
@@ -1514,11 +1523,11 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'k':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ey", 2, LY_STMT_KEY)
         break;
     case 'l':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW_PREFIX("e", 1)
             IF_KW("af-list", 7, LY_STMT_LEAF_LIST)
             else IF_KW("af", 2, LY_STMT_LEAF)
@@ -1527,7 +1536,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         else IF_KW("ist", 3, LY_STMT_LIST)
         break;
     case 'm':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW_PREFIX("a", 1)
             IF_KW("ndatory", 7, LY_STMT_MANDATORY)
             else IF_KW("x-elements", 10, LY_STMT_MAX_ELEMENTS)
@@ -1540,12 +1549,12 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'n':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("amespace", 8, LY_STMT_NAMESPACE)
         else IF_KW("otification", 11, LY_STMT_NOTIFICATION)
         break;
     case 'o':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW_PREFIX("r", 1)
             IF_KW("dered-by", 8, LY_STMT_ORDERED_BY)
             else IF_KW("ganization", 10, LY_STMT_ORGANIZATION)
@@ -1553,7 +1562,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         else IF_KW("utput", 5, LY_STMT_OUTPUT)
         break;
     case 'p':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ath", 3, LY_STMT_PATH)
         else IF_KW("attern", 6, LY_STMT_PATTERN)
         else IF_KW("osition", 7, LY_STMT_POSITION)
@@ -1563,7 +1572,7 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         IF_KW_PREFIX_END
         break;
     case 'r':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ange", 4, LY_STMT_RANGE)
         else IF_KW_PREFIX("e", 1)
             IF_KW_PREFIX("f", 1)
@@ -1577,17 +1586,17 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         else IF_KW("pc", 2, LY_STMT_RPC)
         break;
     case 's':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("tatus", 5, LY_STMT_STATUS)
         else IF_KW("ubmodule", 8, LY_STMT_SUBMODULE)
         break;
     case 't':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ypedef", 6, LY_STMT_TYPEDEF)
         else IF_KW("ype", 3, LY_STMT_TYPE)
         break;
     case 'u':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW_PREFIX("ni", 2)
             IF_KW("que", 3, LY_STMT_UNIQUE)
             else IF_KW("ts", 2, LY_STMT_UNITS)
@@ -1595,29 +1604,29 @@ lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in)
         else IF_KW("ses", 3, LY_STMT_USES)
         break;
     case 'v':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("alue", 4, LY_STMT_VALUE)
         break;
     case 'w':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("hen", 3, LY_STMT_WHEN)
         break;
     case 'y':
-        MOVE_IN(ctx, in, 1);
+        MOVE_IN(1);
         IF_KW("ang-version", 11, LY_STMT_YANG_VERSION)
         else IF_KW("in-element", 10, LY_STMT_YIN_ELEMENT)
         break;
     default:
-        /* if context is not NULL we are matching keyword from YANG data*/
-        if (ctx) {
+        /* if indent is not NULL we are matching keyword from YANG data */
+        if (indent) {
             if (in->current[0] == ';') {
-                MOVE_IN(ctx, in, 1);
+                MOVE_IN(1);
                 *kw = LY_STMT_SYNTAX_SEMICOLON;
             } else if (in->current[0] == '{') {
-                MOVE_IN(ctx, in, 1);
+                MOVE_IN(1);
                 *kw = LY_STMT_SYNTAX_LEFT_BRACE;
             } else if (in->current[0] == '}') {
-                MOVE_IN(ctx, in, 1);
+                MOVE_IN(1);
                 *kw = LY_STMT_SYNTAX_RIGHT_BRACE;
             }
         }

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -94,11 +94,7 @@ lysp_check_date(struct lys_parser_ctx *ctx, const char *date, uint8_t date_len, 
 
 error:
     if (stmt) {
-        if (ctx) {
-            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, date_len, date, stmt);
-        } else {
-            LOGVAL(NULL, LY_VLOG_NONE, NULL, LY_VCODE_INVAL, date_len, date, stmt);
-        }
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, date_len, date, stmt);
     }
     return LY_EINVAL;
 }
@@ -670,13 +666,13 @@ lysp_load_module_check(const struct ly_ctx *ctx, struct lysp_module *mod, struct
 
         /* check that the submodule belongs-to our module */
         if (strcmp(info->submoduleof, submod->mod->name)) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Included \"%s\" submodule from \"%s\" belongs-to a different module \"%s\".",
+            LOGVAL(ctx, LYVE_REFERENCE, "Included \"%s\" submodule from \"%s\" belongs-to a different module \"%s\".",
                     submod->name, info->submoduleof, submod->mod->name);
             return LY_EVALID;
         }
         /* check circular dependency */
         if (submod->parsing) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "A circular dependency (include) for module \"%s\".", submod->name);
+            LOGVAL(ctx, LYVE_REFERENCE, "A circular dependency (include) for module \"%s\".", submod->name);
             return LY_EVALID;
         }
     }
@@ -806,8 +802,7 @@ lysp_load_module(struct ly_ctx *ctx, const char *name, const char *revision, ly_
     if (implement) {
         m = ly_ctx_get_module_implemented(ctx, name);
         if (m && (!*mod || (*mod && (m != *mod)))) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE,
-                    "Module \"%s\" is already present in other implemented revision.", name);
+            LOGVAL(ctx, LYVE_REFERENCE, "Module \"%s\" is already present in other implemented revision.", name);
             *mod = NULL;
             return LY_EDENIED;
         }
@@ -860,14 +855,13 @@ search_file:
         }
 
         if (!*mod) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "%s \"%s\" module failed.",
-                    implement ? "Loading" : "Importing", name);
+            LOGVAL(ctx, LYVE_REFERENCE, "%s \"%s\" module failed.", implement ? "Loading" : "Importing", name);
             return LY_EVALID;
         }
     } else {
         /* we have module from the current context, circular check */
         if ((*mod)->parsed->parsing) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "A circular dependency (import) for module \"%s\".", name);
+            LOGVAL(ctx, LYVE_REFERENCE, "A circular dependency (import) for module \"%s\".", name);
             *mod = NULL;
             return LY_EVALID;
         }
@@ -988,8 +982,7 @@ search_file:
         inc->submodule = submod;
     }
     if (!inc->submodule) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_REFERENCE, "Including \"%s\" submodule into \"%s\" failed.",
-                inc->name, pctx->parsed_mod->mod->name);
+        LOGVAL(ctx, LYVE_REFERENCE, "Including \"%s\" submodule into \"%s\" failed.", inc->name, pctx->parsed_mod->mod->name);
         return LY_EVALID;
     }
 

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -143,6 +143,7 @@ struct lys_yang_parser_ctx {
     struct lysp_module *parsed_mod; /**< (sub)module being parsed */
     struct lys_glob_unres *unres;   /**< global unres structure */
     enum LY_VLOG_ELEM pos_type;     /**< */
+    struct ly_in *in;               /**< input handler for the parser */
     union {
         uint64_t line;              /**< line number */
         const char *path;           /**< path */

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -119,11 +119,11 @@ enum yang_arg {
 
 #define LOGVAL_YANG(CTX, ...) LOGVAL(PARSER_CTX(CTX), ((struct lys_yang_parser_ctx *)CTX)->pos_type, \
                                      ((struct lys_yang_parser_ctx *)CTX)->pos_type == LY_VLOG_LINE ? \
-                                        (void *)&((struct lys_yang_parser_ctx *)CTX)->line : \
+                                        (void *)&((struct lys_yang_parser_ctx *)CTX)->in->line : \
                                         (void *)((struct lys_yang_parser_ctx *)CTX)->path, __VA_ARGS__)
 
 #define LOGVAL_YIN(CTX, ...) LOGVAL(PARSER_CTX(CTX), LY_VLOG_LINE, \
-                                     &((struct lys_yin_parser_ctx *)CTX)->xmlctx->line, __VA_ARGS__)
+                                     &((struct lys_yin_parser_ctx *)CTX)->xmlctx->in->line, __VA_ARGS__)
 
 struct lys_parser_ctx {
     LYS_INFORMAT format;            /**< parser format */
@@ -144,10 +144,9 @@ struct lys_yang_parser_ctx {
     struct lys_glob_unres *unres;   /**< global unres structure */
     enum LY_VLOG_ELEM pos_type;     /**< */
     struct ly_in *in;               /**< input handler for the parser */
-    union {
-        uint64_t line;              /**< line number */
-        const char *path;           /**< path */
-    };
+
+    const char *path;           /**< path */
+
     uint64_t indent;                /**< current position on the line for YANG indentation */
 };
 
@@ -692,11 +691,11 @@ void lys_module_free(struct lys_module *module, void (*private_destructor)(const
 /**
  * @brief match yang keyword
  *
- * @param[in] ctx yang parser context for logging, can be NULL if keyword is from YIN data.
  * @param[in,out] in Input structure, is updated.
+ * @param[in,out] indent Pointer to the counter of current position on the line for YANG indentation (optional).
  * @return yang_keyword values.
  */
-enum ly_stmt lysp_match_kw(struct lys_yang_parser_ctx *ctx, struct ly_in *in);
+enum ly_stmt lysp_match_kw(struct ly_in *in, uint64_t *indent);
 
 /**
  * @brief Generate path of the given node in the requested format.

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -114,16 +114,7 @@ enum yang_arg {
 };
 
 #define PARSER_CTX(CTX) ((CTX)->parsed_mod->mod->ctx)
-
-#define LOGVAL_PARSER(CTX, ...) (CTX)->format == LYS_IN_YANG ? LOGVAL_YANG(CTX, __VA_ARGS__) : LOGVAL_YIN(CTX, __VA_ARGS__)
-
-#define LOGVAL_YANG(CTX, ...) LOGVAL(PARSER_CTX(CTX), ((struct lys_yang_parser_ctx *)CTX)->pos_type, \
-                                     ((struct lys_yang_parser_ctx *)CTX)->pos_type == LY_VLOG_LINE ? \
-                                        (void *)&((struct lys_yang_parser_ctx *)CTX)->in->line : \
-                                        (void *)((struct lys_yang_parser_ctx *)CTX)->path, __VA_ARGS__)
-
-#define LOGVAL_YIN(CTX, ...) LOGVAL(PARSER_CTX(CTX), LY_VLOG_LINE, \
-                                     &((struct lys_yin_parser_ctx *)CTX)->xmlctx->in->line, __VA_ARGS__)
+#define LOGVAL_PARSER(CTX, ...) LOGVAL((CTX) ? PARSER_CTX(CTX) : NULL, __VA_ARGS__)
 
 struct lys_parser_ctx {
     LYS_INFORMAT format;            /**< parser format */
@@ -142,11 +133,7 @@ struct lys_yang_parser_ctx {
     struct ly_set grps_nodes;       /**< set of grouping nodes */
     struct lysp_module *parsed_mod; /**< (sub)module being parsed */
     struct lys_glob_unres *unres;   /**< global unres structure */
-    enum LY_VLOG_ELEM pos_type;     /**< */
     struct ly_in *in;               /**< input handler for the parser */
-
-    const char *path;           /**< path */
-
     uint64_t indent;                /**< current position on the line for YANG indentation */
 };
 

--- a/src/xml.h
+++ b/src/xml.h
@@ -78,7 +78,6 @@ enum LYXML_PARSER_STATUS {
 
 struct lyxml_ctx {
     const struct ly_ctx *ctx;
-    uint64_t line;          /* current line */
     struct ly_in *in;       /* input structure */
 
     enum LYXML_PARSER_STATUS status; /* status providing information about the last parsed object, following attributes

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -1846,14 +1846,14 @@ lyxp_check_token(const struct ly_ctx *ctx, const struct lyxp_expr *exp, uint16_t
 {
     if (exp->used == tok_idx) {
         if (ctx) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_EOF);
+            LOGVAL(ctx, LY_VCODE_XP_EOF);
         }
         return LY_EINCOMPLETE;
     }
 
     if (want_tok && (exp->tokens[tok_idx] != want_tok)) {
         if (ctx) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INTOK2, lyxp_print_token(exp->tokens[tok_idx]),
+            LOGVAL(ctx, LY_VCODE_XP_INTOK2, lyxp_print_token(exp->tokens[tok_idx]),
                     &exp->expr[exp->tok_pos[tok_idx]], lyxp_print_token(want_tok));
         }
         return LY_ENOT;
@@ -1880,14 +1880,14 @@ exp_check_token2(const struct ly_ctx *ctx, const struct lyxp_expr *exp, uint16_t
 {
     if (exp->used == tok_idx) {
         if (ctx) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_EOF);
+            LOGVAL(ctx, LY_VCODE_XP_EOF);
         }
         return LY_EINCOMPLETE;
     }
 
     if ((exp->tokens[tok_idx] != want_tok1) && (exp->tokens[tok_idx] != want_tok2)) {
         if (ctx) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[tok_idx]),
+            LOGVAL(ctx, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[tok_idx]),
                     &exp->expr[exp->tok_pos[tok_idx]]);
         }
         return LY_ENOT;
@@ -1994,8 +1994,7 @@ step:
             rc = lyxp_check_token(ctx, exp, *tok_idx, LYXP_TOKEN_NONE);
             LY_CHECK_RET(rc);
             if ((exp->tokens[*tok_idx] != LYXP_TOKEN_NAMETEST) && (exp->tokens[*tok_idx] != LYXP_TOKEN_NODETYPE)) {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INTOK,
-                        lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
+                LOGVAL(ctx, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
                 return LY_EVALID;
             }
         /* fall through */
@@ -2025,8 +2024,7 @@ reparse_predicate:
             }
             break;
         default:
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INTOK,
-                    lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
+            LOGVAL(ctx, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
             return LY_EVALID;
         }
     } while (!exp_check_token2(NULL, exp, *tok_idx, LYXP_TOKEN_OPER_PATH, LYXP_TOKEN_OPER_RPATH));
@@ -2248,7 +2246,7 @@ reparse_function_call(const struct ly_ctx *ctx, struct lyxp_expr *exp, uint16_t 
         break;
     }
     if (min_arg_count == -1) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INFUNC, exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]]);
+        LOGVAL(ctx, LY_VCODE_XP_INFUNC, exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]]);
         return LY_EINVAL;
     }
     ++(*tok_idx);
@@ -2281,8 +2279,7 @@ reparse_function_call(const struct ly_ctx *ctx, struct lyxp_expr *exp, uint16_t 
     ++(*tok_idx);
 
     if ((arg_count < (uint32_t)min_arg_count) || (arg_count > max_arg_count)) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INARGCOUNT, arg_count, exp->tok_len[func_tok_idx],
-                &exp->expr[exp->tok_pos[func_tok_idx]]);
+        LOGVAL(ctx, LY_VCODE_XP_INARGCOUNT, arg_count, exp->tok_len[func_tok_idx], &exp->expr[exp->tok_pos[func_tok_idx]]);
         return LY_EVALID;
     }
 
@@ -2357,8 +2354,7 @@ reparse_path_expr(const struct ly_ctx *ctx, struct lyxp_expr *exp, uint16_t *tok
         goto predicate;
         break;
     default:
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INTOK,
-                lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
+        LOGVAL(ctx, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
         return LY_EVALID;
     }
 
@@ -2672,7 +2668,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
     assert(expr_p);
 
     if (!expr_str[0]) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_EOF);
+        LOGVAL(ctx, LY_VCODE_XP_EOF);
         return LY_EVALID;
     }
 
@@ -2680,7 +2676,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
         expr_len = strlen(expr_str);
     }
     if (expr_len > UINT16_MAX) {
-        LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_XPATH, "XPath expression cannot be longer than %ud characters.", UINT16_MAX);
+        LOGVAL(ctx, LYVE_XPATH, "XPath expression cannot be longer than %ud characters.", UINT16_MAX);
         return LY_EVALID;
     }
 
@@ -2774,7 +2770,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
             /* Literal with ' */
             for (tok_len = 1; (expr_str[parsed + tok_len] != '\0') && (expr_str[parsed + tok_len] != '\''); ++tok_len) {}
             LY_CHECK_ERR_GOTO(expr_str[parsed + tok_len] == '\0',
-                    LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_EOE, expr_str[parsed], &expr_str[parsed]); ret = LY_EVALID,
+                    LOGVAL(ctx, LY_VCODE_XP_EOE, expr_str[parsed], &expr_str[parsed]); ret = LY_EVALID,
                     error);
             ++tok_len;
             tok_type = LYXP_TOKEN_LITERAL;
@@ -2784,7 +2780,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
             /* Literal with " */
             for (tok_len = 1; (expr_str[parsed + tok_len] != '\0') && (expr_str[parsed + tok_len] != '\"'); ++tok_len) {}
             LY_CHECK_ERR_GOTO(expr_str[parsed + tok_len] == '\0',
-                    LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_EOE, expr_str[parsed], &expr_str[parsed]); ret = LY_EVALID,
+                    LOGVAL(ctx, LY_VCODE_XP_EOE, expr_str[parsed], &expr_str[parsed]); ret = LY_EVALID,
                     error);
             ++tok_len;
             tok_type = LYXP_TOKEN_LITERAL;
@@ -2877,12 +2873,12 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
                 tok_type = LYXP_TOKEN_OPER_MATH;
 
             } else if (prev_function_check) {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_XPATH, "Invalid character 0x%x ('%c'), perhaps \"%.*s\" is supposed to be a function call.",
+                LOGVAL(ctx, LYVE_XPATH, "Invalid character 0x%x ('%c'), perhaps \"%.*s\" is supposed to be a function call.",
                         expr_str[parsed], expr_str[parsed], expr->tok_len[expr->used - 1], &expr->expr[expr->tok_pos[expr->used - 1]]);
                 ret = LY_EVALID;
                 goto error;
             } else {
-                LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INEXPR, parsed + 1, expr_str);
+                LOGVAL(ctx, LY_VCODE_XP_INEXPR, parsed + 1, expr_str);
                 ret = LY_EVALID;
                 goto error;
             }
@@ -2897,7 +2893,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
             /* NameTest (NCName ':' '*' | QName) or NodeType/FunctionName */
             long int ncname_len = parse_ncname(&expr_str[parsed]);
             LY_CHECK_ERR_GOTO(ncname_len < 0,
-                    LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INEXPR, parsed - ncname_len + 1, expr_str); ret = LY_EVALID,
+                    LOGVAL(ctx, LY_VCODE_XP_INEXPR, parsed - ncname_len + 1, expr_str); ret = LY_EVALID,
                     error);
             tok_len = ncname_len;
 
@@ -2908,7 +2904,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
                 } else {
                     ncname_len = parse_ncname(&expr_str[parsed + tok_len]);
                     LY_CHECK_ERR_GOTO(ncname_len < 0,
-                            LOGVAL(ctx, LY_VLOG_NONE, NULL, LY_VCODE_XP_INEXPR, parsed - ncname_len + 1, expr_str); ret = LY_EVALID,
+                            LOGVAL(ctx, LY_VCODE_XP_INEXPR, parsed - ncname_len + 1, expr_str); ret = LY_EVALID,
                             error);
                     tok_len += ncname_len;
                 }
@@ -2939,7 +2935,7 @@ lyxp_expr_parse(const struct ly_ctx *ctx, const char *expr_str, size_t expr_len,
         /* fill repeat */
         LY_CHECK_ERR_GOTO(reparse_or_expr(ctx, expr, &tok_idx), ret = LY_EVALID, error);
         if (expr->used > tok_idx) {
-            LOGVAL(ctx, LY_VLOG_NONE, NULL, LYVE_XPATH, "Unparsed characters \"%s\" left at the end of an XPath expression.",
+            LOGVAL(ctx, LYVE_XPATH, "Unparsed characters \"%s\" left at the end of an XPath expression.",
                     &expr->expr[expr->tok_pos[tok_idx]]);
             ret = LY_EVALID;
             goto error;
@@ -3408,8 +3404,7 @@ xpath_bit_is_set(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp
     }
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
-                "bit-is-set(node-set, string)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "bit-is-set(node-set, string)");
         return LY_EVALID;
     }
     rc = lyxp_set_cast(args[1], LYXP_SET_STRING);
@@ -3630,7 +3625,7 @@ xpath_count(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set 
     }
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "count(node-set)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "count(node-set)");
         return LY_EVALID;
     }
 
@@ -3652,7 +3647,7 @@ static LY_ERR
 xpath_current(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set *set, uint32_t options)
 {
     if (arg_count || args) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGCOUNT, arg_count, "current()");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGCOUNT, arg_count, "current()");
         return LY_EVALID;
     }
 
@@ -3723,7 +3718,7 @@ xpath_deref(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set 
     }
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "deref(node-set)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "deref(node-set)");
         return LY_EVALID;
     }
 
@@ -3793,8 +3788,7 @@ xpath_derived_(struct lyxp_set **args, struct lyxp_set *set, uint32_t options, l
     }
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
-                "derived-from(-or-self)(node-set, string)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "derived-from(-or-self)(node-set, string)");
         return LY_EVALID;
     }
     rc = lyxp_set_cast(args[1], LYXP_SET_STRING);
@@ -3927,7 +3921,7 @@ xpath_enum_value(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp
     }
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "enum-value(node-set)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "enum-value(node-set)");
         return LY_EVALID;
     }
 
@@ -4024,7 +4018,7 @@ xpath_lang(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set *
     LY_CHECK_RET(rc);
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "lang(string)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "lang(string)");
         return LY_EVALID;
     } else if (!set->used) {
         set_fill_boolean(set, 0);
@@ -4103,7 +4097,7 @@ xpath_last(struct lyxp_set **UNUSED(args), uint16_t UNUSED(arg_count), struct ly
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "last()");
+        LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "last()");
         return LY_EVALID;
     } else if (!set->used) {
         set_fill_number(set, 0);
@@ -4139,7 +4133,7 @@ xpath_local_name(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set *se
 
     if (arg_count) {
         if (args[0]->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
+            LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
                     "local-name(node-set?)");
             return LY_EVALID;
         } else if (!args[0]->used) {
@@ -4153,7 +4147,7 @@ xpath_local_name(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set *se
         item = &args[0]->val.nodes[0];
     } else {
         if (set->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "local-name(node-set?)");
+            LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "local-name(node-set?)");
             return LY_EVALID;
         } else if (!set->used) {
             set_fill_string(set, "", 0);
@@ -4210,7 +4204,7 @@ xpath_name(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set *set, uin
 
     if (arg_count) {
         if (args[0]->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "name(node-set?)");
+            LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "name(node-set?)");
             return LY_EVALID;
         } else if (!args[0]->used) {
             set_fill_string(set, "", 0);
@@ -4223,7 +4217,7 @@ xpath_name(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set *set, uin
         item = &args[0]->val.nodes[0];
     } else {
         if (set->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "name(node-set?)");
+            LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "name(node-set?)");
             return LY_EVALID;
         } else if (!set->used) {
             set_fill_string(set, "", 0);
@@ -4292,7 +4286,7 @@ xpath_namespace_uri(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set 
 
     if (arg_count) {
         if (args[0]->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
+            LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]),
                     "namespace-uri(node-set?)");
             return LY_EVALID;
         } else if (!args[0]->used) {
@@ -4306,7 +4300,7 @@ xpath_namespace_uri(struct lyxp_set **args, uint16_t arg_count, struct lyxp_set 
         item = &args[0]->val.nodes[0];
     } else {
         if (set->type != LYXP_SET_NODE_SET) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "namespace-uri(node-set?)");
+            LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "namespace-uri(node-set?)");
             return LY_EVALID;
         } else if (!set->used) {
             set_fill_string(set, "", 0);
@@ -4538,7 +4532,7 @@ xpath_position(struct lyxp_set **UNUSED(args), uint16_t UNUSED(arg_count), struc
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "position()");
+        LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "position()");
         return LY_EVALID;
     } else if (!set->used) {
         set_fill_number(set, 0);
@@ -4568,7 +4562,6 @@ xpath_re_match(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_s
 {
     struct lysc_pattern **patterns = NULL, **pattern;
     struct lysc_node_leaf *sleaf;
-    char *path;
     LY_ERR rc = LY_SUCCESS;
     struct ly_err_item *err;
 
@@ -4599,9 +4592,9 @@ xpath_re_match(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_s
 
     LY_ARRAY_NEW_RET(set->ctx, patterns, pattern, LY_EMEM);
     *pattern = malloc(sizeof **pattern);
-    path = lyd_path(set->cur_node, LYD_PATH_STD, NULL, 0);
-    rc = lys_compile_type_pattern_check(set->ctx, path, args[1]->val.str, &(*pattern)->code);
-    free(path);
+    LOG_LOCSET(set->ctx, NULL, set->cur_node, NULL, NULL);
+    rc = lys_compile_type_pattern_check(set->ctx, args[1]->val.str, &(*pattern)->code);
+    LOG_LOCBACK(set->ctx, 0, 1, 0, 0);
     if (rc != LY_SUCCESS) {
         LY_ARRAY_FREE(patterns);
         return rc;
@@ -5047,7 +5040,7 @@ xpath_sum(struct lyxp_set **args, uint16_t UNUSED(arg_count), struct lyxp_set *s
     set_fill_number(set, 0);
 
     if (args[0]->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "sum(node-set)");
+        LOGVAL(set->ctx, LY_VCODE_XP_INARGTYPE, 1, print_set_type(args[0]), "sum(node-set)");
         return LY_EVALID;
     } else if (!args[0]->used) {
         return LY_SUCCESS;
@@ -5098,7 +5091,7 @@ xpath_text(struct lyxp_set **UNUSED(args), uint16_t UNUSED(arg_count), struct ly
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INCTX, print_set_type(set), "text()");
+        LOGVAL(set->ctx, LY_VCODE_XP_INCTX, print_set_type(set), "text()");
         return LY_EVALID;
     }
 
@@ -5282,11 +5275,7 @@ moveto_resolve_model(const char **qname, uint16_t *qname_len, const struct lyxp_
 
         /* check for errors and non-implemented modules, as they are not valid */
         if (!mod || !mod->implemented) {
-            if (set->type == LYXP_SET_SCNODE_SET) {
-                LOGVAL(set->ctx, LY_VLOG_LYSC, set->cur_scnode, LY_VCODE_XP_INMOD, pref_len, *qname);
-            } else {
-                LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INMOD, pref_len, *qname);
-            }
+            LOGVAL(set->ctx, LY_VCODE_XP_INMOD, pref_len, *qname);
             return LY_EVALID;
         }
 
@@ -5486,7 +5475,7 @@ moveto_node(struct lyxp_set *set, const struct lys_module *moveto_mod, const cha
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -5555,7 +5544,7 @@ moveto_node_hash(struct lyxp_set *set, const struct lysc_node *scnode, const str
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         ret = LY_EVALID;
         goto cleanup;
     }
@@ -5642,7 +5631,7 @@ moveto_scnode(struct lyxp_set *set, const struct lys_module *moveto_mod, const c
     }
 
     if (set->type != LYXP_SET_SCNODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYSC, set->cur_scnode, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -5739,7 +5728,7 @@ moveto_node_alldesc(struct lyxp_set *set, const struct lys_module *moveto_mod, c
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -5824,7 +5813,7 @@ moveto_scnode_alldesc(struct lyxp_set *set, const struct lys_module *moveto_mod,
     }
 
     if (set->type != LYXP_SET_SCNODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYSC, set->cur_scnode, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -5915,7 +5904,7 @@ moveto_attr(struct lyxp_set *set, const struct lys_module *mod, const char *ncna
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -5970,7 +5959,7 @@ moveto_union(struct lyxp_set *set1, struct lyxp_set *set2)
     LY_ERR rc;
 
     if ((set1->type != LYXP_SET_NODE_SET) || (set2->type != LYXP_SET_NODE_SET)) {
-        LOGVAL(set1->ctx, LY_VLOG_LYD, set1->cur_node, LY_VCODE_XP_INOP_2, "union", print_set_type(set1), print_set_type(set2));
+        LOGVAL(set1->ctx, LY_VCODE_XP_INOP_2, "union", print_set_type(set1), print_set_type(set2));
         return LY_EVALID;
     }
 
@@ -6021,7 +6010,7 @@ moveto_attr_alldesc(struct lyxp_set *set, const struct lys_module *mod, const ch
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -6166,7 +6155,7 @@ moveto_self(struct lyxp_set *set, ly_bool all_desc, uint32_t options)
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -6226,7 +6215,7 @@ moveto_scnode_self(struct lyxp_set *set, ly_bool all_desc, uint32_t options)
     }
 
     if (set->type != LYXP_SET_SCNODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYSC, set->cur_scnode, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -6313,7 +6302,7 @@ moveto_parent(struct lyxp_set *set, ly_bool all_desc, uint32_t options)
     }
 
     if (set->type != LYXP_SET_NODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -6390,7 +6379,7 @@ moveto_scnode_parent(struct lyxp_set *set, ly_bool all_desc, uint32_t options)
     }
 
     if (set->type != LYXP_SET_SCNODE_SET) {
-        LOGVAL(set->ctx, LY_VLOG_LYSC, set->cur_scnode, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
+        LOGVAL(set->ctx, LY_VCODE_XP_INOP_1, "path operator", print_set_type(set));
         return LY_EVALID;
     }
 
@@ -7564,7 +7553,7 @@ eval_function_call(const struct lyxp_expr *exp, uint16_t *tok_idx, struct lyxp_s
         }
 
         if (!xpath_func) {
-            LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INFUNC, exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]]);
+            LOGVAL(set->ctx, LY_VCODE_XP_INFUNC, exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]]);
             return LY_EVALID;
         }
     }
@@ -7648,7 +7637,6 @@ cleanup:
         lyxp_set_free(args[i]);
     }
     free(args);
-
     return rc;
 }
 
@@ -7671,13 +7659,13 @@ eval_number(struct ly_ctx *ctx, const struct lyxp_expr *exp, uint16_t *tok_idx, 
         errno = 0;
         num = strtold(&exp->expr[exp->tok_pos[*tok_idx]], &endptr);
         if (errno) {
-            LOGVAL(ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INTOK, "Unknown", &exp->expr[exp->tok_pos[*tok_idx]]);
-            LOGVAL(ctx, LY_VLOG_LYD, set->cur_node, LYVE_XPATH, "Failed to convert \"%.*s\" into a long double (%s).",
+            LOGVAL(ctx, LY_VCODE_XP_INTOK, "Unknown", &exp->expr[exp->tok_pos[*tok_idx]]);
+            LOGVAL(ctx, LYVE_XPATH, "Failed to convert \"%.*s\" into a long double (%s).",
                     exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]], strerror(errno));
             return LY_EVALID;
         } else if (endptr - &exp->expr[exp->tok_pos[*tok_idx]] != exp->tok_len[*tok_idx]) {
-            LOGVAL(ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INTOK, "Unknown", &exp->expr[exp->tok_pos[*tok_idx]]);
-            LOGVAL(ctx, LY_VLOG_LYD, set->cur_node, LYVE_XPATH, "Failed to convert \"%.*s\" into a long double.",
+            LOGVAL(ctx, LY_VCODE_XP_INTOK, "Unknown", &exp->expr[exp->tok_pos[*tok_idx]]);
+            LOGVAL(ctx, LYVE_XPATH, "Failed to convert \"%.*s\" into a long double.",
                     exp->tok_len[*tok_idx], &exp->expr[exp->tok_pos[*tok_idx]]);
             return LY_EVALID;
         }
@@ -7793,8 +7781,7 @@ eval_path_expr(const struct lyxp_expr *exp, uint16_t *tok_idx, struct lyxp_set *
         goto predicate;
 
     default:
-        LOGVAL(set->ctx, LY_VLOG_LYD, set->cur_node, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[*tok_idx]),
-                &exp->expr[exp->tok_pos[*tok_idx]]);
+        LOGVAL(set->ctx, LY_VCODE_XP_INTOK, lyxp_print_token(exp->tokens[*tok_idx]), &exp->expr[exp->tok_pos[*tok_idx]]);
         return LY_EVALID;
     }
 
@@ -8502,12 +8489,15 @@ lyxp_eval(const struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_PREF
     set->format = format;
     set->prefix_data = prefix_data;
 
+    LOG_LOCSET(set->ctx, NULL, set->cur_node, NULL, NULL);
+
     /* evaluate */
     rc = eval_expr_select(exp, &tok_idx, 0, set, options);
     if (rc != LY_SUCCESS) {
         lyxp_set_free_content(set);
     }
 
+    LOG_LOCBACK(set->ctx, 0, 1, 0, 0);
     return rc;
 }
 
@@ -8743,6 +8733,7 @@ LY_ERR
 lyxp_atomize(const struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_PREFIX_FORMAT format, void *prefix_data,
         const struct lysc_node *ctx_scnode, struct lyxp_set *set, uint32_t options)
 {
+    LY_ERR ret;
     uint16_t tok_idx = 0;
 
     LY_CHECK_ARG_RET(NULL, exp, set, LY_EINVAL);
@@ -8767,8 +8758,13 @@ lyxp_atomize(const struct lyxp_expr *exp, const struct lys_module *cur_mod, LY_P
     set->format = format;
     set->prefix_data = prefix_data;
 
+    LOG_LOCSET(set->ctx, set->cur_scnode, NULL, NULL, NULL);
+
     /* evaluate */
-    return eval_expr_select(exp, &tok_idx, 0, set, options);
+    ret = eval_expr_select(exp, &tok_idx, 0, set, options);
+
+    LOG_LOCBACK(set->ctx, 1, 0, 0, 0);
+    return ret;
 }
 
 API const char *

--- a/tests/utests/basic/test_xml.c
+++ b/tests/utests/basic/test_xml.c
@@ -377,6 +377,7 @@ test_text(void **state)
     /* empty value but in single quotes */
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_SUCCESS, lyxml_ctx_next(xmlctx));
     assert_int_equal(LYXML_ATTR_CONTENT, xmlctx->status);
@@ -388,6 +389,7 @@ test_text(void **state)
     /* empty element content - only formating before defining child */
     assert_int_equal(LY_SUCCESS, ly_in_new_memory(">\n  <y>", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ELEMENT;
     assert_int_equal(LY_SUCCESS, lyxml_ctx_next(xmlctx));
     assert_int_equal(LYXML_ELEM_CONTENT, xmlctx->status);
@@ -399,6 +401,7 @@ test_text(void **state)
     /* empty element content is invalid - missing content terminating character < */
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ELEM_CONTENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Unexpected end-of-input.", "Line number 1.");
@@ -406,6 +409,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("xxx", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ELEM_CONTENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character sequence \"xxx\", expected element tag start ('<').", "Line number 1.");
@@ -430,6 +434,7 @@ test_text(void **state)
     /* test using n-bytes UTF8 hexadecimal code points */
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#x0024;&#x00A2;&#x20ac;&#x10348;\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_SUCCESS, lyxml_ctx_next(xmlctx));
     assert_int_equal(LYXML_ATTR_CONTENT, xmlctx->status);
@@ -442,6 +447,7 @@ test_text(void **state)
     /* invalid characters in string */
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#x52\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character sequence \"'\", expected ;.", "Line number 1.");
@@ -449,6 +455,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\"&#82\"", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character sequence \"\"\", expected ;.", "Line number 1.");
@@ -456,6 +463,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\"&nonsense;\"", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Entity reference \"&nonsense;\" not supported, only predefined references allowed.", "Line number 1.");
@@ -463,6 +471,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory(">&#o122;", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ELEMENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character reference \"&#o122;\".", "Line number 1.");
@@ -470,6 +479,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#x06;\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character reference \"&#x06;\'\" (0x00000006).", "Line number 1.");
@@ -477,6 +487,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#xfdd0;\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character reference \"&#xfdd0;\'\" (0x0000fdd0).", "Line number 1.");
@@ -484,6 +495,7 @@ test_text(void **state)
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#xffff;\'", &in));
     xmlctx->in = in;
+    LOG_LOCINIT(UTEST_LYCTX, NULL, NULL, NULL, in);
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
     CHECK_LOG_CTX("Invalid character reference \"&#xffff;\'\" (0x0000ffff).", "Line number 1.");

--- a/tests/utests/basic/test_xml.c
+++ b/tests/utests/basic/test_xml.c
@@ -401,14 +401,14 @@ test_text(void **state)
     xmlctx->in = in;
     xmlctx->status = LYXML_ELEM_CONTENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Unexpected end-of-input.", "Line number 2.");
+    CHECK_LOG_CTX("Unexpected end-of-input.", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("xxx", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ELEM_CONTENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character sequence \"xxx\", expected element tag start ('<').", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character sequence \"xxx\", expected element tag start ('<').", "Line number 1.");
     ly_in_free(in, 0);
 
     lyxml_ctx_free(xmlctx);
@@ -444,49 +444,49 @@ test_text(void **state)
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character sequence \"'\", expected ;.", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character sequence \"'\", expected ;.", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\"&#82\"", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character sequence \"\"\", expected ;.", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character sequence \"\"\", expected ;.", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\"&nonsense;\"", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Entity reference \"&nonsense;\" not supported, only predefined references allowed.", "Line number 2.");
+    CHECK_LOG_CTX("Entity reference \"&nonsense;\" not supported, only predefined references allowed.", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory(">&#o122;", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ELEMENT;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character reference \"&#o122;\".", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character reference \"&#o122;\".", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#x06;\'", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character reference \"&#x06;\'\" (0x00000006).", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character reference \"&#x06;\'\" (0x00000006).", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#xfdd0;\'", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character reference \"&#xfdd0;\'\" (0x0000fdd0).", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character reference \"&#xfdd0;\'\" (0x0000fdd0).", "Line number 1.");
     ly_in_free(in, 0);
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("=\'&#xffff;\'", &in));
     xmlctx->in = in;
     xmlctx->status = LYXML_ATTRIBUTE;
     assert_int_equal(LY_EVALID, lyxml_ctx_next(xmlctx));
-    CHECK_LOG_CTX("Invalid character reference \"&#xffff;\'\" (0x0000ffff).", "Line number 2.");
+    CHECK_LOG_CTX("Invalid character reference \"&#xffff;\'\" (0x0000ffff).", "Line number 1.");
     ly_in_free(in, 0);
 
     lyxml_ctx_free(xmlctx);

--- a/tests/utests/data/test_new.c
+++ b/tests/utests/data/test_new.c
@@ -80,13 +80,13 @@ test_top_level(void **state)
     lyd_free_tree(node);
 
     assert_int_equal(lyd_new_list2(NULL, mod, "l1", "[]", 0, &node), LY_EVALID);
-    CHECK_LOG_CTX("Unexpected XPath token \"]\" (\"]\").", NULL);
+    CHECK_LOG_CTX("Unexpected XPath token \"]\" (\"]\").", "Schema location /a:l1.");
 
     assert_int_equal(lyd_new_list2(NULL, mod, "l1", "[key1='a'][key2='b']", 0, &node), LY_ENOTFOUND);
-    CHECK_LOG_CTX("Not found node \"key1\" in path.", NULL);
+    CHECK_LOG_CTX("Not found node \"key1\" in path.", "Schema location /a:l1.");
 
     assert_int_equal(lyd_new_list2(NULL, mod, "l1", "[a='a'][b='b'][c='c']", 0, &node), LY_EVALID);
-    CHECK_LOG_CTX("Key expected instead of leaf \"c\" in path.", "/a:l1/c");
+    CHECK_LOG_CTX("Key expected instead of leaf \"c\" in path.", "Schema location /a:l1.");
 
     assert_int_equal(lyd_new_list2(NULL, mod, "c", "[a='a'][b='b']", 0, &node), LY_ENOTFOUND);
     CHECK_LOG_CTX("List node \"c\" not found.", NULL);
@@ -105,7 +105,7 @@ test_top_level(void **state)
 
     /* leaf */
     assert_int_equal(lyd_new_term(NULL, mod, "foo", "[a='a'][b='b'][c='c']", 0, &node), LY_EVALID);
-    CHECK_LOG_CTX("Invalid uint16 value \"[a='a'][b='b'][c='c']\".", "/a:foo");
+    CHECK_LOG_CTX("Invalid uint16 value \"[a='a'][b='b'][c='c']\".", "Schema location /a:foo.");
 
     assert_int_equal(lyd_new_term(NULL, mod, "c", "value", 0, &node), LY_ENOTFOUND);
     CHECK_LOG_CTX("Term node \"c\" not found.", NULL);
@@ -133,7 +133,7 @@ test_top_level(void **state)
 
     /* key-less list */
     assert_int_equal(lyd_new_list2(NULL, mod, "l2", "[a='a'][b='b']", 0, &node), LY_EVALID);
-    CHECK_LOG_CTX("List predicate defined for keyless list \"l2\" in path.", NULL);
+    CHECK_LOG_CTX("List predicate defined for keyless list \"l2\" in path.", "Schema location /a:l2.");
 
     assert_int_equal(lyd_new_list2(NULL, mod, "l2", "", 0, &node), LY_SUCCESS);
     lyd_free_tree(node);
@@ -215,7 +215,7 @@ test_path(void **state)
     /* try LYD_NEWOPT_OPAQ */
     ret = lyd_new_path2(NULL, UTEST_LYCTX, "/a:l1", NULL, 0, 0, NULL, NULL);
     assert_int_equal(ret, LY_EINVAL);
-    CHECK_LOG_CTX("Predicate missing for list \"l1\" in path.", NULL);
+    CHECK_LOG_CTX("Predicate missing for list \"l1\" in path \"/a:l1\".", "Schema location /a:l1.");
 
     ret = lyd_new_path2(NULL, UTEST_LYCTX, "/a:l1", NULL, 0, LYD_NEW_PATH_OPAQ, NULL, &root);
     assert_int_equal(ret, LY_SUCCESS);
@@ -226,7 +226,7 @@ test_path(void **state)
 
     ret = lyd_new_path2(NULL, UTEST_LYCTX, "/a:foo", NULL, 0, 0, NULL, NULL);
     assert_int_equal(ret, LY_EVALID);
-    CHECK_LOG_CTX("Invalid empty uint16 value.", "/a:foo");
+    CHECK_LOG_CTX("Invalid empty uint16 value.", "Schema location /a:foo.");
 
     ret = lyd_new_path2(NULL, UTEST_LYCTX, "/a:foo", NULL, 0, LYD_NEW_PATH_OPAQ, NULL, &root);
     assert_int_equal(ret, LY_SUCCESS);

--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -131,15 +131,15 @@ test_leaf(void **state)
     lyd_free_all(tree);
 
     PARSER_CHECK_ERROR(data, LYD_PARSE_STRICT, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Unknown (or not implemented) YANG module \"x\" for metadata \"x:xxx\".", "/a:foo");
+            "Unknown (or not implemented) YANG module \"x\" for metadata \"x:xxx\".", "Data location /@a:foo, line number 1.");
 
     /* missing referenced metadata node */
     PARSER_CHECK_ERROR("{\"@a:foo\" : { \"a:hint\" : 1 }}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Missing JSON data instance to be coupled with @a:foo metadata.", "/");
+            "Missing JSON data instance to be coupled with @a:foo metadata.", "Data location /@a:foo, line number 1.");
 
     /* missing namespace for meatadata*/
     PARSER_CHECK_ERROR("{\"a:foo\" : \"value\", \"@a:foo\" : { \"hint\" : 1 }}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Metadata in JSON must be namespace-qualified, missing prefix for \"hint\".", "/a:foo");
+            "Metadata in JSON must be namespace-qualified, missing prefix for \"hint\".", "Schema location /a:foo, line number 1.");
 }
 
 static void
@@ -223,13 +223,13 @@ test_leaflist(void **state)
 
     /* missing referenced metadata node */
     PARSER_CHECK_ERROR("{\"@a:ll1\":[{\"a:hint\":1}]}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Missing JSON data instance to be coupled with @a:ll1 metadata.", "/");
+            "Missing JSON data instance to be coupled with @a:ll1 metadata.", "Data location /@a:ll1, line number 1.");
 
     PARSER_CHECK_ERROR("{\"a:ll1\":[1],\"@a:ll1\":[{\"a:hint\":1},{\"a:hint\":2}]}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Missing JSON data instance no. 2 of a:ll1 to be coupled with metadata.", "/");
+            "Missing JSON data instance no. 2 of a:ll1 to be coupled with metadata.", "Schema location /a:ll1, line number 1.");
 
     PARSER_CHECK_ERROR("{\"@a:ll1\":[{\"a:hint\":1},{\"a:hint\":2},{\"a:hint\":3}],\"a:ll1\" : [1, 2]}", 0, LYD_VALIDATE_PRESENT,
-            tree, LY_EVALID, "Missing 3rd JSON data instance to be coupled with @a:ll1 metadata.", "/");
+            tree, LY_EVALID, "Missing 3rd JSON data instance to be coupled with @a:ll1 metadata.", "Data location /@a:ll1, line number 1.");
 }
 
 static void
@@ -271,17 +271,17 @@ test_list(void **state)
 
     /* missing keys */
     PARSER_CHECK_ERROR("{ \"a:l1\": [ {\"c\" : 1, \"b\" : \"b\"}]}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"a\".", "/a:l1[b='b'][c='1']");
+            "List instance is missing its key \"a\".", "Schema location /a:l1, data location /a:l1[b='b'][c='1'], line number 1.");
 
     PARSER_CHECK_ERROR("{ \"a:l1\": [ {\"a\" : \"a\"}]}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"b\".", "/a:l1[a='a']");
+            "List instance is missing its key \"b\".", "Schema location /a:l1, data location /a:l1[a='a'], line number 1.");
 
     PARSER_CHECK_ERROR("{ \"a:l1\": [ {\"b\" : \"b\", \"a\" : \"a\"}]}", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"c\".", "/a:l1[a='a'][b='b']");
+            "List instance is missing its key \"c\".", "Schema location /a:l1, data location /a:l1[a='a'][b='b'], line number 1.");
 
     /* key duplicate */
     PARSER_CHECK_ERROR("{ \"a:l1\": [ {\"c\" : 1, \"b\" : \"b\", \"a\" : \"a\", \"c\" : 1}]}", 0, LYD_VALIDATE_PRESENT,
-            tree, LY_EVALID, "Duplicate instance of \"c\".", "/a:l1[a='a'][b='b'][c='1'][c='1']/c");
+            tree, LY_EVALID, "Duplicate instance of \"c\".", "Schema location /a:l1/c, data location /a:l1[a='a'][b='b'][c='1'][c='1']/c, line number 1.");
 
     /* keys order, in contrast to XML, JSON accepts keys in any order even in strict mode */
     CHECK_PARSE_LYD("{ \"a:l1\": [ {\"d\" : \"d\", \"a\" : \"a\", \"c\" : 1, \"b\" : \"b\"}]}", 0, LYD_VALIDATE_PRESENT, tree);
@@ -373,7 +373,7 @@ test_opaq(void **state)
     /* invalid value, no flags */
     data = "{\"a:foo3\":[null]}";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Invalid non-number-encoded uint32 value \"\".", "/a:foo3");
+            "Invalid non-number-encoded uint32 value \"\".", "Schema location /a:foo3, line number 1.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, LYD_VALIDATE_PRESENT, tree);
@@ -384,7 +384,7 @@ test_opaq(void **state)
     /* missing key, no flags */
     data = "{\"a:l1\":[{\"a\":\"val_a\",\"b\":\"val_b\",\"d\":\"val_d\"}]}";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"c\".", "/a:l1[a='val_a'][b='val_b']");
+            "List instance is missing its key \"c\".", "Schema location /a:l1, data location /a:l1[a='val_a'][b='val_b'], line number 1.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, LYD_VALIDATE_PRESENT, tree);
@@ -395,7 +395,7 @@ test_opaq(void **state)
     /* invalid key, no flags */
     data = "{\"a:l1\":[{\"a\":\"val_a\",\"b\":\"val_b\",\"c\":\"val_c\"}]}";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Invalid non-number-encoded int16 value \"val_c\".", "/a:l1/c");
+            "Invalid non-number-encoded int16 value \"val_c\".", "Schema location /a:l1/c, data location /a:l1[a='val_a'][b='val_b'], line number 1.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, LYD_VALIDATE_PRESENT, tree);

--- a/tests/utests/data/test_parser_xml.c
+++ b/tests/utests/data/test_parser_xml.c
@@ -167,17 +167,17 @@ test_list(void **state)
 
     /* missing keys */
     PARSER_CHECK_ERROR("<l1 xmlns=\"urn:tests:a\"><c>1</c><b>b</b></l1>", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"a\".", "/a:l1[b='b'][c='1']");
+            "List instance is missing its key \"a\".", "Schema location /a:l1, data location /a:l1[b='b'][c='1'], line number 1.");
 
     PARSER_CHECK_ERROR("<l1 xmlns=\"urn:tests:a\"><a>a</a></l1>", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"b\".", "/a:l1[a='a']");
+            "List instance is missing its key \"b\".", "Schema location /a:l1, data location /a:l1[a='a'], line number 1.");
 
     PARSER_CHECK_ERROR("<l1 xmlns=\"urn:tests:a\"><b>b</b><a>a</a></l1>", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"c\".", "/a:l1[a='a'][b='b']");
+            "List instance is missing its key \"c\".", "Schema location /a:l1, data location /a:l1[a='a'][b='b'], line number 1.");
 
     /* key duplicate */
     PARSER_CHECK_ERROR("<l1 xmlns=\"urn:tests:a\"><c>1</c><b>b</b><a>a</a><c>1</c></l1>", 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Duplicate instance of \"c\".", "/a:l1[a='a'][b='b'][c='1'][c='1']/c");
+            "Duplicate instance of \"c\".", "Schema location /a:l1/c, data location /a:l1[a='a'][b='b'][c='1'][c='1']/c, line number 1.");
 
     /* keys order */
     CHECK_PARSE_LYD("<l1 xmlns=\"urn:tests:a\"><d>d</d><a>a</a><c>1</c><b>b</b></l1>", 0, LYD_VALIDATE_PRESENT, tree);
@@ -209,7 +209,7 @@ test_list(void **state)
     lyd_free_all(tree);
 
     PARSER_CHECK_ERROR(data, LYD_PARSE_STRICT, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Invalid position of the key \"b\" in a list.", "Line number 1.");
+            "Invalid position of the key \"b\" in a list.", "Schema location /a:l1/b, data location /a:b, line number 1.");
 }
 
 static void
@@ -243,7 +243,7 @@ test_opaq(void **state)
     /* invalid value, no flags */
     data = "<foo3 xmlns=\"urn:tests:a\"/>";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Invalid empty uint32 value.", "/a:foo3");
+            "Invalid empty uint32 value.", "Schema location /a:foo3, line number 1.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, 0, tree);
@@ -258,7 +258,7 @@ test_opaq(void **state)
             "  <d>val_d</d>\n"
             "</l1>\n";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "List instance is missing its key \"c\".", "/a:l1[a='val_a'][b='val_b']");
+            "List instance is missing its key \"c\".", "Schema location /a:l1, data location /a:l1[a='val_a'][b='val_b'], line number 5.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, 0, tree);
@@ -273,7 +273,7 @@ test_opaq(void **state)
             "  <c>val_c</c>\n"
             "</l1>\n";
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
-            "Invalid int16 value \"val_c\".", "/a:l1/c");
+            "Invalid int16 value \"val_c\".", "Schema location /a:l1/c, data location /a:l1[a='val_a'][b='val_b'], line number 4.");
 
     /* opaq flag */
     CHECK_PARSE_LYD(data, LYD_PARSE_OPAQ | LYD_PARSE_ONLY, 0, tree);

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -57,7 +57,7 @@ test_when(void **state)
     UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
 
     CHECK_PARSE_LYD_PARAM("<c xmlns=\"urn:tests:a\">hey</c>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("When condition \"/cont/b = 'val_b'\" not satisfied.", "/a:c");
+    CHECK_LOG_CTX("When condition \"/cont/b = 'val_b'\" not satisfied.", "Schema location /a:c, data location /a:c.");
 
     LYD_TREE_CREATE("<cont xmlns=\"urn:tests:a\"><b>val_b</b></cont><c xmlns=\"urn:tests:a\">hey</c>", tree);
     CHECK_LYSC_NODE(tree->next->schema, NULL, 0, LYS_CONFIG_W | LYS_STATUS_CURR, 1, "c", 0, LYS_LEAF, 0, 0, NULL, 1);
@@ -105,13 +105,13 @@ test_mandatory(void **state)
     UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
 
     CHECK_PARSE_LYD_PARAM("<d xmlns=\"urn:tests:b\"/>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Mandatory node \"choic\" instance does not exist.", "/b:choic");
+    CHECK_LOG_CTX("Mandatory node \"choic\" instance does not exist.", "Schema location /b:choic.");
 
     CHECK_PARSE_LYD_PARAM("<l xmlns=\"urn:tests:b\">string</l><d xmlns=\"urn:tests:b\"/>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Mandatory node \"c\" instance does not exist.", "/b:c");
+    CHECK_LOG_CTX("Mandatory node \"c\" instance does not exist.", "Schema location /b:c.");
 
     CHECK_PARSE_LYD_PARAM("<a xmlns=\"urn:tests:b\">string</a>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Mandatory node \"c\" instance does not exist.", "/b:c");
+    CHECK_LOG_CTX("Mandatory node \"c\" instance does not exist.", "Schema location /b:c.");
 
     LYD_TREE_CREATE("<a xmlns=\"urn:tests:b\">string</a><c xmlns=\"urn:tests:b\">string2</c>", tree);
     lyd_free_siblings(tree);
@@ -153,12 +153,12 @@ test_minmax(void **state)
     UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
 
     CHECK_PARSE_LYD_PARAM("<d xmlns=\"urn:tests:c\"/>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Too few \"l\" instances.", "/c:choic/b/l");
+    CHECK_LOG_CTX("Too few \"l\" instances.", "Schema location /c:choic/b/l.");
 
     CHECK_PARSE_LYD_PARAM("<l xmlns=\"urn:tests:c\">val1</l>"
             "<l xmlns=\"urn:tests:c\">val2</l>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Too few \"l\" instances.", "/c:choic/b/l");
+    CHECK_LOG_CTX("Too few \"l\" instances.", "Schema location /c:choic/b/l.");
 
     LYD_TREE_CREATE("<l xmlns=\"urn:tests:c\">val1</l>"
             "<l xmlns=\"urn:tests:c\">val2</l>"
@@ -172,8 +172,9 @@ test_minmax(void **state)
             "<lt xmlns=\"urn:tests:c\"><k>val2</k></lt>"
             "<lt xmlns=\"urn:tests:c\"><k>val3</k></lt>"
             "<lt xmlns=\"urn:tests:c\"><k>val4</k></lt>"
-            "<lt xmlns=\"urn:tests:c\"><k>val5</k></lt>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Too many \"lt\" instances.", "/c:lt");
+            "<lt xmlns=\"urn:tests:c\"><k>val5</k></lt>"
+            "<lt xmlns=\"urn:tests:c\"><k>val6</k></lt>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
+    CHECK_LOG_CTX("Too many \"lt\" instances.", "Schema location /c:lt, data location /c:lt[k='val5'].");
 }
 
 const char *schema_d =
@@ -260,7 +261,8 @@ test_unique(void **state)
             "    <k>val2</k>\n"
             "    <l1>same</l1>\n"
             "</lt>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Unique data leaf(s) \"l1\" not satisfied in \"/d:lt[k='val1']\" and \"/d:lt[k='val2']\".", "/d:lt[k='val2']");
+    CHECK_LOG_CTX("Unique data leaf(s) \"l1\" not satisfied in \"/d:lt[k='val1']\" and \"/d:lt[k='val2']\".",
+            "Schema location /d:lt, data location /d:lt[k='val2'].");
 
     /* now try with more instances */
     LYD_TREE_CREATE("<lt xmlns=\"urn:tests:d\">\n"
@@ -357,7 +359,8 @@ test_unique(void **state)
             "    <k>val8</k>\n"
             "    <l1>8</l1>\n"
             "</lt>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Unique data leaf(s) \"l1\" not satisfied in \"/d:lt[k='val7']\" and \"/d:lt[k='val2']\".", "/d:lt[k='val2']");
+    CHECK_LOG_CTX("Unique data leaf(s) \"l1\" not satisfied in \"/d:lt[k='val7']\" and \"/d:lt[k='val2']\".",
+            "Schema location /d:lt, data location /d:lt[k='val2'].");
 }
 
 static void
@@ -481,9 +484,8 @@ test_unique_nested(void **state)
             "        <l3>3</l3>\n"
             "    </lt3>\n"
             "</lt2>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Unique data leaf(s) \"l3\" not satisfied in"
-            " \"/d:lt2[k='val2']/lt3[kk='val3']\" and"
-            " \"/d:lt2[k='val2']/lt3[kk='val1']\".", "/d:lt2[k='val2']/lt3[kk='val1']");
+    CHECK_LOG_CTX("Unique data leaf(s) \"l3\" not satisfied in \"/d:lt2[k='val2']/lt3[kk='val3']\" and \"/d:lt2[k='val2']/lt3[kk='val1']\".",
+            "Schema location /d:lt2/lt3, data location /d:lt2[k='val2']/lt3[kk='val1'].");
 
     CHECK_PARSE_LYD_PARAM("<lt2 xmlns=\"urn:tests:d\">\n"
             "    <k>val1</k>\n"
@@ -520,7 +522,8 @@ test_unique_nested(void **state)
             "    </cont>\n"
             "    <l4>5</l4>\n"
             "</lt2>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Unique data leaf(s) \"cont/l2 l4\" not satisfied in \"/d:lt2[k='val4']\" and \"/d:lt2[k='val2']\".", "/d:lt2[k='val2']");
+    CHECK_LOG_CTX("Unique data leaf(s) \"cont/l2 l4\" not satisfied in \"/d:lt2[k='val4']\" and \"/d:lt2[k='val2']\".",
+            "Schema location /d:lt2, data location /d:lt2[k='val2'].");
 
     CHECK_PARSE_LYD_PARAM("<lt2 xmlns=\"urn:tests:d\">\n"
             "    <k>val1</k>\n"
@@ -566,7 +569,7 @@ test_unique_nested(void **state)
             "    <l6>3</l6>\n"
             "</lt2>", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
     CHECK_LOG_CTX("Unique data leaf(s) \"l5 l6\" not satisfied in \"/d:lt2[k='val5']\" and \"/d:lt2[k='val3']\".",
-            "/d:lt2[k='val3']");
+            "Schema location /d:lt2, data location /d:lt2[k='val3'].");
 }
 
 static void
@@ -627,28 +630,28 @@ test_dup(void **state)
 
     CHECK_PARSE_LYD_PARAM("<d xmlns=\"urn:tests:e\">25</d><d xmlns=\"urn:tests:e\">50</d>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"d\".", "/e:d");
+    CHECK_LOG_CTX("Duplicate instance of \"d\".", "Schema location /e:d, data location /e:d.");
 
     CHECK_PARSE_LYD_PARAM("<lt xmlns=\"urn:tests:e\"><k>A</k></lt>"
             "<lt xmlns=\"urn:tests:e\"><k>B</k></lt>"
             "<lt xmlns=\"urn:tests:e\"><k>A</k></lt>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"lt\".", "/e:lt[k='A']");
+    CHECK_LOG_CTX("Duplicate instance of \"lt\".", "Schema location /e:lt, data location /e:lt[k='A'].");
 
     CHECK_PARSE_LYD_PARAM("<ll xmlns=\"urn:tests:e\">A</ll>"
             "<ll xmlns=\"urn:tests:e\">B</ll>"
             "<ll xmlns=\"urn:tests:e\">B</ll>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"ll\".", "/e:ll[.='B']");
+    CHECK_LOG_CTX("Duplicate instance of \"ll\".", "Schema location /e:ll, data location /e:ll[.='B'].");
 
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:e\"></cont><cont xmlns=\"urn:tests:e\"/>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"cont\".", "/e:cont");
+    CHECK_LOG_CTX("Duplicate instance of \"cont\".", "Schema location /e:cont, data location /e:cont.");
 
     /* same tests again but using hashes */
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:e\"><d>25</d><d>50</d><ll>1</ll><ll>2</ll><ll>3</ll><ll>4</ll></cont>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"d\".", "/e:cont/d");
+    CHECK_LOG_CTX("Duplicate instance of \"d\".", "Schema location /e:cont/d, data location /e:cont/d, line number 1.");
 
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:e\"><ll>1</ll><ll>2</ll><ll>3</ll><ll>4</ll>"
             "<lt><k>a</k></lt>"
@@ -657,12 +660,12 @@ test_dup(void **state)
             "<lt><k>d</k></lt>"
             "<lt><k>c</k></lt></cont>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"lt\".", "/e:cont/lt[k='c']");
+    CHECK_LOG_CTX("Duplicate instance of \"lt\".", "Schema location /e:cont/lt, data location /e:cont/lt[k='c'], line number 1.");
 
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:e\"><ll>1</ll><ll>2</ll><ll>3</ll><ll>4</ll>"
             "<ll>a</ll><ll>b</ll><ll>c</ll><ll>d</ll><ll>d</ll></cont>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"ll\".", "/e:cont/ll[.='d']");
+    CHECK_LOG_CTX("Duplicate instance of \"ll\".", "Schema location /e:cont/ll, data location /e:cont/ll[.='d'], line number 1.");
 
     /* cases */
     CHECK_PARSE_LYD_PARAM("<l xmlns=\"urn:tests:e\">a</l>"
@@ -670,13 +673,13 @@ test_dup(void **state)
             "<l xmlns=\"urn:tests:e\">c</l>"
             "<l xmlns=\"urn:tests:e\">b</l>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Duplicate instance of \"l\".", "/e:l[.='b']");
+    CHECK_LOG_CTX("Duplicate instance of \"l\".", "Schema location /e:choic/b/l, data location /e:l[.='b'].");
 
     CHECK_PARSE_LYD_PARAM("<l xmlns=\"urn:tests:e\">a</l><l xmlns=\"urn:tests:e\">b</l>"
             "<l xmlns=\"urn:tests:e\">c</l>"
             "<a xmlns=\"urn:tests:e\">aa</a>",
             LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Data for both cases \"a\" and \"b\" exist.", "/e:choic");
+    CHECK_LOG_CTX("Data for both cases \"a\" and \"b\" exist.", "Schema location /e:choic.");
 }
 
 static void
@@ -963,11 +966,13 @@ test_state(void **state)
             "  </cont2>\n"
             "</cont>\n";
     CHECK_PARSE_LYD_PARAM(data, LYD_XML, LYD_PARSE_ONLY | LYD_PARSE_NO_STATE, 0, LY_EVALID, tree);
-    CHECK_LOG_CTX("Invalid state data node \"cont2\" found.", "/h:cont/cont2");
+    CHECK_LOG_CTX("Invalid state data node \"cont2\" found.",
+            "Schema location /h:cont/cont2, data location /h:cont, line number 3.");
 
     CHECK_PARSE_LYD_PARAM(data, LYD_XML, LYD_PARSE_ONLY, 0, LY_SUCCESS, tree);
     assert_int_equal(LY_EVALID, lyd_validate_all(&tree, NULL, LYD_VALIDATE_PRESENT | LYD_VALIDATE_NO_STATE, NULL));
-    CHECK_LOG_CTX("Invalid state data node \"cont2\" found.", "/h:cont/cont2");
+    CHECK_LOG_CTX("Invalid state data node \"cont2\" found.",
+            "Schema location /h:cont/cont2, data location /h:cont/cont2.");
     lyd_free_all(tree);
 }
 
@@ -998,7 +1003,8 @@ test_must(void **state)
             "  <l>wrong</l>\n"
             "  <l2>val</l2>\n"
             "</cont>\n", LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
-    CHECK_LOG_CTX("Must condition \"../l = 'right'\" not satisfied.", "/i:cont/l2");
+    CHECK_LOG_CTX("Must condition \"../l = 'right'\" not satisfied.",
+            "Schema location /i:cont/l2, data location /i:cont/l2.");
 
     LYD_TREE_CREATE("<cont xmlns=\"urn:tests:i\">\n"
             "  <l>right</l>\n"
@@ -1080,7 +1086,8 @@ test_action(void **state)
 
     /* missing leafref */
     assert_int_equal(LY_EVALID, lyd_validate_op(op_tree, NULL, LYD_VALIDATE_OP_RPC, NULL));
-    CHECK_LOG_CTX("Invalid leafref value \"target\" - no existing target instance \"/lf3\".", "/j:cont/l1[k='val1']/act/lf2");
+    CHECK_LOG_CTX("Invalid leafref value \"target\" - no existing target instance \"/lf3\".",
+            "Schema location /j:cont/l1/act/lf2, data location /j:cont/l1[k='val1']/act/lf2.");
     ly_in_free(in, 0);
 
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:j\">\n"
@@ -1091,7 +1098,8 @@ test_action(void **state)
 
     /* input must false */
     assert_int_equal(LY_EVALID, lyd_validate_op(op_tree, tree, LYD_VALIDATE_OP_RPC, NULL));
-    CHECK_LOG_CTX("Must condition \"../../lf1 = 'true'\" not satisfied.", "/j:cont/l1[k='val1']/act");
+    CHECK_LOG_CTX("Must condition \"../../lf1 = 'true'\" not satisfied.",
+            "Data location /j:cont/l1[k='val1']/act.");
 
     lyd_free_all(tree);
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:j\">\n"
@@ -1130,7 +1138,8 @@ test_reply(void **state)
 
     /* missing leafref */
     assert_int_equal(LY_EVALID, lyd_validate_op(op_tree, NULL, LYD_VALIDATE_OP_REPLY, NULL));
-    CHECK_LOG_CTX("Invalid leafref value \"target\" - no existing target instance \"/lf4\".", "/j:cont/l1[k='val1']/act/lf2");
+    CHECK_LOG_CTX("Invalid leafref value \"target\" - no existing target instance \"/lf4\".",
+            "Schema location /j:cont/l1/act/lf2, data location /j:cont/l1[k='val1']/act/lf2.");
 
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:j\">\n"
             "  <lf1>not true</lf1>\n"
@@ -1140,7 +1149,7 @@ test_reply(void **state)
 
     /* input must false */
     assert_int_equal(LY_EVALID, lyd_validate_op(op_tree, tree, LYD_VALIDATE_OP_REPLY, NULL));
-    CHECK_LOG_CTX("Must condition \"../../lf1 = 'true2'\" not satisfied.", "/j:cont/l1[k='val1']/act");
+    CHECK_LOG_CTX("Must condition \"../../lf1 = 'true2'\" not satisfied.", "Data location /j:cont/l1[k='val1']/act.");
 
     lyd_free_all(tree);
     CHECK_PARSE_LYD_PARAM("<cont xmlns=\"urn:tests:j\">\n"

--- a/tests/utests/schema/test_parser_yang.c
+++ b/tests/utests/schema/test_parser_yang.c
@@ -36,35 +36,39 @@ void lysp_node_free(struct ly_ctx *ctx, struct lysp_node *node);
 void lysp_when_free(struct ly_ctx *ctx, struct lysp_when *when);
 
 LY_ERR buf_add_char(struct ly_ctx *ctx, struct ly_in *in, size_t len, char **buf, size_t *buf_len, size_t *buf_used);
-LY_ERR buf_store_char(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg, char **word_p,
+LY_ERR buf_store_char(struct lys_yang_parser_ctx *ctx, enum yang_arg arg, char **word_p,
         size_t *word_len, char **word_b, size_t *buf_len, uint8_t need_buf, uint8_t *prefix);
-LY_ERR get_keyword(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt *kw, char **word_p, size_t *word_len);
-LY_ERR get_argument(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum yang_arg arg,
+LY_ERR get_keyword(struct lys_yang_parser_ctx *ctx, enum ly_stmt *kw, char **word_p, size_t *word_len);
+LY_ERR get_argument(struct lys_yang_parser_ctx *ctx, enum yang_arg arg,
         uint16_t *flags, char **word_p, char **word_b, size_t *word_len);
-LY_ERR skip_comment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, uint8_t comment);
+LY_ERR skip_comment(struct lys_yang_parser_ctx *ctx, uint8_t comment);
 
-LY_ERR parse_action(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_action **actions);
-LY_ERR parse_any(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt kw, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_augment(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_augment **augments);
-LY_ERR parse_case(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_container(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_deviate(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_deviate **deviates);
-LY_ERR parse_deviation(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_deviation **deviations);
-LY_ERR parse_grouping(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_grp **groupings);
-LY_ERR parse_choice(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_leaf(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_leaflist(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_list(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_maxelements(struct lys_yang_parser_ctx *ctx, struct ly_in *in, uint32_t *max, uint16_t *flags, struct lysp_ext_instance **exts);
-LY_ERR parse_minelements(struct lys_yang_parser_ctx *ctx, struct ly_in *in, uint32_t *min, uint16_t *flags, struct lysp_ext_instance **exts);
-LY_ERR parse_module(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_module *mod);
-LY_ERR parse_notif(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_notif **notifs);
-LY_ERR parse_submodule(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_submodule *submod);
-LY_ERR parse_uses(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_node *parent, struct lysp_node **siblings);
-LY_ERR parse_when(struct lys_yang_parser_ctx *ctx, struct ly_in *in, struct lysp_when **when_p);
-LY_ERR parse_type_enum_value_pos(struct lys_yang_parser_ctx *ctx, struct ly_in *in, enum ly_stmt val_kw, int64_t *value, uint16_t *flags, struct lysp_ext_instance **exts);
+LY_ERR parse_action(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_action **actions);
+LY_ERR parse_any(struct lys_yang_parser_ctx *ctx, enum ly_stmt kw, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_augment(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_augment **augments);
+LY_ERR parse_case(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_container(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_deviate(struct lys_yang_parser_ctx *ctx, struct lysp_deviate **deviates);
+LY_ERR parse_deviation(struct lys_yang_parser_ctx *ctx, struct lysp_deviation **deviations);
+LY_ERR parse_grouping(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_grp **groupings);
+LY_ERR parse_choice(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_leaf(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_leaflist(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_list(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_maxelements(struct lys_yang_parser_ctx *ctx, uint32_t *max, uint16_t *flags, struct lysp_ext_instance **exts);
+LY_ERR parse_minelements(struct lys_yang_parser_ctx *ctx, uint32_t *min, uint16_t *flags, struct lysp_ext_instance **exts);
+LY_ERR parse_module(struct lys_yang_parser_ctx *ctx, struct lysp_module *mod);
+LY_ERR parse_notif(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_notif **notifs);
+LY_ERR parse_submodule(struct lys_yang_parser_ctx *ctx, struct lysp_submodule *submod);
+LY_ERR parse_uses(struct lys_yang_parser_ctx *ctx, struct lysp_node *parent, struct lysp_node **siblings);
+LY_ERR parse_when(struct lys_yang_parser_ctx *ctx, struct lysp_when **when_p);
+LY_ERR parse_type_enum_value_pos(struct lys_yang_parser_ctx *ctx, enum ly_stmt val_kw, int64_t *value, uint16_t *flags, struct lysp_ext_instance **exts);
 
 struct lys_yang_parser_ctx *YCTX;
+
+#define YCTX_INIT \
+    struct ly_in in = {0}; \
+    YCTX->in = &in
 
 static int
 setup(void **state)
@@ -102,16 +106,17 @@ teardown(void **state)
 
 #define TEST_DUP_GENERIC(PREFIX, MEMBER, VALUE1, VALUE2, FUNC, RESULT, LINE, CLEANUP) \
     in.current = PREFIX MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, FUNC(YCTX, &in, RESULT)); \
+    assert_int_equal(LY_EVALID, FUNC(YCTX, RESULT)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number "LINE".");\
     CLEANUP
 static void
 test_helpers(void **state)
 {
-    struct ly_in in = {0};
     char *buf, *p;
     size_t len, size;
     uint8_t prefix = 0;
+
+    YCTX_INIT;
 
     /* storing into buffer */
     in.current = "abcd";
@@ -128,28 +133,28 @@ test_helpers(void **state)
     /* invalid first characters */
     len = 0;
     in.current = "2invalid";
-    assert_int_equal(LY_EVALID, buf_store_char(YCTX, &in, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_EVALID, buf_store_char(YCTX, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     in.current = ".invalid";
-    assert_int_equal(LY_EVALID, buf_store_char(YCTX, &in, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_EVALID, buf_store_char(YCTX, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     in.current = "-invalid";
-    assert_int_equal(LY_EVALID, buf_store_char(YCTX, &in, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_EVALID, buf_store_char(YCTX, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     /* invalid following characters */
     len = 3; /* number of characters read before the str content */
     in.current = "!";
-    assert_int_equal(LY_EVALID, buf_store_char(YCTX, &in, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_EVALID, buf_store_char(YCTX, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     in.current = ":";
-    assert_int_equal(LY_EVALID, buf_store_char(YCTX, &in, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_EVALID, buf_store_char(YCTX, Y_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     /* valid colon for prefixed identifiers */
     len = size = 0;
     p = NULL;
     prefix = 0;
     in.current = "x:id";
-    assert_int_equal(LY_SUCCESS, buf_store_char(YCTX, &in, Y_PREF_IDENTIF_ARG, &p, &len, &buf, &size, 0, &prefix));
+    assert_int_equal(LY_SUCCESS, buf_store_char(YCTX, Y_PREF_IDENTIF_ARG, &p, &len, &buf, &size, 0, &prefix));
     assert_int_equal(1, len);
     assert_null(buf);
     assert_string_equal(":id", in.current);
     assert_int_equal('x', p[len - 1]);
-    assert_int_equal(LY_SUCCESS, buf_store_char(YCTX, &in, Y_PREF_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
+    assert_int_equal(LY_SUCCESS, buf_store_char(YCTX, Y_PREF_IDENTIF_ARG, &p, &len, &buf, &size, 1, &prefix));
     assert_int_equal(2, len);
     assert_string_equal("id", in.current);
     assert_int_equal(':', p[len - 1]);
@@ -179,7 +184,7 @@ test_helpers(void **state)
     {\
         const char * text  = INPUT_TEXT;\
         in.current = text;\
-        assert_int_equal(LY_SUCCESS, get_argument(CTX, &in, Y_MAYBE_STR_ARG, NULL, &word, &buf, &len));\
+        assert_int_equal(LY_SUCCESS, get_argument(CTX, Y_MAYBE_STR_ARG, NULL, &word, &buf, &len));\
         assert_string_equal(word, EXPECT_WORD);\
         assert_int_equal(len, EXPECT_LEN);\
         assert_string_equal(EXPECT_CURRENT, in.current);\
@@ -188,10 +193,11 @@ test_helpers(void **state)
 static void
 test_comments(void **state)
 {
-    struct ly_in in = {0};
     char *word, *buf;
     size_t len;
     const char *in_text;
+
+    YCTX_INIT;
 
     // in.current = " // this is a text of / one * line */ comment\nargument;";
     in_text = " // this is a text of / one * line */ comment\nargument;";
@@ -204,11 +210,11 @@ test_comments(void **state)
     free(word);
 
     in.current = " this is one line comment on last line";
-    assert_int_equal(LY_SUCCESS, skip_comment(YCTX, &in, 1));
+    assert_int_equal(LY_SUCCESS, skip_comment(YCTX, 1));
     assert_true(in.current[0] == '\0');
 
     in.current = " this is a not terminated comment x";
-    assert_int_equal(LY_EVALID, skip_comment(YCTX, &in, 2));
+    assert_int_equal(LY_EVALID, skip_comment(YCTX, 2));
     CHECK_LOG_CTX("Unexpected end-of-input, non-terminated comment.", "Line number 5.");
     assert_true(in.current[0] == '\0');
 }
@@ -216,45 +222,46 @@ test_comments(void **state)
 static void
 test_arg(void **state)
 {
-    struct ly_in in = {0};
     char *word, *buf;
     size_t len;
 
+    YCTX_INIT;
+
     /* missing argument */
     in.current = ";";
-    assert_int_equal(LY_SUCCESS, get_argument(YCTX, &in, Y_MAYBE_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_SUCCESS, get_argument(YCTX, Y_MAYBE_STR_ARG, NULL, &word, &buf, &len));
     assert_null(word);
 
     in.current = "{";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Invalid character sequence \"{\", expected an argument.", "Line number 1.");
 
     /* invalid escape sequence */
     in.current = "\"\\s\"";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Double-quoted string unknown special character \'\\s\'.", "Line number 1.");
 
     TEST_GET_ARGUMENT_SUCCESS("\'\\s\'", YCTX, Y_STR_ARG, "\\s\'", 2, "");
 
     /* invalid character after the argument */
     in.current = "hello\"";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Invalid character sequence \"\"\", expected unquoted string character, optsep, semicolon or opening brace.", "Line number 1.");
 
     in.current = "hello}";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Invalid character sequence \"}\", expected unquoted string character, optsep, semicolon or opening brace.", "Line number 1.");
     /* invalid identifier-ref-arg-str */
     in.current = "pre:pre:value";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_PREF_IDENTIF_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_PREF_IDENTIF_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Invalid identifier character ':' (0x003a).", "Line number 1.");
 
     in.current = "\"\";"; /* empty identifier is not allowed */
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_IDENTIF_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_IDENTIF_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Statement argument is required.", "Line number 1.");
 
     in.current = "\"\";"; /* empty reference identifier is not allowed */
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_PREF_IDENTIF_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_PREF_IDENTIF_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Statement argument is required.", "Line number 1.");
 
     /* slash is not an invalid character */
@@ -302,7 +309,7 @@ test_arg(void **state)
     free(buf);
 
     in.current = "\"hel\"  +\t\nlo"; /* unquoted the second part */
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Both string parts divided by '+' must be quoted.", "Line number 6.");
 
     TEST_GET_ARGUMENT_SUCCESS("\'he\'\t\n+ \"llo\"", YCTX, Y_STR_ARG, "hello", 5, "");
@@ -313,13 +320,13 @@ test_arg(void **state)
 
     /* missing argument */
     in.current = ";";
-    assert_int_equal(LY_EVALID, get_argument(YCTX, &in, Y_STR_ARG, NULL, &word, &buf, &len));
+    assert_int_equal(LY_EVALID, get_argument(YCTX, Y_STR_ARG, NULL, &word, &buf, &len));
     CHECK_LOG_CTX("Invalid character sequence \";\", expected an argument.", "Line number 8.");
 }
 
 #define TEST_STMS_SUCCESS(INPUT_TEXT, CTX, ACTION, EXPECT_WORD)\
                    in.current = INPUT_TEXT;\
-                   assert_int_equal(LY_SUCCESS, get_keyword(CTX, &in, &kw, &word, &len));\
+                   assert_int_equal(LY_SUCCESS, get_keyword(CTX, &kw, &word, &len));\
                    assert_int_equal(ACTION, kw);\
                    assert_int_equal(strlen(EXPECT_WORD), len);\
                    assert_true(0 == strncmp(EXPECT_WORD, word, len))
@@ -327,41 +334,42 @@ test_arg(void **state)
 static void
 test_stmts(void **state)
 {
-    struct ly_in in = {0};
     const char *p;
     enum ly_stmt kw;
     char *word;
     size_t len;
 
+    YCTX_INIT;
+
     in.current = "\n// comment\n\tinput\t{";
-    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &kw, &word, &len));
     assert_int_equal(LY_STMT_INPUT, kw);
     assert_int_equal(5, len);
     assert_string_equal("input\t{", word);
     assert_string_equal("\t{", in.current);
 
     in.current = "\t /* comment */\t output\n\t{";
-    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &kw, &word, &len));
     assert_int_equal(LY_STMT_OUTPUT, kw);
     assert_int_equal(6, len);
     assert_string_equal("output\n\t{", word);
     assert_string_equal("\n\t{", in.current);
-    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &kw, &word, &len));
     assert_int_equal(LY_STMT_SYNTAX_LEFT_BRACE, kw);
     assert_int_equal(1, len);
     assert_string_equal("{", word);
     assert_string_equal("", in.current);
 
     in.current = "/input { "; /* invalid slash */
-    assert_int_equal(LY_EVALID, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_EVALID, get_keyword(YCTX, &kw, &word, &len));
     CHECK_LOG_CTX("Invalid identifier first character '/'.", "Line number 4.");
 
     in.current = "not-a-statement-nor-extension { "; /* invalid identifier */
-    assert_int_equal(LY_EVALID, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_EVALID, get_keyword(YCTX, &kw, &word, &len));
     CHECK_LOG_CTX("Invalid character sequence \"not-a-statement-nor-extension\", expected a keyword.", "Line number 4.");
 
     in.current = "path;"; /* missing sep after the keyword */
-    assert_int_equal(LY_EVALID, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_EVALID, get_keyword(YCTX, &kw, &word, &len));
     CHECK_LOG_CTX("Invalid character sequence \"path;\", expected a keyword followed by a separator.", "Line number 4.");
 
     TEST_STMS_SUCCESS("action ", YCTX, LY_STMT_ACTION, "action");
@@ -442,7 +450,7 @@ test_stmts(void **state)
 
     /* geenric extension */
     in.current = p = "nacm:default-deny-write;";
-    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &in, &kw, &word, &len));
+    assert_int_equal(LY_SUCCESS, get_keyword(YCTX, &kw, &word, &len));
     assert_int_equal(LY_STMT_EXTENSION_INSTANCE, kw);
     assert_int_equal(23, len);
     assert_ptr_equal(p, word);
@@ -451,10 +459,10 @@ test_stmts(void **state)
 #define TEST_MINMAX_SUCCESS(INPUT_TEXT, CTX, TYPE, VALUE)\
     in.current = INPUT_TEXT;\
     if(TYPE == LYS_SET_MIN){\
-       assert_int_equal(LY_SUCCESS, parse_minelements(CTX, &in, &value, &flags, &ext));\
+       assert_int_equal(LY_SUCCESS, parse_minelements(CTX, &value, &flags, &ext));\
     }\
     if(TYPE == LYS_SET_MAX){\
-       assert_int_equal(LY_SUCCESS, parse_maxelements(CTX, &in, &value, &flags, &ext));\
+       assert_int_equal(LY_SUCCESS, parse_maxelements(CTX, &value, &flags, &ext));\
     }\
     assert_int_equal(TYPE, flags);\
     assert_int_equal(VALUE, value)
@@ -465,23 +473,23 @@ test_minmax(void **state)
     uint16_t flags = 0;
     uint32_t value = 0;
     struct lysp_ext_instance *ext = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     in.current = " 1invalid; ...";
-    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid value \"1invalid\" of \"min-elements\".", "Line number 1.");
 
     flags = value = 0;
     in.current = " -1; ...";
-    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid value \"-1\" of \"min-elements\".", "Line number 1.");
 
     /* implementation limit */
     flags = value = 0;
     in.current = " 4294967296; ...";
-    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Value \"4294967296\" is out of \"min-elements\" bounds.", "Line number 1.");
 
     flags = value = 0;
@@ -495,22 +503,22 @@ test_minmax(void **state)
 
     flags = value = 0;
     in.current = " 1 {config true;} ...";
-    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_minelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"min-elements\".", "Line number 1.");
 
     in.current = " 1invalid; ...";
-    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid value \"1invalid\" of \"max-elements\".", "Line number 1.");
 
     flags = value = 0;
     in.current = " -1; ...";
-    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid value \"-1\" of \"max-elements\".", "Line number 1.");
 
     /* implementation limit */
     flags = value = 0;
     in.current = " 4294967296; ...";
-    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Value \"4294967296\" is out of \"max-elements\" bounds.", "Line number 1.");
 
     flags = value = 0;
@@ -527,7 +535,7 @@ test_minmax(void **state)
 
     flags = value = 0;
     in.current = " 1 {config true;} ...";
-    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &in, &value, &flags, &ext));
+    assert_int_equal(LY_EVALID, parse_maxelements(YCTX, &value, &flags, &ext));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"max-elements\".", "Line number 1.");
 }
 
@@ -577,27 +585,28 @@ test_module(void **state)
     struct lysp_module *mod = NULL;
     struct lysp_submodule *submod = NULL;
     struct lys_module *m;
-    struct ly_in in = {0};
     struct lys_glob_unres unres = {0};
     struct lys_yang_parser_ctx *ctx_p;
+
+    YCTX_INIT;
 
     mod = mod_renew(YCTX);
 
     /* missing mandatory substatements */
     in.current = " name {}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     assert_string_equal("name", mod->mod->name);
     CHECK_LOG_CTX("Missing mandatory keyword \"namespace\" as a child of \"module\".", "Line number 1.");
 
     mod = mod_renew(YCTX);
     in.current = " name {namespace urn:x;}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     assert_string_equal("urn:x", mod->mod->ns);
     CHECK_LOG_CTX("Missing mandatory keyword \"prefix\" as a child of \"module\".", "Line number 1.");
     mod = mod_renew(YCTX);
 
     in.current = " name {namespace urn:x;prefix \"x\";}";
-    assert_int_equal(LY_SUCCESS, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_SUCCESS, parse_module(YCTX, mod));
     assert_string_equal("x", mod->mod->prefix);
     mod = mod_renew(YCTX);
 
@@ -605,14 +614,14 @@ test_module(void **state)
 #define SCHEMA_BEGINNING2 " name {namespace urn:x;prefix \"x\";"
 #define TEST_NODE(NODETYPE, INPUT, NAME) \
         in.current = SCHEMA_BEGINNING INPUT; \
-        assert_int_equal(LY_SUCCESS, parse_module(YCTX, &in, mod)); \
+        assert_int_equal(LY_SUCCESS, parse_module(YCTX, mod)); \
         assert_non_null(mod->data); \
         assert_int_equal(NODETYPE, mod->data->nodetype); \
         assert_string_equal(NAME, mod->data->name); \
         mod = mod_renew(YCTX);
 #define TEST_GENERIC(INPUT, TARGET, TEST) \
         in.current = SCHEMA_BEGINNING INPUT; \
-        assert_int_equal(LY_SUCCESS, parse_module(YCTX, &in, mod)); \
+        assert_int_equal(LY_SUCCESS, parse_module(YCTX, mod)); \
         assert_non_null(TARGET); \
         TEST; \
         mod = mod_renew(YCTX);
@@ -630,7 +639,7 @@ test_module(void **state)
 
     /* not allowed in module (submodule-specific) */
     in.current = SCHEMA_BEGINNING "belongs-to master {prefix m;}}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Invalid keyword \"belongs-to\" as a child of \"module\".", "Line number 1.");
     mod = mod_renew(YCTX);
 
@@ -673,12 +682,12 @@ test_module(void **state)
 
     /* import - prefix collision */
     in.current = SCHEMA_BEGINNING "import zzz {prefix x;}}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Prefix \"x\" already used as module prefix.", "Line number 2.");
     mod = mod_renew(YCTX);
 
     in.current = SCHEMA_BEGINNING "import zzz {prefix y;}import zzz {prefix y;}}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Prefix \"y\" already used to import \"zzz\" module.", "Line number 2.");
 
     mod = mod_renew(YCTX);
@@ -729,19 +738,19 @@ test_module(void **state)
     TEST_NODE(LYS_USES, "uses test;}", "test");
     /* yang-version */
     in.current = SCHEMA_BEGINNING2 "\n\tyang-version 10;}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Invalid value \"10\" of \"yang-version\".", "Line number 3.");
     mod = mod_renew(YCTX);
     in.current = SCHEMA_BEGINNING2 "yang-version 1;yang-version 1.1;}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Duplicate keyword \"yang-version\".", "Line number 3.");
     mod = mod_renew(YCTX);
     in.current = SCHEMA_BEGINNING2 "yang-version 1;}";
-    assert_int_equal(LY_SUCCESS, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_SUCCESS, parse_module(YCTX, mod));
     assert_int_equal(1, mod->version);
     mod = mod_renew(YCTX);
     in.current = SCHEMA_BEGINNING2 "yang-version \"1.1\";}";
-    assert_int_equal(LY_SUCCESS, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_SUCCESS, parse_module(YCTX, mod));
     assert_int_equal(2, mod->version);
     mod = mod_renew(YCTX);
 
@@ -777,7 +786,7 @@ test_module(void **state)
 
     /* invalid substatement */
     in.current = SCHEMA_BEGINNING "must false;}";
-    assert_int_equal(LY_EVALID, parse_module(YCTX, &in, mod));
+    assert_int_equal(LY_EVALID, parse_module(YCTX, mod));
     CHECK_LOG_CTX("Invalid keyword \"must\" as a child of \"module\".", "Line number 3.");
 
     /* submodule */
@@ -785,14 +794,14 @@ test_module(void **state)
 
     /* missing mandatory substatements */
     in.current = " subname {}";
-    assert_int_equal(LY_EVALID, parse_submodule(YCTX, &in, submod));
+    assert_int_equal(LY_EVALID, parse_submodule(YCTX, submod));
     CHECK_LOG_CTX("Missing mandatory keyword \"belongs-to\" as a child of \"submodule\".", "Line number 3.");
     assert_string_equal("subname", submod->name);
 
     submod = submod_renew(YCTX);
 
     in.current = " subname {belongs-to name {prefix x;}}";
-    assert_int_equal(LY_SUCCESS, parse_submodule(YCTX, &in, submod));
+    assert_int_equal(LY_SUCCESS, parse_submodule(YCTX, submod));
     assert_string_equal("name", submod->mod->name);
     submod = submod_renew(YCTX);
 
@@ -801,27 +810,27 @@ test_module(void **state)
 
     /* duplicated namespace, prefix */
     in.current = " subname {belongs-to name {prefix x;}belongs-to module1;belongs-to module2;} ...";
-    assert_int_equal(LY_EVALID, parse_submodule(YCTX, &in, submod));
+    assert_int_equal(LY_EVALID, parse_submodule(YCTX, submod));
     CHECK_LOG_CTX("Duplicate keyword \"belongs-to\".", "Line number 3.");
     submod = submod_renew(YCTX);
 
     /* not allowed in submodule (module-specific) */
     in.current = SCHEMA_BEGINNING "namespace \"urn:z\";}";
-    assert_int_equal(LY_EVALID, parse_submodule(YCTX, &in, submod));
+    assert_int_equal(LY_EVALID, parse_submodule(YCTX, submod));
     CHECK_LOG_CTX("Invalid keyword \"namespace\" as a child of \"submodule\".", "Line number 3.");
     submod = submod_renew(YCTX);
     in.current = SCHEMA_BEGINNING "prefix m;}}";
-    assert_int_equal(LY_EVALID, parse_submodule(YCTX, &in, submod));
+    assert_int_equal(LY_EVALID, parse_submodule(YCTX, submod));
     CHECK_LOG_CTX("Invalid keyword \"prefix\" as a child of \"submodule\".", "Line number 3.");
     submod = submod_renew(YCTX);
 
     in.current = "submodule " SCHEMA_BEGINNING "} module q {namespace urn:q;prefixq;}";
-    assert_int_equal(LY_EVALID, yang_parse_submodule(&ctx_p, YCTX->parsed_mod->mod->ctx, (struct lys_parser_ctx *)YCTX, &in, &submod));
+    assert_int_equal(LY_EVALID, yang_parse_submodule(&ctx_p, YCTX->parsed_mod->mod->ctx, (struct lys_parser_ctx *)YCTX, YCTX->in, &submod));
     CHECK_LOG_CTX("Trailing garbage \"module q {names...\" after submodule, expected end-of-input.", "Line number 1.");
     yang_parser_ctx_free(ctx_p);
 
     in.current = "prefix " SCHEMA_BEGINNING "}";
-    assert_int_equal(LY_EVALID, yang_parse_submodule(&ctx_p, YCTX->parsed_mod->mod->ctx, (struct lys_parser_ctx *)YCTX, &in, &submod));
+    assert_int_equal(LY_EVALID, yang_parse_submodule(&ctx_p, YCTX->parsed_mod->mod->ctx, (struct lys_parser_ctx *)YCTX, YCTX->in, &submod));
     CHECK_LOG_CTX("Invalid keyword \"prefix\", expected \"module\" or \"submodule\".", "Line number 1.");
     yang_parser_ctx_free(ctx_p);
     submod = submod_renew(YCTX);
@@ -836,7 +845,8 @@ static void
 test_deviation(void **state)
 {
     struct lysp_deviation *d = NULL;
-    struct ly_in in = {0};
+
+    YCTX_INIT;
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
@@ -848,7 +858,7 @@ test_deviation(void **state)
 
     /* full content */
     in.current = " test {deviate not-supported;description text;reference \'another text\';prefix:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_deviation(YCTX, &in, &d));
+    assert_int_equal(LY_SUCCESS, parse_deviation(YCTX, &d));
     assert_non_null(d);
     assert_string_equal(" ...", in.current);
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, d, lysp_deviation_free);
@@ -856,14 +866,14 @@ test_deviation(void **state)
 
     /* missing mandatory substatement */
     in.current = " test {description text;}";
-    assert_int_equal(LY_EVALID, parse_deviation(YCTX, &in, &d));
+    assert_int_equal(LY_EVALID, parse_deviation(YCTX, &d));
     CHECK_LOG_CTX("Missing mandatory keyword \"deviate\" as a child of \"deviation\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, d, lysp_deviation_free);
     d = NULL;
 
     /* invalid substatement */
     in.current = " test {deviate not-supported; status obsolete;}";
-    assert_int_equal(LY_EVALID, parse_deviation(YCTX, &in, &d));
+    assert_int_equal(LY_EVALID, parse_deviation(YCTX, &d));
     CHECK_LOG_CTX("Invalid keyword \"status\" as a child of \"deviation\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, d, lysp_deviation_free);
     d = NULL;
@@ -872,7 +882,7 @@ test_deviation(void **state)
 
 #define TEST_DEVIATE_SUCCESS(INPUT_TEXT, REMAIN_TEXT)\
                     in.current = INPUT_TEXT;\
-                    assert_int_equal(LY_SUCCESS, parse_deviate(YCTX, &in, &d));\
+                    assert_int_equal(LY_SUCCESS, parse_deviate(YCTX, &d));\
                     assert_non_null(d);\
                     assert_string_equal(REMAIN_TEXT, in.current);\
                     lysp_deviate_free(YCTX->parsed_mod->mod->ctx, d); free(d); d = NULL
@@ -881,7 +891,8 @@ static void
 test_deviate(void **state)
 {
     struct lysp_deviate *d = NULL;
-    struct ly_in in = {0};
+
+    YCTX_INIT;
 
     /* invalid cardinality */
 #define TEST_DUP(TYPE, MEMBER, VALUE1, VALUE2) \
@@ -905,7 +916,7 @@ test_deviate(void **state)
     /* invalid substatements */
 #define TEST_NOT_SUP(DEV, STMT, VALUE) \
     in.current = " "DEV" {"STMT" "VALUE";}..."; \
-    assert_int_equal(LY_EVALID, parse_deviate(YCTX, &in, &d)); \
+    assert_int_equal(LY_EVALID, parse_deviate(YCTX, &d)); \
     CHECK_LOG_CTX("Deviate \""DEV"\" does not support keyword \""STMT"\".", "Line number 1.");\
     lysp_deviate_free(YCTX->parsed_mod->mod->ctx, d); free(d); d = NULL
 
@@ -928,7 +939,7 @@ test_deviate(void **state)
     TEST_NOT_SUP("replace", "unique", "a");
 
     in.current = " nonsence; ...";
-    assert_int_equal(LY_EVALID, parse_deviate(YCTX, &in, &d));
+    assert_int_equal(LY_EVALID, parse_deviate(YCTX, &d));
     CHECK_LOG_CTX("Invalid value \"nonsence\" of \"deviate\".", "Line number 1.");\
     assert_null(d);
 #undef TEST_NOT_SUP
@@ -939,14 +950,14 @@ static void
 test_container(void **state)
 {
     struct lysp_node_container *c = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "cont {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_container(YCTX, &in, NULL, (struct lysp_node**)&c)); \
+    assert_int_equal(LY_EVALID, parse_container(YCTX, NULL, (struct lysp_node**)&c)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)c); c = NULL;
 
@@ -961,7 +972,7 @@ test_container(void **state)
     /* full content */
     in.current = "cont {action x;anydata any;anyxml anyxml; choice ch;config false;container c;description test;grouping g;if-feature f; leaf l {type string;}"
             "leaf-list ll {type string;} list li;must 'expr';notification not; presence true; reference test;status current;typedef t {type int8;}uses g;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_SUCCESS, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     CHECK_LYSP_NODE(c, "test", 1, LYS_CONFIG_R | LYS_STATUS_CURR, 1, "cont", 0, LYS_CONTAINER, 0, "test", 1);
     assert_non_null(c->actions);
     assert_non_null(c->child);
@@ -975,17 +986,17 @@ test_container(void **state)
 
     /* invalid */
     in.current = " cont {augment /root;} ...";
-    assert_int_equal(LY_EVALID, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_EVALID, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     CHECK_LOG_CTX("Invalid keyword \"augment\" as a child of \"container\".", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)c); c = NULL;
     in.current = " cont {nonsence true;} ...";
-    assert_int_equal(LY_EVALID, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_EVALID, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     CHECK_LOG_CTX("Invalid character sequence \"nonsence\", expected a keyword.", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)c); c = NULL;
 
     YCTX->parsed_mod->version = 1; /* simulate YANG 1.0 */
     in.current = " cont {action x;} ...";
-    assert_int_equal(LY_EVALID, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_EVALID, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     CHECK_LOG_CTX("Invalid keyword \"action\" as a child of \"container\" - "
             "the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)c); c = NULL;
@@ -995,12 +1006,13 @@ static void
 test_leaf(void **state)
 {
     struct lysp_node_leaf *l = NULL;
-    struct ly_in in = {0};
+
+    YCTX_INIT;
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_leaf(YCTX, &in, NULL, (struct lysp_node**)&l)); \
+    assert_int_equal(LY_EVALID, parse_leaf(YCTX, NULL, (struct lysp_node**)&l)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)l); l = NULL;
 
@@ -1018,7 +1030,7 @@ test_leaf(void **state)
     /* full content - without mandatory which is mutual exclusive with default */
     in.current = "l {config false;default \"xxx\";description test;if-feature f;"
             "must 'expr';reference test;status current;type string; units yyy;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_leaf(YCTX, &in, NULL, (struct lysp_node **)&l));
+    assert_int_equal(LY_SUCCESS, parse_leaf(YCTX, NULL, (struct lysp_node **)&l));
     CHECK_LYSP_NODE(l, "test", 1, LYS_CONFIG_R | LYS_STATUS_CURR, 1, "l", 0, LYS_LEAF, 0, "test", 1);
     assert_string_equal("xxx", l->dflt.str);
     assert_string_equal("yyy", l->units);
@@ -1028,14 +1040,14 @@ test_leaf(void **state)
 
     /* full content - now with mandatory */
     in.current = "l {mandatory true; type string;} ...";
-    assert_int_equal(LY_SUCCESS, parse_leaf(YCTX, &in, NULL, (struct lysp_node **)&l));
+    assert_int_equal(LY_SUCCESS, parse_leaf(YCTX, NULL, (struct lysp_node **)&l));
     CHECK_LYSP_NODE(l, NULL, 0, LYS_MAND_TRUE, 0, "l", 0, LYS_LEAF, 0, NULL, 0);
     assert_string_equal("string", l->type.name);
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)l); l = NULL;
 
     /* invalid */
     in.current = " l {description \"missing type\";} ...";
-    assert_int_equal(LY_EVALID, parse_leaf(YCTX, &in, NULL, (struct lysp_node **)&l));
+    assert_int_equal(LY_EVALID, parse_leaf(YCTX, NULL, (struct lysp_node **)&l));
     CHECK_LOG_CTX("Missing mandatory keyword \"type\" as a child of \"leaf\".", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)l); l = NULL;
 }
@@ -1044,14 +1056,14 @@ static void
 test_leaflist(void **state)
 {
     struct lysp_node_leaflist *ll = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "ll {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, &in, NULL, (struct lysp_node**)&ll)); \
+    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, NULL, (struct lysp_node**)&ll)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)ll); ll = NULL;
 
@@ -1071,7 +1083,7 @@ test_leaflist(void **state)
     in.current = "ll {config false;default \"xxx\"; default \"yyy\";description test;if-feature f;"
             "max-elements 10;must 'expr';ordered-by user;reference test;"
             "status current;type string; units zzz;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_leaflist(YCTX, &in, NULL, (struct lysp_node **)&ll));
+    assert_int_equal(LY_SUCCESS, parse_leaflist(YCTX, NULL, (struct lysp_node **)&ll));
     CHECK_LYSP_NODE(ll, "test", 1, 0x446, 1, "ll", 0, LYS_LEAFLIST, 0, "test", 1);
     assert_non_null(ll->dflts);
     assert_int_equal(2, LY_ARRAY_COUNT(ll->dflts));
@@ -1087,7 +1099,7 @@ test_leaflist(void **state)
 
     /* full content - now with min-elements */
     in.current = "ll {min-elements 10; type string;} ...";
-    assert_int_equal(LY_SUCCESS, parse_leaflist(YCTX, &in, NULL, (struct lysp_node **)&ll));
+    assert_int_equal(LY_SUCCESS, parse_leaflist(YCTX, NULL, (struct lysp_node **)&ll));
     CHECK_LYSP_NODE(ll, NULL, 0, 0x200, 0, "ll", 0, LYS_LEAFLIST, 0, NULL, 0);
     assert_string_equal("string", ll->type.name);
     assert_int_equal(0, ll->max);
@@ -1097,13 +1109,13 @@ test_leaflist(void **state)
 
     /* invalid */
     in.current = " ll {description \"missing type\";} ...";
-    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, &in, NULL, (struct lysp_node **)&ll));
+    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, NULL, (struct lysp_node **)&ll));
     CHECK_LOG_CTX("Missing mandatory keyword \"type\" as a child of \"leaf-list\".", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)ll); ll = NULL;
 
     YCTX->parsed_mod->version = 1; /* simulate YANG 1.0 - default statement is not allowed */
     in.current = " ll {default xx; type string;} ...";
-    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, &in, NULL, (struct lysp_node **)&ll));
+    assert_int_equal(LY_EVALID, parse_leaflist(YCTX, NULL, (struct lysp_node **)&ll));
     CHECK_LOG_CTX("Invalid keyword \"default\" as a child of \"leaf-list\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)ll); ll = NULL;
 }
@@ -1112,14 +1124,14 @@ static void
 test_list(void **state)
 {
     struct lysp_node_list *l = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_list(YCTX, &in, NULL, (struct lysp_node**)&l)); \
+    assert_int_equal(LY_EVALID, parse_list(YCTX, NULL, (struct lysp_node**)&l)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)l); l = NULL;
 
@@ -1138,7 +1150,7 @@ test_list(void **state)
     in.current = "l {action x;anydata any;anyxml anyxml; choice ch;config false;container c;description test;grouping g;if-feature f; key l; leaf l {type string;}"
             "leaf-list ll {type string;} list li;max-elements 10; min-elements 1;must 'expr';notification not; ordered-by system; reference test;"
             "status current;typedef t {type int8;}unique xxx;unique yyy;uses g;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_list(YCTX, &in, NULL, (struct lysp_node **)&l));
+    assert_int_equal(LY_SUCCESS, parse_list(YCTX, NULL, (struct lysp_node **)&l));
     CHECK_LYSP_NODE(l, "test", 1, LYS_CONFIG_R | LYS_STATUS_CURR | LYS_ORDBY_SYSTEM | LYS_SET_MAX | LYS_SET_MIN, 1, "l",
             0, LYS_LIST, 0, "test", 1);
     assert_string_equal("l", l->key);
@@ -1155,7 +1167,7 @@ test_list(void **state)
     /* invalid content */
     YCTX->parsed_mod->version = 1; /* simulate YANG 1.0 */
     in.current = "l {action x;} ...";
-    assert_int_equal(LY_EVALID, parse_list(YCTX, &in, NULL, (struct lysp_node **)&l));
+    assert_int_equal(LY_EVALID, parse_list(YCTX, NULL, (struct lysp_node **)&l));
     CHECK_LOG_CTX("Invalid keyword \"action\" as a child of \"list\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)l); l = NULL;
 }
@@ -1164,14 +1176,14 @@ static void
 test_choice(void **state)
 {
     struct lysp_node_choice *ch = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "ch {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_choice(YCTX, &in, NULL, (struct lysp_node**)&ch)); \
+    assert_int_equal(LY_EVALID, parse_choice(YCTX, NULL, (struct lysp_node**)&ch)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)ch); ch = NULL;
 
@@ -1187,13 +1199,13 @@ test_choice(void **state)
     /* full content - without default due to a collision with mandatory */
     in.current = "ch {anydata any;anyxml anyxml; case c;choice ch;config false;container c;description test;if-feature f;leaf l {type string;}"
             "leaf-list ll {type string;} list li;mandatory true;reference test;status current;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_choice(YCTX, &in, NULL, (struct lysp_node **)&ch));
+    assert_int_equal(LY_SUCCESS, parse_choice(YCTX, NULL, (struct lysp_node **)&ch));
     CHECK_LYSP_NODE(ch, "test", 1, LYS_CONFIG_R | LYS_STATUS_CURR | LYS_MAND_TRUE, 1, "ch", 0, LYS_CHOICE, 0, "test", 1);
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)ch); ch = NULL;
 
     /* full content - the default missing from the previous node */
     in.current = "ch {default c;case c;} ...";
-    assert_int_equal(LY_SUCCESS, parse_choice(YCTX, &in, NULL, (struct lysp_node **)&ch));
+    assert_int_equal(LY_SUCCESS, parse_choice(YCTX, NULL, (struct lysp_node **)&ch));
     CHECK_LYSP_NODE(ch, NULL, 0, 0, 0, "ch", 0, LYS_CHOICE, 0, NULL, 0);
     assert_string_equal("c", ch->dflt.str);
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)ch); ch = NULL;
@@ -1203,14 +1215,14 @@ static void
 test_case(void **state)
 {
     struct lysp_node_case *cs = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "cs {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_case(YCTX, &in, NULL, (struct lysp_node**)&cs)); \
+    assert_int_equal(LY_EVALID, parse_case(YCTX, NULL, (struct lysp_node**)&cs)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)cs); cs = NULL;
 
@@ -1223,13 +1235,13 @@ test_case(void **state)
     /* full content */
     in.current = "cs {anydata any;anyxml anyxml; choice ch;container c;description test;if-feature f;leaf l {type string;}"
             "leaf-list ll {type string;} list li;reference test;status current;uses grp;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_case(YCTX, &in, NULL, (struct lysp_node **)&cs));
+    assert_int_equal(LY_SUCCESS, parse_case(YCTX, NULL, (struct lysp_node **)&cs));
     CHECK_LYSP_NODE(cs, "test", 1, LYS_STATUS_CURR, 1, "cs", 0, LYS_CASE, 0, "test", 1);
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)cs); cs = NULL;
 
     /* invalid content */
     in.current = "cs {config true} ...";
-    assert_int_equal(LY_EVALID, parse_case(YCTX, &in, NULL, (struct lysp_node **)&cs));
+    assert_int_equal(LY_EVALID, parse_case(YCTX, NULL, (struct lysp_node **)&cs));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"case\".", "Line number 1.");
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node *)cs); cs = NULL;
 }
@@ -1238,8 +1250,8 @@ static void
 test_any(void **state, enum ly_stmt kw)
 {
     struct lysp_node_anydata *any = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     if (kw == LY_STMT_ANYDATA) {
         YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
     } else {
@@ -1249,7 +1261,7 @@ test_any(void **state, enum ly_stmt kw)
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_any(YCTX, &in, kw, NULL, (struct lysp_node**)&any)); \
+    assert_int_equal(LY_EVALID, parse_any(YCTX, kw, NULL, (struct lysp_node**)&any)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)any); any = NULL;
 
@@ -1263,7 +1275,7 @@ test_any(void **state, enum ly_stmt kw)
 
     /* full content */
     in.current = "any {config true;description test;if-feature f;mandatory true;must 'expr';reference test;status current;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_any(YCTX, &in, kw, NULL, (struct lysp_node **)&any));
+    assert_int_equal(LY_SUCCESS, parse_any(YCTX, kw, NULL, (struct lysp_node **)&any));
     // CHECK_LYSP_NODE(NODE, DSC, EXTS, FLAGS, IFFEATURES, NAME, NEXT, TYPE, PARENT, REF, WHEN)
     uint16_t node_type = kw == LY_STMT_ANYDATA ? LYS_ANYDATA : LYS_ANYXML;
     CHECK_LYSP_NODE(any, "test", 1, LYS_CONFIG_W | LYS_STATUS_CURR | LYS_MAND_TRUE, 1, "any", 0, node_type, 0, "test", 1);
@@ -1287,14 +1299,14 @@ static void
 test_grouping(void **state)
 {
     struct lysp_grp *grp = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_grouping(YCTX, &in, NULL, &grp)); \
+    assert_int_equal(LY_EVALID, parse_grouping(YCTX, NULL, &grp)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, grp, lysp_grp_free); grp = NULL;
 
@@ -1306,7 +1318,7 @@ test_grouping(void **state)
     /* full content */
     in.current = "grp {action x;anydata any;anyxml anyxml; choice ch;container c;description test;grouping g;leaf l {type string;}"
             "leaf-list ll {type string;} list li;notification not;reference test;status current;typedef t {type int8;}uses g;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_grouping(YCTX, &in, NULL, &grp));
+    assert_int_equal(LY_SUCCESS, parse_grouping(YCTX, NULL, &grp));
     assert_non_null(grp);
     assert_int_equal(LYS_GROUPING, grp->nodetype);
     assert_string_equal("grp", grp->name);
@@ -1320,12 +1332,12 @@ test_grouping(void **state)
 
     /* invalid content */
     in.current = "grp {config true} ...";
-    assert_int_equal(LY_EVALID, parse_grouping(YCTX, &in, NULL, &grp));
+    assert_int_equal(LY_EVALID, parse_grouping(YCTX, NULL, &grp));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"grouping\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, grp, lysp_grp_free); grp = NULL;
 
     in.current = "grp {must 'expr'} ...";
-    assert_int_equal(LY_EVALID, parse_grouping(YCTX, &in, NULL, &grp));
+    assert_int_equal(LY_EVALID, parse_grouping(YCTX, NULL, &grp));
     CHECK_LOG_CTX("Invalid keyword \"must\" as a child of \"grouping\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, grp, lysp_grp_free); grp = NULL;
 }
@@ -1335,14 +1347,14 @@ test_action(void **state)
 {
     struct lysp_action *rpcs = NULL;
     struct lysp_node_container *c = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "func {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_action(YCTX, &in, NULL, &rpcs)); \
+    assert_int_equal(LY_EVALID, parse_action(YCTX, NULL, &rpcs)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, rpcs, lysp_action_free); rpcs = NULL;
 
@@ -1355,13 +1367,13 @@ test_action(void **state)
 
     /* full content */
     in.current = "top;";
-    assert_int_equal(LY_SUCCESS, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_SUCCESS, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     in.current = "func {description test;grouping grp;if-feature f;reference test;status current;typedef mytype {type int8;} m:ext;"
             "input {anydata a1; anyxml a2; choice ch; container c; grouping grp; leaf l {type int8;} leaf-list ll {type int8;}"
             " list li; must 1; typedef mytypei {type int8;} uses grp; m:ext;}"
             "output {anydata a1; anyxml a2; choice ch; container c; grouping grp; leaf l {type int8;} leaf-list ll {type int8;}"
             " list li; must 1; typedef mytypeo {type int8;} uses grp; m:ext;}} ...";
-    assert_int_equal(LY_SUCCESS, parse_action(YCTX, &in, (struct lysp_node *)c, &rpcs));
+    assert_int_equal(LY_SUCCESS, parse_action(YCTX, (struct lysp_node *)c, &rpcs));
     assert_non_null(rpcs);
     assert_int_equal(LYS_ACTION, rpcs->nodetype);
     assert_string_equal("func", rpcs->name);
@@ -1392,7 +1404,7 @@ test_action(void **state)
 
     /* invalid content */
     in.current = "func {config true} ...";
-    assert_int_equal(LY_EVALID, parse_action(YCTX, &in, NULL, &rpcs));
+    assert_int_equal(LY_EVALID, parse_action(YCTX, NULL, &rpcs));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"rpc\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, rpcs, lysp_action_free); rpcs = NULL;
 
@@ -1404,14 +1416,14 @@ test_notification(void **state)
 {
     struct lysp_notif *notifs = NULL;
     struct lysp_node_container *c = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "func {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_notif(YCTX, &in, NULL, &notifs)); \
+    assert_int_equal(LY_EVALID, parse_notif(YCTX, NULL, &notifs)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, notifs, lysp_notif_free); notifs = NULL;
 
@@ -1422,10 +1434,10 @@ test_notification(void **state)
 
     /* full content */
     in.current = "top;";
-    assert_int_equal(LY_SUCCESS, parse_container(YCTX, &in, NULL, (struct lysp_node **)&c));
+    assert_int_equal(LY_SUCCESS, parse_container(YCTX, NULL, (struct lysp_node **)&c));
     in.current = "ntf {anydata a1; anyxml a2; choice ch; container c; description test; grouping grp; if-feature f; leaf l {type int8;}"
             "leaf-list ll {type int8;} list li; must 1; reference test; status current; typedef mytype {type int8;} uses grp; m:ext;}";
-    assert_int_equal(LY_SUCCESS, parse_notif(YCTX, &in, (struct lysp_node *)c, &notifs));
+    assert_int_equal(LY_SUCCESS, parse_notif(YCTX, (struct lysp_node *)c, &notifs));
     assert_non_null(notifs);
     assert_int_equal(LYS_NOTIF, notifs->nodetype);
     assert_string_equal("ntf", notifs->name);
@@ -1444,7 +1456,7 @@ test_notification(void **state)
 
     /* invalid content */
     in.current = "ntf {config true} ...";
-    assert_int_equal(LY_EVALID, parse_notif(YCTX, &in, NULL, &notifs));
+    assert_int_equal(LY_EVALID, parse_notif(YCTX, NULL, &notifs));
     CHECK_LOG_CTX("Invalid keyword \"config\" as a child of \"notification\".", "Line number 1.");
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, notifs, lysp_notif_free); notifs = NULL;
 
@@ -1455,14 +1467,14 @@ static void
 test_uses(void **state)
 {
     struct lysp_node_uses *u = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_uses(YCTX, &in, NULL, (struct lysp_node**)&u)); \
+    assert_int_equal(LY_EVALID, parse_uses(YCTX, NULL, (struct lysp_node**)&u)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     lysp_node_free(YCTX->parsed_mod->mod->ctx, (struct lysp_node*)u); u = NULL;
 
@@ -1474,7 +1486,7 @@ test_uses(void **state)
 
     /* full content */
     in.current = "grpref {augment some/node;description test;if-feature f;reference test;refine some/other/node;status current;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_uses(YCTX, &in, NULL, (struct lysp_node **)&u));
+    assert_int_equal(LY_SUCCESS, parse_uses(YCTX, NULL, (struct lysp_node **)&u));
     CHECK_LYSP_NODE(u, "test", 1, LYS_STATUS_CURR, 1, "grpref", 0, LYS_USES, 0, "test", 1);
     assert_non_null(u->augments);
     assert_non_null(u->refines);
@@ -1485,14 +1497,14 @@ static void
 test_augment(void **state)
 {
     struct lysp_augment *a = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_augment(YCTX, &in, NULL, &a)); \
+    assert_int_equal(LY_EVALID, parse_augment(YCTX, NULL, &a)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     FREE_ARRAY(YCTX->parsed_mod->mod->ctx, a, lysp_augment_free); a = NULL;
 
@@ -1505,7 +1517,7 @@ test_augment(void **state)
     /* full content */
     in.current = "/target/nodeid {action x; anydata any;anyxml anyxml; case cs; choice ch;container c;description test;if-feature f;leaf l {type string;}"
             "leaf-list ll {type string;} list li;notification not;reference test;status current;uses g;when true;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_augment(YCTX, &in, NULL, &a));
+    assert_int_equal(LY_SUCCESS, parse_augment(YCTX, NULL, &a));
     assert_non_null(a);
     assert_int_equal(LYS_AUGMENT, a->nodetype);
     assert_string_equal("/target/nodeid", a->nodeid);
@@ -1523,14 +1535,14 @@ static void
 test_when(void **state)
 {
     struct lysp_when *w = NULL;
-    struct ly_in in = {0};
 
+    YCTX_INIT;
     YCTX->parsed_mod->version = 2; /* simulate YANG 1.1 */
 
     /* invalid cardinality */
 #define TEST_DUP(MEMBER, VALUE1, VALUE2) \
     in.current = "l {" MEMBER" "VALUE1";"MEMBER" "VALUE2";} ..."; \
-    assert_int_equal(LY_EVALID, parse_when(YCTX, &in, &w)); \
+    assert_int_equal(LY_EVALID, parse_when(YCTX, &w)); \
     CHECK_LOG_CTX("Duplicate keyword \""MEMBER"\".", "Line number 1."); \
     FREE_MEMBER(YCTX->parsed_mod->mod->ctx, w, lysp_when_free); w = NULL;
 
@@ -1540,7 +1552,7 @@ test_when(void **state)
 
     /* full content */
     in.current = "expression {description test;reference test;m:ext;} ...";
-    assert_int_equal(LY_SUCCESS, parse_when(YCTX, &in, &w));
+    assert_int_equal(LY_SUCCESS, parse_when(YCTX, &w));
     assert_non_null(w);
     assert_string_equal("expression", w->cond);
     assert_string_equal("test", w->dsc);
@@ -1550,7 +1562,7 @@ test_when(void **state)
 
     /* empty condition */
     in.current = "\"\";";
-    assert_int_equal(LY_SUCCESS, parse_when(YCTX, &in, &w));
+    assert_int_equal(LY_SUCCESS, parse_when(YCTX, &w));
     CHECK_LOG_CTX("Empty argument of when statement does not make sense.", NULL);
     assert_non_null(w);
     assert_string_equal("", w->cond);
@@ -1560,17 +1572,18 @@ test_when(void **state)
 static void
 test_value(void **state)
 {
-    struct ly_in in = {0};
     int64_t val = 0;
     uint16_t flags = 0;
 
+    YCTX_INIT;
+
     in.current = "-0;";
-    assert_int_equal(parse_type_enum_value_pos(YCTX, &in, LY_STMT_VALUE, &val, &flags, NULL), LY_SUCCESS);
+    assert_int_equal(parse_type_enum_value_pos(YCTX, LY_STMT_VALUE, &val, &flags, NULL), LY_SUCCESS);
     assert_int_equal(val, 0);
 
     in.current = "-0;";
     flags = 0;
-    assert_int_equal(parse_type_enum_value_pos(YCTX, &in, LY_STMT_POSITION, &val, &flags, NULL), LY_EVALID);
+    assert_int_equal(parse_type_enum_value_pos(YCTX, LY_STMT_POSITION, &val, &flags, NULL), LY_EVALID);
     CHECK_LOG_CTX("Invalid value \"-0\" of \"position\".", "Line number 1.");
 }
 

--- a/tests/utests/schema/test_schema_common.c
+++ b/tests/utests/schema/test_schema_common.c
@@ -189,61 +189,61 @@ test_typedef(void **state)
 
     str = "module a {namespace urn:a; prefix a; typedef binary {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"binary\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"binary\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef bits {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"bits\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"bits\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef boolean {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"boolean\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"boolean\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef decimal64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"decimal64\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"decimal64\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef empty {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"empty\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"empty\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef enumeration {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"enumeration\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"enumeration\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int8 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"int8\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"int8\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int16 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"int16\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"int16\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int32 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"int32\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"int32\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"int64\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"int64\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef instance-identifier {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"instance-identifier\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"instance-identifier\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef identityref {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"identityref\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"identityref\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef leafref {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"leafref\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"leafref\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef string {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"string\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"string\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef union {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"union\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"union\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint8 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"uint8\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"uint8\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint16 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"uint16\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"uint16\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint32 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"uint32\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"uint32\" of typedef - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"uint64\" of typedef - name collision with a built-in type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"uint64\" of typedef - name collision with a built-in type.", NULL);
 
     str = "module mytypes {namespace urn:types; prefix t; typedef binary_ {type string;} typedef bits_ {type string;} typedef boolean_ {type string;} "
             "typedef decimal64_ {type string;} typedef empty_ {type string;} typedef enumeration_ {type string;} typedef int8_ {type string;} typedef int16_ {type string;}"
@@ -254,34 +254,34 @@ test_typedef(void **state)
 
     str = "module a {namespace urn:a; prefix a; typedef test {type string;} typedef test {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"test\" of typedef - name collision with another top-level type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"test\" of typedef - name collision with another top-level type.", NULL);
 
     str = "module a {namespace urn:a; prefix a; typedef x {type string;} container c {typedef x {type int8;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", NULL);
 
     str = "module a {namespace urn:a; prefix a; container c {container d {typedef y {type int8;}} typedef y {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"y\" of typedef - name collision with another scoped type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"y\" of typedef - name collision with another scoped type.", NULL);
 
     str = "module a {namespace urn:a; prefix a; container c {typedef y {type int8;} typedef y {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"y\" of typedef - name collision with sibling type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"y\" of typedef - name collision with sibling type.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} typedef x {type string;}}");
     str = "module a {namespace urn:a; prefix a; include b; typedef x {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"x\" of typedef - name collision with another top-level type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"x\" of typedef - name collision with another top-level type.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} container c {typedef x {type string;}}}");
     str = "module a {namespace urn:a; prefix a; include b; typedef x {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} typedef x {type int8;}}");
     str = "module a {namespace urn:a; prefix a; include b; container c {typedef x {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EEXIST);
-    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", "Line number 1.");
+    CHECK_LOG("Invalid name \"x\" of typedef - scoped type collide with a top-level type.", NULL);
 }
 
 void
@@ -330,7 +330,7 @@ test_accessible_tree(void **state)
             "}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
     CHECK_LOG_CTX("Invalid leafref path \"/cont/l\" - target is supposed to represent configuration data"
-            " (as the leafref does), but it does not.", "/b:cont2/l2");
+            " (as the leafref does), but it does not.", "Schema location /b:cont2/l2.");
 
     /* config -> state must */
     str = "module b {\n"
@@ -480,7 +480,7 @@ test_accessible_tree(void **state)
             "    }\n"
             "}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG_CTX("Not found node \"l\" in path.", "/h:rp/l2");
+    CHECK_LOG_CTX("Not found node \"l\" in path.", "Schema location /h:rp/l2.");
 
     /* rpc input -> rpc output must */
     str = "module h {\n"
@@ -523,7 +523,7 @@ test_accessible_tree(void **state)
             "    }\n"
             "}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG_CTX("Not found node \"notif\" in path.", "/i:rp/l2");
+    CHECK_LOG_CTX("Not found node \"notif\" in path.", "Schema location /i:rp/l2.");
 
     /* rpc input -> notif must */
     str = "module i {\n"
@@ -606,7 +606,7 @@ test_accessible_tree(void **state)
             "    }\n"
             "}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG_CTX("Not found node \"l\" in path.", "/k:cont/ll/act/l2");
+    CHECK_LOG_CTX("Not found node \"l\" in path.", "Schema location /k:cont/ll/act/l2.");
 
     /* action output -> action input must */
     str = "module k {\n"

--- a/tests/utests/schema/test_schema_stmts.c
+++ b/tests/utests/schema/test_schema_stmts.c
@@ -104,11 +104,11 @@ test_identity(void **state)
     assert_int_equal(1, LY_ARRAY_COUNT(mod->identities[1].derived));
     assert_ptr_equal(mod->identities[1].derived[0], &mod->identities[0]);
 
-    TEST_SCHEMA_ERR(0, 0, "inv", "identity i1;identity i1;", "Duplicate identifier \"i1\" of identity statement.", "Line number 1.");
+    TEST_SCHEMA_ERR(0, 0, "inv", "identity i1;identity i1;", "Duplicate identifier \"i1\" of identity statement.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule inv_sub {belongs-to inv {prefix inv;} identity i1;}");
     TEST_SCHEMA_ERR(0, 0, "inv", "include inv_sub;identity i1;",
-            "Duplicate identifier \"i1\" of identity statement.", "Line number 1.");
+            "Duplicate identifier \"i1\" of identity statement.", NULL);
     TEST_SCHEMA_ERR(0, 0, "inv", "identity i1 {base i2;}", "Unable to find base (i2) of identity \"i1\".", "/inv:{identity='i1'}");
     TEST_SCHEMA_ERR(0, 0, "inv", "identity i1 {base i1;}", "Identity \"i1\" is derived from itself.", "/inv:{identity='i1'}");
     TEST_SCHEMA_ERR(0, 0, "inv", "identity i1 {base i2;}identity i2 {base i3;}identity i3 {base i1;}",
@@ -122,12 +122,12 @@ test_identity(void **state)
     /* default value from non-implemented module */
     TEST_SCHEMA_ERR(0, 0, "ident2", "import base {prefix b;} leaf l {type identityref {base b:i1;} default b:i2;}",
             "Invalid default - value does not fit the type (Invalid identityref \"b:i2\" value"
-            " - identity found in non-implemented module \"base\".).", "/ident2:l");
+            " - identity found in non-implemented module \"base\".).", "Schema location /ident2:l.");
 
     /* default value in typedef from non-implemented module */
     TEST_SCHEMA_ERR(0, 0, "ident2", "import base {prefix b;} typedef t1 {type identityref {base b:i1;} default b:i2;}"
             "leaf l {type t1;}", "Invalid default - value does not fit the type (Invalid"
-            " identityref \"b:i2\" value - identity found in non-implemented module \"base\".).", "/ident2:l");
+            " identityref \"b:i2\" value - identity found in non-implemented module \"base\".).", "Schema location /ident2:l.");
 
     /*
      * printing
@@ -227,11 +227,11 @@ test_feature(void **state)
     TEST_SCHEMA_ERR(0, 0, "inv", "feature f1; feature f2{if-feature 'not f1';}",
             "Invalid value \"not f1\" of if-feature - YANG 1.1 expression in YANG 1.0 module.", NULL);
     TEST_SCHEMA_ERR(0, 0, "inv", "feature f1; feature f1;",
-            "Duplicate identifier \"f1\" of feature statement.", "Line number 1.");
+            "Duplicate identifier \"f1\" of feature statement.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule inv_sub {belongs-to inv {prefix inv;} feature f1;}");
     TEST_SCHEMA_ERR(0, 0, "inv", "include inv_sub;feature f1;",
-            "Duplicate identifier \"f1\" of feature statement.", "Line number 1.");
+            "Duplicate identifier \"f1\" of feature statement.", NULL);
     TEST_SCHEMA_ERR(0, 0, "inv", "feature f1 {if-feature f2;} feature f2 {if-feature f1;}",
             "Feature \"f1\" is indirectly referenced from itself.", NULL);
     TEST_SCHEMA_ERR(0, 0, "inv", "feature f1 {if-feature f1;}",

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -300,7 +300,7 @@ test_node_leaflist(void **state)
     CHECK_LOG_CTX("Leaf-list of type \"empty\" is allowed only in YANG 1.1 modules.", "/aa:ll");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {yang-version 1.1;namespace urn:bb;prefix bb;leaf-list ll {type empty; default x;}}", LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid empty value \"x\".).", "/bb:ll");
+    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid empty value \"x\".).", "Schema location /bb:ll.");
 
     assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, "module cc {yang-version 1.1;namespace urn:cc;prefix cc;"
             "leaf-list ll {config false;type string; default one;default two;default one;}}", LYS_IN_YANG, &mod));
@@ -315,7 +315,7 @@ test_node_leaflist(void **state)
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {yang-version 1.1; namespace urn:ee;prefix ee;"
             "leaf ref {type instance-identifier {require-instance true;} default \"/ee:g\";}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid default - value does not fit the type "
-            "(Invalid instance-identifier \"/ee:g\" value - semantic error.).", "/ee:ref");
+            "(Invalid instance-identifier \"/ee:g\" value - semantic error.).", "Schema location /ee:ref.");
 }
 
 static void
@@ -413,7 +413,7 @@ test_node_list(void **state)
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {yang-version 1.1;namespace urn:cc;prefix cc;feature f;"
             "list l {key x; leaf x {type string; if-feature f;}}}", LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Key \"x\" is disabled by its if-features.", "/cc:l/x");
+    CHECK_LOG_CTX("Key \"x\" is disabled by its if-features.", "Schema location /cc:l/x.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module dd {namespace urn:dd;prefix dd;"
             "list l {key x; leaf x {type string; config false;}}}", LYS_IN_YANG, NULL));
@@ -1636,26 +1636,26 @@ test_type_leafref(void **state)
     /* invalid paths */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;container a {leaf target2 {type uint8;}}"
             "leaf ref1 {type leafref {path ../a/invalid;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"invalid\" in path.", "/aa:ref1");
+    CHECK_LOG_CTX("Not found node \"invalid\" in path.", "Schema location /aa:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb;container a {leaf target2 {type uint8;}}"
             "leaf ref1 {type leafref {path ../../toohigh;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Too many parent references in path.", "/bb:ref1");
+    CHECK_LOG_CTX("Too many parent references in path.", "Schema location /bb:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {namespace urn:cc;prefix cc;container a {leaf target2 {type uint8;}}"
             "leaf ref1 {type leafref {path /a:invalid;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("No module connected with the prefix \"a\" found (prefix format schema stored mapping).", "/cc:ref1");
+    CHECK_LOG_CTX("No module connected with the prefix \"a\" found (prefix format schema stored mapping).", "Schema location /cc:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module dd {namespace urn:dd;prefix dd;leaf target1 {type string;}"
             "container a {leaf target2 {type uint8;}} leaf ref1 {type leafref {"
             "path '/a[target2 = current()/../target1]/target2';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("List predicate defined for container \"a\" in path.", "/dd:ref1");
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;container a {leaf target2 {type uint8;}}"
+    CHECK_LOG_CTX("List predicate defined for container \"a\" in path.", "Schema location /dd:ref1.");
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;\n  container a {leaf target2 {type uint8;}}\n"
             "leaf ref1 {type leafref {path /a!invalid;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x21 ('!'), perhaps \"a\" is supposed to be a function call.", NULL);
+    CHECK_LOG_CTX("Invalid character 0x21 ('!'), perhaps \"a\" is supposed to be a function call.", "Line number 3.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ff {namespace urn:ff;prefix ff;container a {leaf target2 {type uint8;}}"
             "leaf ref1 {type leafref {path /a;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid leafref path \"/a\" - target node is container instead of leaf or leaf-list.", "/ff:ref1");
+    CHECK_LOG_CTX("Invalid leafref path \"/a\" - target node is container instead of leaf or leaf-list.", "Schema location /ff:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg {namespace urn:gg;prefix gg;container a {leaf target2 {type uint8;"
             "status deprecated;}} leaf ref1 {type leafref {path /a/target2;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("A current definition \"ref1\" is not allowed to reference deprecated definition \"target2\".", "/gg:ref1");
+    CHECK_LOG_CTX("A current definition \"ref1\" is not allowed to reference deprecated definition \"target2\".", "Schema location /gg:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module hh {namespace urn:hh;prefix hh;"
             "leaf ref1 {type leafref;}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Missing path substatement for leafref type.", "/hh:ref1");
@@ -1664,10 +1664,10 @@ test_type_leafref(void **state)
     CHECK_LOG_CTX("Missing path substatement for leafref type mytype.", "/ii:ref1");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module jj {namespace urn:jj;prefix jj;feature f;"
             "leaf ref {type leafref {path /target;}}leaf target {if-feature f;type string;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"target\" in path.", "/jj:ref");
+    CHECK_LOG_CTX("Not found node \"target\" in path.", "Schema location /jj:ref.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module kk {namespace urn:kk;prefix kk;"
             "leaf ref {type leafref {path /target;}}leaf target {type string;config false;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid leafref path \"/target\" - target is supposed to represent configuration data (as the leafref does), but it does not.", "/kk:ref");
+    CHECK_LOG_CTX("Invalid leafref path \"/target\" - target is supposed to represent configuration data (as the leafref does), but it does not.", "Schema location /kk:ref.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ll {namespace urn:ll;prefix ll;"
             "leaf ref {type leafref {path /target; require-instance true;}}leaf target {type string;}}", LYS_IN_YANG, &mod));
@@ -1676,127 +1676,127 @@ test_type_leafref(void **state)
             "leaf ref {type mytype;}leaf target {type string;}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Leafref type \"mytype\" can be restricted by require-instance statement only in YANG 1.1 modules.", "/mm:ref");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module nn {namespace urn:nn;prefix nn;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}"
-            "leaf address {type leafref{ path \"/interface[name is current()/../ifname]/ip\";}}}",
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module nn {namespace urn:nn;prefix nn;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
+            "leaf address {type leafref{\n path \"/interface[name is current()/../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x69 ('i'), perhaps \"name\" is supposed to be a function call.", NULL);
+    CHECK_LOG_CTX("Invalid character 0x69 ('i'), perhaps \"name\" is supposed to be a function call.", "Line number 5.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo {namespace urn:oo;prefix oo;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}"
-            "leaf address {type leafref{ path \"/interface[name=current()/../ifname/ip\";}}}",
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo {namespace urn:oo;prefix oo;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
+            "leaf address {type leafref{\n path \"/interface[name=current()/../ifname/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath expression end.", NULL);
+    CHECK_LOG_CTX("Unexpected XPath expression end.", "Line number 5.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module pp {namespace urn:pp;prefix pp;"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
             "leaf ifname{type leafref{ path \"../interface/name\";}}"
             "leaf address {type leafref{ path \"/interface[x:name=current()/../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("No module connected with the prefix \"x\" found (prefix format schema stored mapping).", "/pp:address");
+    CHECK_LOG_CTX("No module connected with the prefix \"x\" found (prefix format schema stored mapping).", "Schema location /pp:address.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module qq {namespace urn:qq;prefix qq;"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
             "leaf ifname{type leafref{ path \"../interface/name\";}}"
             "leaf address {type leafref{ path \"/interface[id=current()/../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"id\" in path.", "/qq:address");
+    CHECK_LOG_CTX("Not found node \"id\" in path.", "Schema location /qq:address.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module rr {namespace urn:rr;prefix rr;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module rr {namespace urn:rr;prefix rr;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name=current() /  .. / ifname][name=current()/../test]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Duplicate predicate key \"name\" in path.", NULL);
+    CHECK_LOG_CTX("Duplicate predicate key \"name\" in path.", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ss {namespace urn:ss;prefix ss;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ss {namespace urn:ss;prefix ss;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = ../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"FunctionName\".", NULL);
+    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"FunctionName\".", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module tt {namespace urn:tt;prefix tt;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module tt {namespace urn:tt;prefix tt;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"]\".", NULL);
+    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"]\".", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module uu {namespace urn:uu;prefix uu;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module uu {namespace urn:uu;prefix uu;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/..ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character number 31 of expression '/interface[name = current()/..ifname]/ip'.", NULL);
+    CHECK_LOG_CTX("Invalid character number 31 of expression '/interface[name = current()/..ifname]/ip'.", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module vv {namespace urn:vv;prefix vv;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module vv {namespace urn:vv;prefix vv;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"NameTest\" (\"ifname]/ip\"), expected \"..\".", NULL);
+    CHECK_LOG_CTX("Unexpected XPath token \"NameTest\" (\"ifname]/ip\"), expected \"..\".", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ww {namespace urn:ww;prefix ww;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ww {namespace urn:ww;prefix ww;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/../]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"]\" (\"]/ip\").", NULL);
+    CHECK_LOG_CTX("Unexpected XPath token \"]\" (\"]/ip\").", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module xx {namespace urn:xx;prefix xx;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module xx {namespace urn:xx;prefix xx;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/../$node]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x24 ('$'), perhaps \"\" is supposed to be a function call.", NULL);
+    CHECK_LOG_CTX("Invalid character 0x24 ('$'), perhaps \"\" is supposed to be a function call.", "Line number 4.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module yy {namespace urn:yy;prefix yy;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module yy {namespace urn:yy;prefix yy;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
             "leaf address {type leafref{ path \"/interface[name=current()/../x:ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("No module connected with the prefix \"x\" found (prefix format schema stored mapping).", "/yy:address");
+    CHECK_LOG_CTX("No module connected with the prefix \"x\" found (prefix format schema stored mapping).", "Schema location /yy:address.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zz {namespace urn:zz;prefix zz;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zz {namespace urn:zz;prefix zz;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
             "leaf address {type leafref{ path \"/interface[name=current()/../xxx]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"xxx\" in path.", "/zz:address");
+    CHECK_LOG_CTX("Not found node \"xxx\" in path.", "Schema location /zz:address.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zza {namespace urn:zza;prefix zza;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}container c;"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zza {namespace urn:zza;prefix zza;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}container c;\n"
             "leaf address {type leafref{ path \"/interface[name=current()/../c]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Leaf expected instead of container \"c\" in leafref predicate in path.", "/zza:address");
+    CHECK_LOG_CTX("Leaf expected instead of container \"c\" in leafref predicate in path.", "Schema location /zza:address.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzb {namespace urn:zzb;prefix zzb;"
-            "list interface{key name;leaf name{type string;}leaf ip {type string;}container c;}"
-            "leaf ifname{type leafref{ path \"../interface/name\";}}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzb {namespace urn:zzb;prefix zzb;\n"
+            "list interface{key name;leaf name{type string;}leaf ip {type string;}container c;}\n"
+            "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
             "leaf address {type leafref{ path \"/interface[c=current()/../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Key expected instead of container \"c\" in path.", "/zzb:address");
+    CHECK_LOG_CTX("Key expected instead of container \"c\" in path.", "Schema location /zzb:address.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzc {namespace urn:zzc;prefix zzc;"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzc {namespace urn:zzc;prefix zzc;\n"
             "leaf source {type leafref {path \"../target\";}default true;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"target\" in path.", "/zzc:source");
+    CHECK_LOG_CTX("Not found node \"target\" in path.", "Schema location /zzc:source.");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzd {namespace urn:zzd;prefix zzd;"
-            "leaf source {type leafref {path \"../target\";}default true;}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module zzd {namespace urn:zzd;prefix zzd;\n"
+            "leaf source {type leafref {path \"../target\";}default true;}\n"
             "leaf target {type uint8;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid uint8 value \"true\".).", "/zzd:source");
+    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid uint8 value \"true\".).", "Schema location /zzd:source.");
 
     /* circular chain */
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aaa {namespace urn:aaa;prefix aaa;"
-            "leaf ref1 {type leafref {path /ref2;}}"
-            "leaf ref2 {type leafref {path /ref3;}}"
-            "leaf ref3 {type leafref {path /ref4;}}"
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aaa {namespace urn:aaa;prefix aaa;\n"
+            "leaf ref1 {type leafref {path /ref2;}}\n"
+            "leaf ref2 {type leafref {path /ref3;}}\n"
+            "leaf ref3 {type leafref {path /ref4;}}\n"
             "leaf ref4 {type leafref {path /ref1;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid leafref path \"/ref1\" - circular chain of leafrefs detected.", "/aaa:ref4");
+    CHECK_LOG_CTX("Invalid leafref path \"/ref1\" - circular chain of leafrefs detected.", "Schema location /aaa:ref4.");
 }
 
 static void
@@ -1806,7 +1806,7 @@ test_type_empty(void **state)
     /* invalid */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;"
             "leaf l {type empty; default x;}}", LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid empty value \"x\".).", "/aa:l");
+    CHECK_LOG_CTX("Invalid default - value does not fit the type (Invalid empty value \"x\".).", "Schema location /aa:l.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb;typedef mytype {type empty; default x;}"
             "leaf l {type mytype;}}", LYS_IN_YANG, NULL));
@@ -1989,7 +1989,7 @@ test_status(void **state)
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {namespace urn:dd;prefix d;"
             "container c {leaf l {status obsolete; type string;}}"
             "container d {leaf m {when \"../../c/l\"; type string;}}}", LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("A current definition \"m\" is not allowed to reference obsolete definition \"l\".", "/cc:d/m");
+    CHECK_LOG_CTX("A current definition \"m\" is not allowed to reference obsolete definition \"l\".", "Schema location /cc:d/m.");
 }
 
 static void
@@ -2296,13 +2296,13 @@ test_refine(void **state)
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;import grp {prefix g;}"
             "uses g:grp {refine c/l {mandatory true;}}}", LYS_IN_YANG, &mod));
-    // CHECK_LOG_CTX("Invalid refine of mandatory - leaf already has \"default\" statement.", "/ee:{uses='g:grp'}/{refine='c/l'}");
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ee:{uses='g:grp'}/ee:c/l");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ee:{uses='g:grp'}/ee:c/l",
+            "Invalid mandatory leaf with a default value.", "/ee:{uses='g:grp'}/ee:c/l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ef {namespace urn:ef;prefix ef;import grp {prefix g;}"
             "uses g:grp {refine c/ch {mandatory true;}}}", LYS_IN_YANG, &mod));
-    // CHECK_LOG_CTX("Invalid refine of mandatory - choice already has \"default\" statement.", "/ef:{uses='g:grp'}/{refine='c/ch'}");
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ef:{uses='g:grp'}/ef:c/ch");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ef:{uses='g:grp'}/ef:c/ch",
+            "Invalid mandatory choice with a default case.", "/ef:{uses='g:grp'}/ef:c/ch");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ff {namespace urn:ff;prefix ff;import grp {prefix g;}"
             "uses g:grp {refine c/ch/ca/ca {mandatory true;}}}", LYS_IN_YANG, &mod));
@@ -2310,13 +2310,13 @@ test_refine(void **state)
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg {namespace urn:gg;prefix gg;import grp {prefix g;}"
             "uses g:grp {refine c/x {default hello;}}}", LYS_IN_YANG, &mod));
-    // CHECK_LOG_CTX("Invalid refine of default - the node is mandatory.", "/gg:{uses='g:grp'}/{refine='c/x'}");
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/gg:{uses='g:grp'}/gg:c/x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/gg:{uses='g:grp'}/gg:c/x",
+            "Invalid mandatory leaf with a default value.", "/gg:{uses='g:grp'}/gg:c/x");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module hh {namespace urn:hh;prefix hh;import grp {prefix g;}"
             "uses g:grp {refine c/c/l {config true;}}}", LYS_IN_YANG, &mod));
-    // CHECK_LOG_CTX("Invalid refine of config - configuration node cannot be child of any state data node.", "/hh:{uses='g:grp'}/{refine='c/c/l'}");
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/hh:{uses='g:grp'}/hh:c/c/l");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/hh:{uses='g:grp'}/hh:c/c/l",
+            "Configuration node cannot be child of any state data node.", "/hh:{uses='g:grp'}/hh:c/c/l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ii {namespace urn:ii;prefix ii;grouping grp {leaf l {type string; status deprecated;}}"
             "uses grp {status obsolete;}}", LYS_IN_YANG, &mod));
@@ -2466,7 +2466,7 @@ test_augment(void **state)
 
     assert_int_equal(LY_ENOTFOUND, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; container c {leaf a {type string;}}"
             "augment /x {leaf a {type int8;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Augment target node \"/x\" from module \"aa\" was not found.", NULL);
+    CHECK_LOG_CTX("Augment target node \"/x\" from module \"aa\" was not found.", "/aa:{augment='/x'}");
 
     assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb; container c {leaf a {type string;}}"
             "augment /c {leaf a {type int8;}}}", LYS_IN_YANG, &mod));
@@ -2873,7 +2873,7 @@ test_deviation(void **state)
 
     assert_int_equal(LY_ENOTFOUND, lys_parse_mem(UTEST_LYCTX, "module aa1 {namespace urn:aa1;prefix aa1;import a {prefix a;}"
             "deviation /a:top/a:z {deviate not-supported;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Deviation(s) target node \"/a:top/a:z\" from module \"aa1\" was not found.", NULL);
+    CHECK_LOG_CTX("Deviation(s) target node \"/a:top/a:z\" from module \"aa1\" was not found.", "/a:{deviation='/a:top/a:z'}");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa2 {namespace urn:aa2;prefix aa2;import a {prefix a;}"
             "deviation /a:top/a:a {deviate not-supported;}"
@@ -2931,13 +2931,12 @@ test_deviation(void **state)
     CHECK_LOG_CTX("Invalid deviation adding \"default\" property which already exists (with value \"x:ba\").", "/gg1:{deviation='/e:b'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg2 {namespace urn:gg2;prefix gg2; import e {prefix e;}"
             "deviation /e:a {deviate add {default x:a;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation adding \"default\" property \"x:a\" of choice. "
-                  "The prefix does not match any imported module of the deviation module. /gg2:{deviation='/e:a'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/e:a");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/e:a",
+            "Default case prefix \"x\" not found in imports of \"gg2\".", "/e:a");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg3 {namespace urn:gg3;prefix gg3; import e {prefix e;}"
             "deviation /e:a {deviate add {default a;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation adding \"default\" property \"a\" of choice - the specified case does not exists.", "/gg3:{deviation='/e:a'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/e:a");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/e:a",
+            "Default case \"a\" not found.", "/e:a");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg4 {namespace urn:gg4;prefix gg4; import e {prefix e;}"
             "deviation /e:c {deviate add {default hi;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid deviation adding \"default\" property which already exists (with value \"hello\").", "/gg4:{deviation='/e:c'}");
@@ -2947,8 +2946,8 @@ test_deviation(void **state)
     CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/e:a");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg5 {namespace urn:gg5;prefix gg5; leaf x {type string; mandatory true;}"
             "deviation /x {deviate add {default error;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation combining default value and mandatory leaf.", "/gg5:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/gg5:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/gg5:{deviation='/x'}",
+            "Invalid mandatory leaf with a default value.", "/gg5:{deviation='/x'}");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module hh1 {yang-version 1.1; namespace urn:hh1;prefix hh1; import e {prefix e;}"
             "deviation /e:d {deviate replace {default hi;}}}", LYS_IN_YANG, &mod));
@@ -2972,8 +2971,8 @@ test_deviation(void **state)
     CHECK_LOG_CTX("Invalid deviation of case node - it is not possible to add \"config\" property.", "/jj1:{deviation='/ch/a'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module jj2 {namespace urn:jj2;prefix jj2; container top {config false; leaf x {type string;}}"
             "deviation /top/x {deviate add {config true;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation of config - configuration node cannot be child of any state data node.", "/jj2:{deviation='/top/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/jj2:top/x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/jj2:{deviation='/top/x'}",
+            "Configuration node cannot be child of any state data node.", "/jj2:{deviation='/top/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module jj3 {namespace urn:jj3;prefix jj3; container top {leaf x {type string;}}"
             "deviation /top/x {deviate replace {config false;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid deviation replacing \"config\" property \"config false\" which is not present.", "/jj3:{deviation='/top/x'}");
@@ -2982,8 +2981,8 @@ test_deviation(void **state)
     CHECK_LOG_CTX("Invalid deviation of case node - it is not possible to replace \"config\" property.", "/jj4:{deviation='/ch/a'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module jj5 {namespace urn:jj5;prefix jj5; container top {leaf x {type string; config true;}}"
             "deviation /top {deviate add {config false;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation of config - configuration node cannot be child of any state data node.", "/jj5:{deviation='/top'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/jj5:top");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/jj5:top",
+            "Configuration node cannot be child of any state data node.", "/jj5:top/x");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module jj6 {namespace urn:jj6;prefix jj6; leaf x {config false; type string;}"
             "deviation /x {deviate add {config true;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid deviation adding \"config\" property which already exists (with value \"config false\").", "/jj6:{deviation='/x'}");
@@ -3003,33 +3002,33 @@ test_deviation(void **state)
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ll1 {namespace urn:ll1;prefix ll1; leaf x {default test; type string;}"
             "deviation /x {deviate add {mandatory true;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation combining default value and mandatory leaf.", "/ll1:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll1:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll1:{deviation='/x'}",
+            "Invalid mandatory leaf with a default value.", "/ll1:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ll2 {yang-version 1.1; namespace urn:ll2;prefix ll2; leaf-list x {default test; type string;}"
             "deviation /x {deviate add {min-elements 1;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation combining default value and mandatory leaf-list.", "/ll2:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll2:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll2:{deviation='/x'}",
+            "The default statement is present on leaf-list with a nonzero min-elements.", "/ll2:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ll2 {namespace urn:ll2;prefix ll2; choice ch {default a; leaf a {type string;} leaf b {type string;}}"
             "deviation /ch {deviate add {mandatory true;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid deviation combining default case and mandatory choice.", "/ll2:{deviation='/ch'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll2:ch");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/ll2:ch",
+            "Invalid mandatory choice with a default case.", "/ll2:ch");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm1 {namespace urn:mm1;prefix mm1; leaf-list x {min-elements 10; type string;}"
             "deviation /x {deviate add {max-elements 5;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid combination of min-elements and max-elements after deviation: min value 10 is bigger than max value 5.", "/mm1:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm1:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm1:{deviation='/x'}",
+            "Leaf-list min-elements 10 is bigger than max-elements 5.", "/mm1:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm2 {namespace urn:mm2;prefix mm2; leaf-list x {max-elements 10; type string;}"
             "deviation /x {deviate add {min-elements 20;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid combination of min-elements and max-elements after deviation: min value 20 is bigger than max value 10.", "/mm2:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm2:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm2:{deviation='/x'}",
+            "Leaf-list min-elements 20 is bigger than max-elements 10.", "/mm2:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm3 {namespace urn:mm3;prefix mm3; list x {min-elements 5; max-elements 10; config false;}"
             "deviation /x {deviate replace {max-elements 1;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid combination of min-elements and max-elements after deviation: min value 5 is bigger than max value 1.", "/mm3:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm3:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm3:{deviation='/x'}",
+            "List min-elements 5 is bigger than max-elements 1.", "/mm3:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm4 {namespace urn:mm4;prefix mm4; list x {min-elements 5; max-elements 10; config false;}"
             "deviation /x {deviate replace {min-elements 20;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Invalid combination of min-elements and max-elements after deviation: min value 20 is bigger than max value 10.", "/mm4:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm4:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm4:{deviation='/x'}",
+            "List min-elements 20 is bigger than max-elements 10.", "/mm4:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm5 {namespace urn:mm5;prefix mm5; leaf-list x {type string; min-elements 5;}"
             "deviation /x {deviate add {min-elements 1;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid deviation adding \"min-elements\" property which already exists (with value \"5\").", "/mm5:{deviation='/x'}");
@@ -3060,27 +3059,27 @@ test_deviation(void **state)
     CHECK_LOG_CTX("Invalid deviation of anyxml node - it is not possible to replace \"type\" property.", "/nn1:{deviation='/x'}");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module nn2 {namespace urn:nn2;prefix nn2; leaf-list x {type string;}"
             "deviation /x {deviate replace {type empty;}}}", LYS_IN_YANG, &mod));
-    /*CHECK_LOG_CTX("Leaf-list of type \"empty\" is allowed only in YANG 1.1 modules.", "/nn2:{deviation='/x'}");*/
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/nn2:x");
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/nn2:{deviation='/x'}",
+            "Leaf-list of type \"empty\" is allowed only in YANG 1.1 modules.", "/nn2:{deviation='/x'}");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo1 {namespace urn:oo1;prefix oo1; leaf x {type uint16; default 300;}"
             "deviation /x {deviate replace {type uint8;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid default - value does not fit the type "
-            "(Value \"300\" is out of uint8's min/max bounds.).", "/oo1:x");
+            "(Value \"300\" is out of uint8's min/max bounds.).", "Schema location /oo1:x.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo2 {yang-version 1.1;namespace urn:oo2;prefix oo2; leaf-list x {type uint16; default 10; default 300;}"
             "deviation /x {deviate replace {type uint8;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid default - value does not fit the type "
-            "(Value \"300\" is out of uint8's min/max bounds.).", "/oo2:x");
+            "(Value \"300\" is out of uint8's min/max bounds.).", "Schema location /oo2:x.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo3 {namespace urn:oo3;prefix oo3; leaf x {type uint8;}"
             "deviation /x {deviate add {default 300;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid default - value does not fit the type "
-            "(Value \"300\" is out of uint8's min/max bounds.).", "/oo3:x");
+            "(Value \"300\" is out of uint8's min/max bounds.).", "Schema location /oo3:x.");
 
     assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, "module pp {namespace urn:pp;prefix pp; leaf l { type leafref {path /c/x;}}"
             "container c {leaf x {type string;} leaf y {type string;}}}", LYS_IN_YANG, &mod));
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module pp1 {namespace urn:pp1;prefix pp1; import pp {prefix pp;}"
             "deviation /pp:c/pp:x {deviate not-supported;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Not found node \"x\" in path.", "/pp:l");
+    CHECK_LOG_CTX("Not found node \"x\" in path.", "Schema location /pp:l.");
 }
 
 static void
@@ -3112,7 +3111,7 @@ test_when(void **state)
             "    }\n"
             "}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("When condition of \"val\" includes a self-reference (referenced by when of \"cont2\").", "/a:cont/lst/val");
+    CHECK_LOG_CTX("When condition includes a self-reference.", "Schema location /a:cont/lst/val.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX,
             "module a {\n"
@@ -3140,7 +3139,7 @@ test_when(void **state)
             "    }\n"
             "}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("When condition of \"val\" includes a self-reference (referenced by when of \"cont2\").", "/a:cont/lst/val");
+    CHECK_LOG_CTX("When condition includes a self-reference.", "Schema location /a:cont/lst/val.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX,
             "module a {\n"
@@ -3152,7 +3151,7 @@ test_when(void **state)
             "    }\n"
             "}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("When condition of \"val\" is accessing its own conditional node.", "/a:val");
+    CHECK_LOG_CTX("When condition is accessing its own conditional node.", "Schema location /a:val.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX,
             "module a {\n"
@@ -3168,7 +3167,7 @@ test_when(void **state)
             "    }\n"
             "}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("When condition of \"val\" is accessing its own conditional node.", "/a:val");
+    CHECK_LOG_CTX("When condition is accessing its own conditional node.", "Schema location /a:val.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX,
             "module a {\n"
@@ -3183,7 +3182,7 @@ test_when(void **state)
             "    container cont;\n"
             "}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("When condition of \"val\" is accessing its own conditional node.", "/a:cont/val");
+    CHECK_LOG_CTX("When condition is accessing its own conditional node.", "Schema location /a:cont/val.");
 }
 
 int

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -2335,9 +2335,9 @@ test_refine(void **state)
     CHECK_LOG_CTX("Invalid refine of leaf node - it is not possible to replace \"min-elements\" property.", "/ll:{uses='g:grp'}/ll:c/x/{refine='c/x'}");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module mm {namespace urn:mm;prefix mm;import grp {prefix g;}"
-            "uses g:grp {refine c/ll {min-elements 10;}}}", LYS_IN_YANG, &mod));
-    // CHECK_LOG_CTX("Invalid refine of min-elements statement - \"min-elements\" is bigger than \"max-elements\".", "/mm:{uses='g:grp'}/{refine='c/ll'}");
-    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm:{uses='g:grp'}/mm:c/ll");
+            "uses g:grp {refine c/ll {min-elements 1;}}}", LYS_IN_YANG, &mod));
+    CHECK_LOG_CTX("Compilation of a deviated and/or refined node failed.", "/mm:{uses='g:grp'}/mm:c/ll",
+            "The default statement is present on leaf-list with a nonzero min-elements.", "/mm:{uses='g:grp'}/mm:c/ll");
 }
 
 static void


### PR DESCRIPTION
Extend location information provided by validation error messages. It is possible to provide more than one of the location types (line number, schema path, data path or manual path). However, providing always the most appropriate/precise information is still an object to improve - because various issues are detected in different parts of the processing, the most relevant location information is not always available (e.g. source of deviation).