### PR TITLE
data tree: Added the API to find the dnode with simple xpath.

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -7987,3 +7987,54 @@ lyd_set_private(const struct lyd_node *node, void *priv)
 }
 
 #endif
+
+API struct lyd_node *
+lyd_find_path_hash_based(struct lyd_node *data_tree, const struct ly_ctx *ctx, const char *path, int output)
+{
+	FUN_IN;
+
+	const char *id;
+	struct lyd_node *node, *parent = NULL;
+	int parsed = 0;
+	int options = 0;
+
+	if (!path || (!data_tree && !ctx)
+			|| (!data_tree && (path[0] != '/'))) {
+		LOGARG;
+		return NULL;
+	}
+
+	/* The only relevant option is LYD_PATH_OPT_OUTPUT  */
+	if (output)
+		options = LYD_PATH_OPT_OUTPUT;
+
+
+	if (!ctx) {
+		ctx = data_tree->schema->module->ctx;
+	}
+
+	id = path;
+
+	if (data_tree) {
+		if (path[0] == '/') {
+			/* absolute path, go through all the siblings and try to find the right parent, if exists,
+			 * first go through all the next siblings keeping the original order, for positional predicates */
+			for (node = data_tree; !parsed && node; node = node->next) {
+				parent = resolve_partial_json_data_nodeid(id, NULL, node, options, &parsed);
+			}
+			if (!parsed) {
+				for (node = data_tree->prev; !parsed && node->next; node = node->prev) {
+					parent = resolve_partial_json_data_nodeid(id, NULL, node, options, &parsed);
+				}
+			}
+		} else {
+			/* relative path, use only the provided data tree root */
+			parent = resolve_partial_json_data_nodeid(id, NULL, data_tree, options, &parsed);
+		}
+		if (parsed == -1) {
+			return NULL;
+		}
+	}
+
+	return parent;
+}

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -1440,6 +1440,23 @@ int lyd_lyb_data_length(const char *data);
  */
 void *lyd_set_private(const struct lyd_node *node, void *priv);
 
+/**
+ * @brief Get the data node based on a simple XPath.
+ * This API returns the closest parent of the node (or the node itself)
+ * identified by the nodeid (path). This API uses lyd_find_sibling() If cache is
+ * enabled and the siblings are NOT top-level nodes, this function finds the
+ * node in a constant time.
+ * @param[in] data_tree Existing data tree to get.
+ * @param[in] ctx Context to use.
+ * @param[in] path Simple data path (see @ref howtoxpath).
+ * @param[in] output possible values are 1 and 0. output value maps to pathoption.
+ * Only valid pathoption in this API context is LYD_PATH_OPT_OUTPUT.
+ * Pass 1 if pathotion LYD_PATH_OPT_OUTPUT to use, else pass 0.
+ * NULL If no lyd_node exists for the given xpath.
+ */
+struct lyd_node * lyd_find_path_hash_based(struct lyd_node *data_tree, const struct ly_ctx *ctx, const char *path,
+										   int output);
+
 #endif
 
 /**@} */


### PR DESCRIPTION
This API is a wrapper over the lyd_find_sibling and takes the
input as simple xpath.

Issue #1094

Signed-off-by: vishaldhingra <vdhingra@vmware.com>