### PR TITLE
explicitly set tmp to empty string to avoid buffer overflow of strlen…

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -172,6 +172,7 @@ print_expr_struct_debug(struct lyxp_expr *exp)
 {
     uint16_t i, j;
     char tmp[DBG_BUFF_SIZE];
+    tmp[0] = 0;
 
     if (!exp || (ly_log_level < LY_LLDBG)) {
         return;


### PR DESCRIPTION
… if tmp happens to contain non-zero garbage