### PR TITLE
schema BUGFIX allow do not touch features settings

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -456,7 +456,9 @@ uint32_t ly_ctx_internal_modules_count(const struct ly_ctx *ctx);
  * @param[in] name Name of the module to load.
  * @param[in] revision Optional revision date of the module. If not specified, the latest revision is loaded.
  * @param[in] features Optional array of features ended with NULL to be enabled if the module is being implemented.
- * NULL for all features disabled and '*' for all enabled.
+ * The feature string '*' enables all and array of length 1 with only the terminating NULL explicitly disables all
+ * the features. In case the parameter is NULL, the features are untouched - left disabled in newly loaded module or
+ * with the current features settings in case the module is already present in the context.
  * @return Pointer to the data model structure, NULL if not found or some error occurred.
  */
 const struct lys_module *ly_ctx_load_module(struct ly_ctx *ctx, const char *name, const char *revision,

--- a/src/schema_features.c
+++ b/src/schema_features.c
@@ -560,6 +560,9 @@ lys_set_features(struct lysp_module *pmod, const char **features)
     ly_bool change = 0;
 
     if (!features) {
+        /* do not touch the features */
+
+    } else if (!features[0]) {
         /* disable all the features */
         while ((f = lysp_feature_next(f, pmod, &i))) {
             if (f->flags & LYS_FENABLED) {

--- a/src/schema_features.h
+++ b/src/schema_features.h
@@ -47,7 +47,10 @@ LY_ERR lys_enable_features(struct lysp_module *pmod, const char **features);
  * @brief Set the specified features of a parsed module, with all the checks.
  *
  * @param[in] pmod Parsed module to modify.
- * @param[in] features Array of features ended with NULL to set. NULL for all features disabled, '*' for all enabled.
+ * @param[in] features Array of features ended with NULL to be enabled if the module is being implemented.
+ * The feature string '*' enables all and array of length 1 with only the terminating NULL explicitly disables all
+ * the features. In case the parameter is NULL, the features are untouched - left disabled in newly loaded module or
+ * with the current features settings in case the module is already present in the context.
  * @return LY_SUCCESS on success.
  * @return LY_EEXIST if the specified features were already set.
  * @return LY_ERR on error.

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -2172,9 +2172,11 @@ const struct lysc_node *lys_find_child(const struct lysc_node *parent, const str
  *
  * @param[in] mod Module to make implemented. It is not an error
  * to provide already implemented module, it just does nothing.
- * @param[in] features Optional array of features ended with NULL to be enabled. NULL for all features disabled
- * and '*' for all enabled. If the module is already implemented, these features are still correctly set and all
- * the modules recompiled.
+ * @param[in] features Optional array of features ended with NULL to be enabled if the module is being implemented.
+ * The feature string '*' enables all and array of length 1 with only the terminating NULL explicitly disables all
+ * the features. In case the parameter is NULL, the features are untouched - left disabled in newly implemented module or
+ * with the current features settings in case the module is already implemented. If the features changes already implemented
+ * module, the context is recompiled.
  * @return LY_SUCCESS on success.
  * @return LY_EDENIED in case the context contains some other revision of the same module which is already implemented.
  * @return LY_ERR on other errors during module compilation.

--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -871,7 +871,14 @@ search_file:
      * module found, make sure it is implemented if should be
      */
     if (implement) {
-        if ((*mod)->implemented) {
+        if (!(*mod)->implemented) {
+            /* implement */
+            ret = lys_set_implemented_r(*mod, features, unres);
+            if (ret) {
+                *mod = NULL;
+                return ret;
+            }
+        } else if (features) {
             /* set features if different */
             ret = lys_set_features((*mod)->parsed, features);
             if (!ret) {
@@ -881,13 +888,6 @@ search_file:
                 /* error */
                 return ret;
             } /* else no feature changes */
-        } else {
-            /* implement */
-            ret = lys_set_implemented_r(*mod, features, unres);
-            if (ret) {
-                *mod = NULL;
-                return ret;
-            }
         }
     }
 


### PR DESCRIPTION
With LY_CTX_ALL_IMPLEMENTED flag, even the imported modules became
implemented and its features were set (disabled). But when importing modules,
we don't want to set the features (we don't know how). It is because it is done
by a common code shared with other functions where the caller is able to set
the features setting and we want to follow his willing. Therefore, we need a
way to say "do not touch the features". In newly implemented module it means
that all features are disabled, for already implemented modules the
features setttings do not change.

This "do not touch" way is available not only internally when importing
module, but it was also propagated to the API functions.

Fixes #1355