### PR TITLE
Do not segfault when loading empty XML files

### DIFF
--- a/src/xml.c
+++ b/src/xml.c
@@ -1253,7 +1253,7 @@ lyxml_parse_mem(struct ly_ctx *ctx, const char *data, int options)
 
 repeat:
     /* process document */
-    while (1) {
+    while (c) {
         if (!*c) {
             /* eof */
             return first;
@@ -1288,6 +1288,10 @@ repeat:
             LOGVAL(ctx, LYE_XML_INCHAR, LY_VLOG_NONE, NULL, c);
             goto error;
         }
+    }
+
+    if (!c) {
+        goto error;
     }
 
     root = lyxml_parse_elem(ctx, c, &len, NULL, options);


### PR DESCRIPTION
```
$ touch empty.xml
$ sysrepocfg --import=empty.xml --format=xml --datastore=running
ThreadSanitizer:DEADLYSIGNAL
==12949==ERROR: ThreadSanitizer: SEGV on unknown address 0x000000000000 (pc 0x7f8b121637f8 bp 0x000000000001 sp 0x7fff4257f350 T12949)
==12949==The signal is caused by a READ memory access.
==12949==Hint: address points to the zero page.
 #0 lyxml_parse_mem /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/libyang/src/xml.c:1257:14 (libyang.so.1+0x377f8)
 #1 lyd_parse_ /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/libyang/src/tree_data.c:951:15 (libyang.so.1+0xb7e79)
 #2 lyd_parse_data_ /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/libyang/src/tree_data.c:1039:12 (libyang.so.1+0xa6476)
 #3 lyd_parse_fd_ /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/libyang/src/tree_data.c:1074:11 (libyang.so.1+0xa66be)
 #4 lyd_parse_path /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/libyang/src/tree_data.c:1117:11 (libyang.so.1+0xa67e1)
 #5 step_load_data /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/sysrepo/src/executables/sysrepocfg.c:235:17 (sysrepocfg+0x4d3041)
 #6 op_import /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/sysrepo/src/executables/sysrepocfg.c:299:9 (sysrepocfg+0x4d206a)
 #7 main /home/jkt/work/cesnet/gerrit/CzechLight/cla-sysrepo/submodules/dependencies/sysrepo/src/executables/sysrepocfg.c:871:14 (sysrepocfg+0x4d1832)
 #8 __libc_start_main <null> (libc.so.6+0x23dbc)
 #9 _start /build/glibc-2.32/csu/../sysdeps/x86_64/start.S:120 (sysrepocfg+0x4235d9)
```

Fixes: https://github.com/sysrepo/sysrepo/issues/2294