### PR TITLE
Fix various errors reported by UBSAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
 endif()
 
-set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
+set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99 -fno-strict-aliasing")
 set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_PACKAGE "-g -O3 -DNDEBUG")
 set(CMAKE_C_FLAGS_DEBUG   "-g -Og")

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -5561,7 +5561,7 @@ _lyd_dup_node(const struct lyd_node *node, const struct lys_node *schema, struct
         new_any = calloc(1, sizeof *new_any);
         new_node = (struct lyd_node *)new_any;
         LY_CHECK_ERR_GOTO(!new_node, LOGMEM(ctx), error);
-        new_node->schema = (struct lys_node *)schema;
+        new_any->schema = (struct lys_node *)schema;
 
         if (_lyd_dup_node_common(new_node, node, ctx, options)) {
             goto error;

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -3285,7 +3285,9 @@ lys_node_dup_recursion(struct lys_module *module, struct lys_node *parent, const
             }
         }
     } else {
-        memcpy(retval->iffeature, node->iffeature, retval->iffeature_size * sizeof *retval->iffeature);
+        if (node->iffeature_size) {
+            memcpy(retval->iffeature, node->iffeature, retval->iffeature_size * sizeof *retval->iffeature);
+        }
     }
 
     /*


### PR DESCRIPTION
## Fix undefined behavior on memcpy()

libnetconf2's test `test_server_thread` eventually ends up in this stack trace:

```
libyang/src/tree_schema.c:3288:16: runtime error: null pointer passed as argument 1, which is declared to never be null
/nix/store/ypih4394q488ljr421x8jak55vmr0ckn-glibc-2.32-dev/include/string.h:44:28: note: nonnull attribute specified here
#0 0x7f565ebf8f6e in lys_node_dup_recursion libyang/src/tree_schema.c:3288:9
#1 0x7f565ebf3409 in lys_node_dup libyang/src/tree_schema.c:3609:14
#2 0x7f565ebbf62c in yang_check_deviation libyang/src/parser_yang.c:4646:26
#3 0x7f565eba6531 in yang_check_sub_module libyang/src/parser_yang.c:4784:13
#4 0x7f565eba3d1c in yang_read_module libyang/src/parser_yang.c:2705:13
#5 0x7f565ebd1077 in lys_parse_mem_ libyang/src/tree_schema.c:1083:15
#6 0x7f565ebd31ab in lys_parse_fd_ libyang/src/tree_schema.c:1271:14
#7 0x7f565e92f291 in ly_ctx_load_localfile libyang/src/context.c:916:39
#8 0x7f565e92c31b in ly_ctx_load_sub_module libyang/src/context.c:1063:19
#9 0x7f565e92fdcc in ly_ctx_load_module libyang/src/context.c:1102:12
#10 0x597422 in main libnetconf2/tests/test_server_thread.c:686:5
#11 0x7f565dc98dbc in __libc_start_main (/nix/store/kah5n342wz4i0s9lz9ka4bgz91xa2i94-glibc-2.32/lib/libc.so.6+0x23dbc)
#12 0x42a4d9 in _start /build/glibc-2.32/csu/../sysdeps/x86_64/start.S:120
```

In other words, it would call `memcpy` with the source parameter being NULL, which is [explicitly said to be undefined behavior](https://www.imperialviolet.org/2016/06/26/nonnull.html).

## Disable strict pointer aliasing
    
I'm not really a C-level language lawyer, but the way how the code routinely uses two differently-types pointers to access the same object is undefined behavior in C. Just having "the same layout" of individual struct members [does not make these types compatible](https://en.cppreference.com/w/c/language/type#Compatible_types), and that means that it is necessary to disable [strict aliasing](https://en.cppreference.com/w/c/language/object#Strict_aliasing) rules in the whole of libyang, as far as I can tell.

## Fix a warning from UBSAN
    
I won't pretend I understand what UBSAN is really trying to tell me
here, but that assignment can be rewritten in a way which does not cause
the following warning:
```
libyang/src/tree_data.c:5564:19: runtime error: member access within address 0x60600005c7e0 with insufficient space for an object of type 'struct lyd_node'
0x60600005c7e0: note: pointer points here
1c 00 00 26  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
	   ^
```
Fixes: https://github.com/sysrepo/sysrepo/issues/2295