### PR TITLE
data tree REFACTOR use common union in all data nodes

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -102,7 +102,7 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
         /* find next node parent */
         parent = node;
         while (parent->parent && (!diff_parent || (parent->parent->schema != diff_parent->schema))) {
-            parent = (struct lyd_node *)parent->parent;
+            parent = lyd_parent(parent);
         }
         if (parent == node) {
             /* no more parents to find */
@@ -127,14 +127,14 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
 
     /* find the first duplicated parent */
     if (!diff_parent) {
-        diff_parent = (struct lyd_node *)dup->parent;
+        diff_parent = lyd_parent(dup);
         while (diff_parent && diff_parent->parent) {
-            diff_parent = (struct lyd_node *)diff_parent->parent;
+            diff_parent = lyd_parent(diff_parent);
         }
     } else {
-        diff_parent = (struct lyd_node *)dup;
+        diff_parent = dup;
         while (diff_parent->parent && (diff_parent->parent->schema == parent->schema)) {
-            diff_parent = (struct lyd_node *)diff_parent->parent;
+            diff_parent = lyd_parent(diff_parent);
         }
     }
 
@@ -754,7 +754,7 @@ lyd_diff_get_op(const struct lyd_node *diff_node, enum lyd_diff_op *op)
     const struct lyd_node *diff_parent;
     const char *str;
 
-    for (diff_parent = diff_node; diff_parent; diff_parent = (struct lyd_node *)diff_parent->parent) {
+    for (diff_parent = diff_node; diff_parent; diff_parent = lyd_parent(diff_parent)) {
         LY_LIST_FOR(diff_parent->meta, meta) {
             if (!strcmp(meta->name, "operation") && !strcmp(meta->annotation->module->name, "yang")) {
                 str = meta->value.canonical;
@@ -810,7 +810,7 @@ lyd_diff_insert(struct lyd_node **first_node, struct lyd_node *parent_node, stru
         return lyd_insert_child(parent_node, new_node);
     }
 
-    assert(!(*first_node)->parent || ((struct lyd_node *)(*first_node)->parent == parent_node));
+    assert(!(*first_node)->parent || (lyd_parent(*first_node) == parent_node));
 
     if (!lysc_is_userordered(new_node->schema)) {
         /* simple insert */

--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -880,7 +880,7 @@ lyb_parse_subtree_r(struct lyd_lyb_ctx *lybctx, struct lyd_node_inner *parent, s
     }
 
     /* insert, keep first pointer correct */
-    lyd_insert_node((struct lyd_node *)parent, first, node);
+    lyd_insert_node(&parent->node, first, node);
     while (!parent && (*first)->prev->next) {
         *first = (*first)->prev;
     }

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -603,7 +603,7 @@ lydxml_subtree_r(struct lyd_xml_ctx *lydctx, struct lyd_node_inner *parent, stru
     }
 
     /* insert, keep first pointer correct */
-    lyd_insert_node((struct lyd_node *)parent, first_p, node);
+    lyd_insert_node(&parent->node, first_p, node);
     while (!parent && (*first_p)->prev->next) {
         *first_p = (*first_p)->prev;
     }

--- a/src/path.c
+++ b/src/path.c
@@ -923,7 +923,7 @@ ly_path_eval_partial(const struct ly_path *path, const struct lyd_node *start, L
     } else {
         /* absolute path, start from the first top-level sibling */
         while (start->parent) {
-            start = (struct lyd_node *)start->parent;
+            start = lyd_parent(start);
         }
         while (start->prev->next) {
             start = start->prev;

--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -59,7 +59,7 @@ lyd_print_all(struct ly_out *out, const struct lyd_node *root, LYD_FORMAT format
     if (root) {
         /* get first top-level sibling */
         while (root->parent) {
-            root = (struct lyd_node *)root->parent;
+            root = lyd_parent(root);
         }
         while (root->prev->next) {
             root = root->prev;

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -403,7 +403,7 @@ json_print_attribute(struct jsonpr_ctx *ctx, const struct lyd_node_opaq *node, c
 
     for (attr = node->attr; attr; attr = attr->next) {
         PRINT_COMMA;
-        json_print_member2(ctx, (struct lyd_node *)node, attr->format, &attr->name, 0);
+        json_print_member2(ctx, &node->node, attr->format, &attr->name, 0);
 
         if (attr->hints & (LYD_VALHINT_BOOLEAN | LYD_VALHINT_DECNUM)) {
             ly_print_(ctx->out, "%s", attr->value[0] ? attr->value : "null");
@@ -763,26 +763,24 @@ json_print_opaq(struct jsonpr_ctx *ctx, const struct lyd_node_opaq *node)
     ly_bool first = 1, last = 1;
 
     if (node->hints & (LYD_NODEHINT_LIST | LYD_NODEHINT_LEAFLIST)) {
-        const struct lyd_node_opaq *prev = (const struct lyd_node_opaq *)node->prev;
-        const struct lyd_node_opaq *next = (const struct lyd_node_opaq *)node->next;
-        if (prev->next && matching_node((const struct lyd_node *)prev, (const struct lyd_node *)node)) {
+        if (node->prev->next && matching_node(node->prev, &node->node)) {
             first = 0;
         }
-        if (next && matching_node((const struct lyd_node *)node, (const struct lyd_node *)next)) {
+        if (node->next && matching_node(&node->node, node->next)) {
             last = 0;
         }
     }
 
     if (first) {
-        LY_CHECK_RET(json_print_member2(ctx, node->parent, node->format, &node->name, 0));
+        LY_CHECK_RET(json_print_member2(ctx, lyd_parent(&node->node), node->format, &node->name, 0));
 
         if (node->hints & (LYD_NODEHINT_LIST | LYD_NODEHINT_LEAFLIST)) {
-            LY_CHECK_RET(json_print_array_open(ctx, (struct lyd_node *)node));
+            LY_CHECK_RET(json_print_array_open(ctx, &node->node));
             LEVEL_INC;
         }
     }
     if (node->child || (node->hints & (LYD_NODEHINT_LIST | LYD_NODEHINT_LEAFLIST))) {
-        LY_CHECK_RET(json_print_inner(ctx, (struct lyd_node *)node));
+        LY_CHECK_RET(json_print_inner(ctx, &node->node));
         LEVEL_PRINTED;
     } else {
         if (node->hints & LYD_VALHINT_EMPTY) {

--- a/src/printer_lyb.c
+++ b/src/printer_lyb.c
@@ -919,7 +919,7 @@ lyb_print_subtree(struct ly_out *out, const struct lyd_node *node, struct hash_t
     LY_CHECK_RET(lyb_write_start_subtree(out, lybctx->lybctx));
 
     /* write model info first */
-    if (!node->schema && !((struct lyd_node_opaq *)node)->parent) {
+    if (!node->schema && !lyd_parent(node)) {
         LY_CHECK_RET(lyb_print_model(out, NULL, lybctx->lybctx));
     } else if (node->schema && !lysc_data_parent(node->schema)) {
         LY_CHECK_RET(lyb_print_model(out, node->schema->module, lybctx->lybctx));

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -323,7 +323,7 @@ xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
     ly_bool dynamic;
     const char *value;
 
-    xml_print_node_open(ctx, (struct lyd_node *)node);
+    xml_print_node_open(ctx, &node->node);
     value = ((struct lysc_node_leaf *)node->schema)->type->plugin->print(&node->value, LY_PREF_XML, &ns_list, &dynamic);
 
     /* print namespaces connected with the values's prefixes */
@@ -358,7 +358,7 @@ xml_print_inner(struct xmlpr_ctx *ctx, const struct lyd_node_inner *node)
     LY_ERR ret;
     struct lyd_node *child;
 
-    xml_print_node_open(ctx, (struct lyd_node *)node);
+    xml_print_node_open(ctx, &node->node);
 
     LY_LIST_FOR(node->child, child) {
         if (ly_should_print(child, ctx->options)) {
@@ -394,7 +394,7 @@ xml_print_anydata(struct xmlpr_ctx *ctx, const struct lyd_node_any *node)
     uint32_t prev_opts, prev_lo;
     LY_ERR ret;
 
-    xml_print_node_open(ctx, (struct lyd_node *)node);
+    xml_print_node_open(ctx, &node->node);
 
     if (!any->value.tree) {
         /* no content */

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -326,7 +326,7 @@ struct lysc_type;
     }\
     if (!(LYD_TREE_DFS_next)) { \
         /* no children */ \
-        if ((ELEM) == (struct lyd_node*)(START)) { \
+        if ((ELEM) == (struct lyd_node *)(START)) { \
             /* we are done, (START) has no children */ \
             break; \
         } \
@@ -335,7 +335,7 @@ struct lysc_type;
     } \
     while (!(LYD_TREE_DFS_next)) { \
         /* parent is already processed, go to its sibling */ \
-        (ELEM) = (struct lyd_node*)(ELEM)->parent; \
+        (ELEM) = (struct lyd_node *)(ELEM)->parent; \
         /* no siblings, go back through parents */ \
         if ((ELEM)->parent == (START)->parent) { \
             /* we are done, no next element to process */ \
@@ -498,7 +498,6 @@ struct lyd_attr {
     LY_PREFIX_FORMAT format;        /**< format of the attribute and any prefixes, ::LY_PREF_XML or ::LY_PREF_JSON */
     void *val_prefix_data;          /**< format-specific prefix data */
     uint32_t hints;                 /**< additional information about from the data source, see the [hints list](@ref lydhints) */
-
 };
 
 #define LYD_NODE_INNER (LYS_CONTAINER|LYS_LIST|LYS_RPC|LYS_ACTION|LYS_NOTIF) /**< Schema nodetype mask for lyd_node_inner */
@@ -558,20 +557,26 @@ struct lyd_node {
  * @brief Data node structure for the inner data tree nodes - containers, lists, RPCs, actions and Notifications.
  */
 struct lyd_node_inner {
-    uint32_t hash;                   /**< hash of this particular node (module name + schema name + key string values if list or
-                                          hashes of all nodes of subtree in case of keyless list). Note that while hash can be
-                                          used to get know that nodes are not equal, it cannot be used to decide that the
-                                          nodes are equal due to possible collisions. */
-    uint32_t flags;                  /**< [data node flags](@ref dnodeflags) */
-    const struct lysc_node *schema;  /**< pointer to the schema definition of this node */
-    struct lyd_node_inner *parent;   /**< pointer to the parent node, NULL in case of root node */
-    struct lyd_node *next;           /**< pointer to the next sibling node (NULL if there is no one) */
-    struct lyd_node *prev;           /**< pointer to the previous sibling node \note Note that this pointer is
-                                          never NULL. If there is no sibling node, pointer points to the node
-                                          itself. In case of the first node, this pointer points to the last
-                                          node in the list. */
-    struct lyd_meta *meta;           /**< pointer to the list of metadata of this node */
-    void *priv;                      /**< private user data, not used by libyang */
+    union {
+        struct lyd_node node;               /**< implicit cast for the members compatible with ::lyd_node */
+        struct {
+            uint32_t hash;                  /**< hash of this particular node (module name + schema name + key string
+                                                 values if list or hashes of all nodes of subtree in case of keyless
+                                                 list). Note that while hash can be used to get know that nodes are
+                                                 not equal, it cannot be used to decide that the nodes are equal due
+                                                 to possible collisions. */
+            uint32_t flags;                 /**< [data node flags](@ref dnodeflags) */
+            const struct lysc_node *schema; /**< pointer to the schema definition of this node */
+            struct lyd_node_inner *parent;  /**< pointer to the parent node, NULL in case of root node */
+            struct lyd_node *next;          /**< pointer to the next sibling node (NULL if there is no one) */
+            struct lyd_node *prev;          /**< pointer to the previous sibling node \note Note that this pointer is
+                                                 never NULL. If there is no sibling node, pointer points to the node
+                                                 itself. In case of the first node, this pointer points to the last
+                                                 node in the list. */
+            struct lyd_meta *meta;          /**< pointer to the list of metadata of this node */
+            void *priv;                     /**< private user data, not used by libyang */
+        };
+    };                                      /**< common part corresponding to ::lyd_node */
 
     struct lyd_node *child;          /**< pointer to the first child node. */
     struct hash_table *children_ht;  /**< hash table with all the direct children (except keys for a list, lists without keys) */
@@ -582,51 +587,63 @@ struct lyd_node_inner {
  * @brief Data node structure for the terminal data tree nodes - leaves and leaf-lists.
  */
 struct lyd_node_term {
-    uint32_t hash;                   /**< hash of this particular node (module name + schema name + key string values if list or
-                                          hashes of all nodes of subtree in case of keyless list). Note that while hash can be
-                                          used to get know that nodes are not equal, it cannot be used to decide that the
-                                          nodes are equal due to possible collisions. */
-    uint32_t flags;                  /**< [data node flags](@ref dnodeflags) */
-    const struct lysc_node *schema;  /**< pointer to the schema definition of this node */
-    struct lyd_node_inner *parent;   /**< pointer to the parent node, NULL in case of root node */
-    struct lyd_node *next;           /**< pointer to the next sibling node (NULL if there is no one) */
-    struct lyd_node *prev;           /**< pointer to the previous sibling node \note Note that this pointer is
-                                          never NULL. If there is no sibling node, pointer points to the node
-                                          itself. In case of the first node, this pointer points to the last
-                                          node in the list. */
-    struct lyd_meta *meta;           /**< pointer to the list of metadata of this node */
-    void *priv;                      /**< private user data, not used by libyang */
+    union {
+        struct lyd_node node;               /**< implicit cast for the members compatible with ::lyd_node */
+        struct {
+            uint32_t hash;                  /**< hash of this particular node (module name + schema name + key string
+                                                 values if list or hashes of all nodes of subtree in case of keyless
+                                                 list). Note that while hash can be used to get know that nodes are
+                                                 not equal, it cannot be used to decide that the nodes are equal due
+                                                 to possible collisions. */
+            uint32_t flags;                 /**< [data node flags](@ref dnodeflags) */
+            const struct lysc_node *schema; /**< pointer to the schema definition of this node */
+            struct lyd_node_inner *parent;  /**< pointer to the parent node, NULL in case of root node */
+            struct lyd_node *next;          /**< pointer to the next sibling node (NULL if there is no one) */
+            struct lyd_node *prev;          /**< pointer to the previous sibling node \note Note that this pointer is
+                                                 never NULL. If there is no sibling node, pointer points to the node
+                                                 itself. In case of the first node, this pointer points to the last
+                                                 node in the list. */
+            struct lyd_meta *meta;          /**< pointer to the list of metadata of this node */
+            void *priv;                     /**< private user data, not used by libyang */
+        };
+    };                                      /**< common part corresponding to ::lyd_node */
 
     struct lyd_value value;          /**< node's value representation */
 };
 
 /**
- * @brief Data node structure for the anydata data tree nodes - anydatas and anyxmls.
+ * @brief Data node structure for the anydata data tree nodes - anydata or anyxml.
  */
 struct lyd_node_any {
-    uint32_t hash;                   /**< hash of this particular node (module name + schema name + key string values if list or
-                                          hashes of all nodes of subtree in case of keyless list). Note that while hash can be
-                                          used to get know that nodes are not equal, it cannot be used to decide that the
-                                          nodes are equal due to possible collisions. */
-    uint32_t flags;                  /**< [data node flags](@ref dnodeflags) */
-    const struct lysc_node *schema;  /**< pointer to the schema definition of this node */
-    struct lyd_node_inner *parent;   /**< pointer to the parent node, NULL in case of root node */
-    struct lyd_node *next;           /**< pointer to the next sibling node (NULL if there is no one) */
-    struct lyd_node *prev;           /**< pointer to the previous sibling node \note Note that this pointer is
-                                          never NULL. If there is no sibling node, pointer points to the node
-                                          itself. In case of the first node, this pointer points to the last
-                                          node in the list. */
-    struct lyd_meta *meta;           /**< pointer to the list of metadata of this node */
-    void *priv;                      /**< private user data, not used by libyang */
+    union {
+        struct lyd_node node;               /**< implicit cast for the members compatible with ::lyd_node */
+        struct {
+            uint32_t hash;                  /**< hash of this particular node (module name + schema name + key string
+                                                 values if list or hashes of all nodes of subtree in case of keyless
+                                                 list). Note that while hash can be used to get know that nodes are
+                                                 not equal, it cannot be used to decide that the nodes are equal due
+                                                 to possible collisions. */
+            uint32_t flags;                 /**< [data node flags](@ref dnodeflags) */
+            const struct lysc_node *schema; /**< pointer to the schema definition of this node */
+            struct lyd_node_inner *parent;  /**< pointer to the parent node, NULL in case of root node */
+            struct lyd_node *next;          /**< pointer to the next sibling node (NULL if there is no one) */
+            struct lyd_node *prev;          /**< pointer to the previous sibling node \note Note that this pointer is
+                                                 never NULL. If there is no sibling node, pointer points to the node
+                                                 itself. In case of the first node, this pointer points to the last
+                                                 node in the list. */
+            struct lyd_meta *meta;          /**< pointer to the list of metadata of this node */
+            void *priv;                     /**< private user data, not used by libyang */
+        };
+    };                                      /**< common part corresponding to ::lyd_node */
 
     union lyd_any_value {
-        struct lyd_node *tree;       /**< data tree */
-        const char *str;             /**< Generic string data */
-        const char *xml;             /**< Serialized XML data */
-        const char *json;            /**< I-JSON encoded string */
-        char *mem;                   /**< LYD_ANYDATA_LYB memory chunk */
-    } value;                         /**< pointer to the stored value representation of the anydata/anyxml node */
-    LYD_ANYDATA_VALUETYPE value_type;/**< type of the data stored as ::lyd_node_any.value */
+        struct lyd_node *tree;          /**< data tree */
+        const char *str;                /**< Generic string data */
+        const char *xml;                /**< Serialized XML data */
+        const char *json;               /**< I-JSON encoded string */
+        char *mem;                      /**< LYD_ANYDATA_LYB memory chunk */
+    } value;                            /**< pointer to the stored value representation of the anydata/anyxml node */
+    LYD_ANYDATA_VALUETYPE value_type;   /**< type of the data stored as ::lyd_node_any.value */
 };
 
 /**
@@ -690,14 +707,22 @@ struct lyd_node_any {
  * @brief Data node structure for unparsed (opaque) nodes.
  */
 struct lyd_node_opaq {
-    uint32_t hash;                  /**< always 0 */
-    uint32_t flags;                 /**< always 0 */
-    const struct lysc_node *schema; /**< always NULL */
-    struct lyd_node *parent;        /**< pointer to the parent node (NULL in case of root node) */
-    struct lyd_node *next;          /**< pointer to the next sibling node (NULL if there is no one) */
-    struct lyd_node *prev;          /**< pointer to the previous sibling node (last sibling if there is none) */
-    struct lyd_attr *attr;          /**< pointer to the list of generic attributes of this node */
-    void *priv;                     /**< private user data, not used by libyang */
+    union {
+        struct lyd_node node;               /**< implicit cast for the members compatible with ::lyd_node */
+        struct {
+            uint32_t hash;                  /**< always 0 */
+            uint32_t flags;                 /**< always 0 */
+            const struct lysc_node *schema; /**< always NULL */
+            struct lyd_node_inner *parent;  /**< pointer to the parent node, NULL in case of root node */
+            struct lyd_node *next;          /**< pointer to the next sibling node (NULL if there is no one) */
+            struct lyd_node *prev;          /**< pointer to the previous sibling node \note Note that this pointer is
+                                                 never NULL. If there is no sibling node, pointer points to the node
+                                                 itself. In case of the first node, this pointer points to the last
+                                                 node in the list. */
+            struct lyd_meta *meta;          /**< always NULL */
+            void *priv;                     /**< private user data, not used by libyang */
+        };
+    };                                      /**< common part corresponding to ::lyd_node */
 
     struct lyd_node *child;         /**< pointer to the child node (compatible with ::lyd_node_inner) */
 
@@ -707,6 +732,7 @@ struct lyd_node_opaq {
     void *val_prefix_data;          /**< format-specific prefix data */
     uint32_t hints;                 /**< additional information about from the data source, see the [hints list](@ref lydhints) */
 
+    struct lyd_attr *attr;          /**< pointer to the list of generic attributes of this node */
     const struct ly_ctx *ctx;       /**< libyang context */
 };
 

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -214,7 +214,7 @@ lyd_free_(struct lyd_node *node, ly_bool top)
 
     /* get the first (top-level) sibling */
     if (top) {
-        for ( ; node->parent; node = (struct lyd_node *)node->parent) {}
+        for ( ; node->parent; node = lyd_parent(node)) {}
     }
     while (node->prev->next) {
         node = node->prev;

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -34,7 +34,7 @@ lyd_hash_keyless_list_dfs(struct lyd_node *child, uint32_t *hash)
         switch (iter->schema->nodetype) {
         case LYS_CONTAINER:
         case LYS_LIST:
-            lyd_hash_keyless_list_dfs(((struct lyd_node_inner *)iter)->child, hash);
+            lyd_hash_keyless_list_dfs(lyd_child(iter), hash);
             break;
         case LYS_LEAFLIST:
         case LYS_ANYXML:

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -92,7 +92,7 @@ lyd_parent(const struct lyd_node *node)
         return NULL;
     }
 
-    return (struct lyd_node *)(node)->parent;
+    return &node->parent->node;
 }
 
 API struct lyd_node *
@@ -106,7 +106,7 @@ lyd_child(const struct lyd_node *node)
 
     if (!node->schema) {
         /* opaq node */
-        return ((struct lyd_node_opaq *)(node))->child;
+        return ((struct lyd_node_opaq *)node)->child;
     }
 
     children = lyd_node_children_p((struct lyd_node *)node);
@@ -128,7 +128,7 @@ lyd_child_no_keys(const struct lyd_node *node)
 
     if (!node->schema) {
         /* opaq node */
-        return ((struct lyd_node_opaq *)(node))->child;
+        return ((struct lyd_node_opaq *)node)->child;
     }
 
     children = lyd_node_children_p((struct lyd_node *)node);


### PR DESCRIPTION
Also, now redundant casting removed where possible.
Fixes #1388