### PR TITLE
data tree REFACTOR inline access functions, cleanup includes

### DIFF
--- a/src/tree.h
+++ b/src/tree.h
@@ -17,8 +17,6 @@
 
 #include <inttypes.h>
 
-#include "tree_data.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -196,31 +194,6 @@ extern "C" {
 #define LY_LIST_FOR_SAFE(START, NEXT, ELEM) \
     for ((ELEM) = (START); \
          (ELEM) ? (NEXT = (ELEM)->next, 1) : 0; \
-         (ELEM) = (NEXT))
-
-/**
- * @brief Macro to iterate via all schema node data instances in data siblings.
- *
- * @param START Pointer to the starting sibling. Even if it is not first, all the siblings are searched.
- * @param SCHEMA Schema node of the searched instances.
- * @param ELEM Iterator.
- */
-#define LYD_LIST_FOR_INST(START, SCHEMA, ELEM) \
-    for (lyd_find_sibling_val(START, SCHEMA, NULL, 0, &(ELEM)); \
-         (ELEM) && ((ELEM)->schema == (SCHEMA)); \
-         (ELEM) = (ELEM)->next)
-
-/**
- * @brief Macro to iterate via all schema node data instances in data siblings allowing to modify the list itself.
- *
- * @param START Pointer to the starting sibling. Even if it is not first, all the siblings are searched.
- * @param SCHEMA Schema node of the searched instances.
- * @param NEXT Temporary storage to allow removing of the current iterator content.
- * @param ELEM Iterator.
- */
-#define LYD_LIST_FOR_INST_SAFE(START, SCHEMA, NEXT, ELEM) \
-    for (lyd_find_sibling_val(START, SCHEMA, NULL, 0, &(ELEM)); \
-         (ELEM) && ((ELEM)->schema == (SCHEMA)) ? ((NEXT) = (ELEM)->next, 1) : 0; \
          (ELEM) = (NEXT))
 
 /**

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -26,9 +26,9 @@
 #include "tree_schema.h"
 
 static void
-lyd_hash_keyless_list_dfs(struct lyd_node *child, uint32_t *hash)
+lyd_hash_keyless_list_dfs(const struct lyd_node *child, uint32_t *hash)
 {
-    struct lyd_node *iter;
+    const struct lyd_node *iter;
 
     LY_LIST_FOR(child, iter) {
         switch (iter->schema->nodetype) {

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -86,38 +86,6 @@ lyd_node_children_p(struct lyd_node *node)
 }
 
 API struct lyd_node *
-lyd_parent(const struct lyd_node *node)
-{
-    if (!node) {
-        return NULL;
-    }
-
-    return &node->parent->node;
-}
-
-API struct lyd_node *
-lyd_child(const struct lyd_node *node)
-{
-    struct lyd_node **children;
-
-    if (!node) {
-        return NULL;
-    }
-
-    if (!node->schema) {
-        /* opaq node */
-        return ((struct lyd_node_opaq *)node)->child;
-    }
-
-    children = lyd_node_children_p((struct lyd_node *)node);
-    if (children) {
-        return *children;
-    } else {
-        return NULL;
-    }
-}
-
-API struct lyd_node *
 lyd_child_no_keys(const struct lyd_node *node)
 {
     struct lyd_node **children;


### PR DESCRIPTION
Also move LYD walk functions to tree_data.h removes requirement to
include tree_data.h in tree.h. tree_data.h now includes tree_schema.h to
allow for inlining. so now it's:

  tree                         for #include "tree.h"
  tree->tree_schema            for #include "tree_schema.h"
  tree->tree_schema->tree_data for #include "tree_data.h"

which better represents the organizational dependencies than what came
before:

  [tree_data]->tree              for #include "tree.h"
  [tree_data]->tree->tree_schema for #include "tree_schema.h"
  tree_data->tree                for #include "tree_data.h"