### PR TITLE
data tree BUGFIX handle when in mandatory true node

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -8432,7 +8432,7 @@ lyxp_get_root_type(const struct lyd_node *ctx_node, const struct lysc_node *ctx_
     if (op || !(options & LYXP_SCHEMA)) {
         /* general root that can access everything */
         return LYXP_NODE_ROOT;
-    } else if (!ctx_node || (ctx_node->schema->flags & LYS_CONFIG_W)) {
+    } else if (!ctx_node || !ctx_node->schema || (ctx_node->schema->flags & LYS_CONFIG_W)) {
         /* root context node can access only config data (because we said so, it is unspecified) */
         return LYXP_NODE_ROOT_CONFIG;
     }


### PR DESCRIPTION
when validation creates opaque context node with no schema, then does an lyxp_eval on it which doesn't check for NULL schema. Check for this. Add UT which exposes the problem (and shows fixed). 