### PR TITLE
data tree BUGFIX endless loop when inserting leaf and NP container

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -4255,6 +4255,8 @@ lyd_replace(struct lyd_node *orig, struct lyd_node *repl)
         orig->parent->child = repl;
     }
 
+    orig->parent = NULL;
+
     /* predecessor */
     if (orig->prev == orig) {
         /* the old was alone */
@@ -4283,7 +4285,10 @@ lyd_replace(struct lyd_node *orig, struct lyd_node *repl)
     }
 
 finish:
-    /* remove the old one */
+    /* the node is already unlinked, remove it from parent's hash table. */
+#ifdef LY_ENABLED_CACHE
+    lyd_unlink_hash(orig, repl->parent);
+#endif
     lyd_free(orig);
 }
 


### PR DESCRIPTION
Hi,
This PR is used to fix an endless loop issue, which can be reproduced with following code and data.

schema:
```
module A{
yang-version 1.1;
prefix a;
namespace "urn:a";

container T{
	leaf f0{
		type string { length 0..5; }
	}
	leaf f1{
		type string { length 0..5; }
	}
	leaf f2{
		type string { length 0..5; }
		default "a";
	}
	leaf f3{
		type string { length 0..5; }
		default "b";
	}
}

}
```
b.json:
```
{
	"A:T": {
		"f0":"1",
		"f1":"2"
	}
}
```
code:
```
int main()
{
    struct ly_ctx *ctx = ly_ctx_new(NULL, 0);
    assert(ctx != NULL);

    const struct lys_module *m = lys_parse_path(ctx, "A.yang", LYS_IN_YANG);
    assert(m != NULL);

    struct lyd_node *d = lyd_parse_path(ctx, "b.json", LYD_JSON, LYD_OPT_CONFIG);
    assert(d);

    struct lyd_node *f2 = lyd_new_leaf(d, NULL, "f2", "bbb");
    assert(f2);

    struct lyd_node *f3 = lyd_new_leaf(d, NULL, "f3", "bbb");
    assert(f3);

    lyd_print_file(stdout, d, LYD_JSON, 0);

    lyd_free_withsiblings(d);

    ly_ctx_destroy(ctx, NULL);

    return 0;
}
```

The reason for this issue seems that the data tree is damaged when inserting `f2`, which causes endless loop when inserting `f3`.
