### PR TITLE
schema REFACTOR compiling nodes' flags

### DIFF
--- a/src/schema_compile.h
+++ b/src/schema_compile.h
@@ -37,17 +37,19 @@ struct lyxp_expr;
  *
  * @{
  */
-#define LYS_COMPILE_RPC_INPUT       LYS_IS_INPUT    /**< Internal option when compiling schema tree of RPC/action input */
-#define LYS_COMPILE_RPC_OUTPUT      LYS_IS_OUTPUT   /**< Internal option when compiling schema tree of RPC/action output */
-#define LYS_COMPILE_NOTIFICATION    LYS_IS_NOTIF    /**< Internal option when compiling schema tree of Notification */
-
-#define LYS_COMPILE_GROUPING        0x08            /**< Compiling (validation) of a non-instantiated grouping.
+#define LYS_COMPILE_GROUPING        0x01            /**< Compiling (validation) of a non-instantiated grouping.
                                                       In this case not all the restrictions are checked since they can
                                                       be valid only in the real placement of the grouping.
                                                       TODO - what specifically is not done */
-#define LYS_COMPILE_DISABLED        0x10            /**< Compiling a disabled subtree (by its if-features). Meaning
+#define LYS_COMPILE_DISABLED        0x02            /**< Compiling a disabled subtree (by its if-features). Meaning
                                                       it will be removed at the end of compilation and should not be
                                                       added to any unres sets. */
+#define LYS_COMPILE_NO_CONFIG       0x04            /**< ignore config statements, neither inherit config value */
+
+#define LYS_COMPILE_RPC_INPUT       (LYS_IS_INPUT | LYS_COMPILE_NO_CONFIG)  /**< Internal option when compiling schema tree of RPC/action input */
+#define LYS_COMPILE_RPC_OUTPUT      (LYS_IS_OUTPUT | LYS_COMPILE_NO_CONFIG) /**< Internal option when compiling schema tree of RPC/action output */
+#define LYS_COMPILE_NOTIFICATION    (LYS_IS_NOTIF | LYS_COMPILE_NO_CONFIG)  /**< Internal option when compiling schema tree of Notification */
+
 /** @} scflags */
 
 /**

--- a/src/schema_compile_amend.c
+++ b/src/schema_compile_amend.c
@@ -699,9 +699,10 @@ lys_apply_refine(struct lysc_ctx *ctx, struct lysp_refine *rfn, struct lysp_node
 
     /* config */
     if (rfn->flags & LYS_CONFIG_MASK) {
-        if (ctx->options & (LYS_COMPILE_NOTIFICATION | LYS_COMPILE_RPC_INPUT | LYS_COMPILE_RPC_OUTPUT)) {
+        if (ctx->options & LYS_COMPILE_NO_CONFIG) {
             LOGWRN(ctx->ctx, "Refining config inside %s has no effect (%s).",
-                    ctx->options & LYS_COMPILE_NOTIFICATION ? "notification" : "RPC/action", ctx->path);
+                    (ctx->options & (LYS_IS_INPUT | LYS_IS_OUTPUT)) ? "RPC/action" :
+                    ctx->options & LYS_IS_NOTIF ? "notification" : "a subtree ignoring config", ctx->path);
         } else {
             target->flags &= ~LYS_CONFIG_MASK;
             target->flags |= rfn->flags & LYS_CONFIG_MASK;


### PR DESCRIPTION
Avoid mixing compilation (setting up) of different node's flags and
clarify the purpose and use of several compilation options.

New compilation flag LYS_COMPILE_NO_CONFIG was added to clearly avoid
processing the config flags. So far it was indirectly deduced from
getting know it is compiling Notification/Action/RPC. However it will
be useful to switch off the config flags processing also in other
situations (YANG extensions), so keep it separated.