### PR TITLE
data parser FEATURE allow returning the envelopes on error

### DIFF
--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -290,7 +290,7 @@ enum lyd_type {
  *   - @p parent - must be NULL, the whole RPC is expected;
  *   - @p format - must be ::LYD_XML, NETCONF supports only this format;
  *   - @p tree - must be provided, all the NETCONF-specific XML envelopes will be returned here as
- *               a separate opaque data tree;
+ *               a separate opaque data tree, even if the function fails, this may be returned;
  *   - @p op - must be provided, the RPC/action data tree itself will be returned here, pointing to the operation;
  *
  * - ::LYD_TYPE_NETCONF_REPLY_OR_NOTIF:

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -129,7 +129,8 @@ LY_ERR yin_parse_submodule(struct lys_yin_parser_ctx **yin_ctx, struct ly_ctx *c
  * @param[in] parse_opts Options for parser, see @ref dataparseroptions.
  * @param[in] val_opts Options for the validation phase, see @ref datavalidationoptions.
  * @param[in] data_type Expected data type of the data.
- * @param[out] envp Individual parsed envelopes tree, returned only by specific @p data_type.
+ * @param[out] envp Individual parsed envelopes tree, returned only by specific @p data_type and possibly even if
+ * an error occurs later.
  * @param[out] parsed Set to add all the parsed siblings into.
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -474,6 +474,14 @@ lyd_parse_op(const struct ly_ctx *ctx, struct lyd_node *parent, struct ly_in *in
     switch (format) {
     case LYD_XML:
         rc = lyd_parse_xml(ctx, parent, &first, in, parse_opts, val_opts, data_type, &envp, &parsed, &lydctx);
+        if (rc && envp) {
+            /* special situation when the envelopes were parsed successfully */
+            if (tree) {
+                *tree = envp;
+            }
+            ly_set_erase(&parsed, NULL);
+            return rc;
+        }
         break;
     case LYD_JSON:
         rc = lyd_parse_json(ctx, parent, &first, in, parse_opts, val_opts, data_type, &parsed, &lydctx);


### PR DESCRIPTION
Because they can be used in NETCONF to read
message-id and even other attributes for
the error reply.