### PR TITLE
adds fuzzer for oss-fuzz integration.

### DIFF
--- a/tests/fuzz/oss-fuzz/fuzz_xml_parse.c
+++ b/tests/fuzz/oss-fuzz/fuzz_xml_parse.c
@@ -1,0 +1,29 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "libyang.h"
+
+int LLVMFuzzerTestOneInput(const char *data, size_t size) {
+    struct ly_ctx *ctx = NULL;
+
+    char filename[256];
+    sprintf(filename, "/tmp/libfuzzer.%d", getpid());
+
+    FILE *fp = fopen(filename, "wb");
+    if (!fp) {
+        return 0;
+    }
+    fwrite(data, size, 1, fp);
+    fclose(fp);
+
+    ctx = ly_ctx_new(NULL, 0);
+    if (!ctx) {
+        return 0;
+    }
+    lyxml_parse_path(ctx, filename, LYS_IN_YANG);
+    ly_ctx_clean(ctx, NULL);
+    ly_ctx_destroy(ctx, NULL);
+
+    unlink(filename);
+    return 0;
+}


### PR DESCRIPTION
Hi Maintainers,

I have worked a bit on setting fuzzing up for libyang by way of OSS-Fuzz. Essentially, OSS-Fuzz is a free service run by Google that performs continuous fuzzing of important open source projects, and it would be great to have libyang integrated. The only expectation of integrating into OSS-Fuzz is that bugs will be fixed. This is not a "hard" requirement in that no one enforces this and the main point is if bugs are not fixed then it is a waste of resources to run the fuzzers, which we would like to avoid.

In this PR https://github.com/google/oss-fuzz/pull/5227 I have done exactly that, namely created the necessary logic from an OSS-Fuzz perspective to integrate libyang. If you would like to integrate, could you please provide a set of email(s) that will get access to the data produced by OSS-Fuzz, such as bug reports, coverage reports and more stats. The emails should be linked to a Google account in order to view the detailed reports and notice the emails affiliated with the project will be public in the OSS-Fuzz repo, as they will be part of a configuration file.

At the moment I stored the fuzzers in the Google OSS-Fuzz repository, but we can move them up here to make maintenance easier.