### PR TITLE
data validation BUGFIX handling when in default nodes

### DIFF
--- a/src/validation.c
+++ b/src/validation.c
@@ -1391,9 +1391,10 @@ lyd_validate(struct lyd_node **tree, const struct lys_module *module, const stru
         ret = lyd_validate_new(first2, NULL, mod, diff);
         LY_CHECK_GOTO(ret, cleanup);
 
-        /* add all top-level defaults for this module, do not add into unres sets, will occur in the next step */
-        ret = lyd_new_implicit_r(NULL, first2, NULL, mod, NULL, NULL, (val_opts & LYD_VALIDATE_NO_STATE) ?
-                LYD_IMPLICIT_NO_STATE : 0, diff);
+        /* add all top-level defaults for this module, if going to validate subtree, do not add into unres sets
+         * (lyd_validate_subtree() adds all the nodes in that case) */
+        ret = lyd_new_implicit_r(NULL, first2, NULL, mod, validate_subtree ? NULL : node_types_p,
+                validate_subtree ? NULL : node_when_p, (val_opts & LYD_VALIDATE_NO_STATE) ? LYD_IMPLICIT_NO_STATE : 0, diff);
         LY_CHECK_GOTO(ret, cleanup);
 
         /* our first module node pointer may no longer be the first */

--- a/tests/utests/data/test_validation.c
+++ b/tests/utests/data/test_validation.c
@@ -767,6 +767,11 @@ test_defaults(void **state)
             "        type uint32;\n"
             "        default 15;\n"
             "    }\n"
+            "    leaf dd {\n"
+            "        type uint32;\n"
+            "        when '../d = 666';\n"
+            "        default 15;\n"
+            "    }\n"
             "    leaf-list ll2 {\n"
             "        type string;\n"
             "        default \"dflt1\";\n"
@@ -794,6 +799,11 @@ test_defaults(void **state)
             "        }\n"
             "        leaf d {\n"
             "            type uint32;\n"
+            "            default 15;\n"
+            "        }\n"
+            "        leaf dd {\n"
+            "            type uint32;\n"
+            "            when '../d = 666';\n"
             "            default 15;\n"
             "        }\n"
             "        leaf-list ll2 {\n"
@@ -985,6 +995,29 @@ test_defaults(void **state)
             "</cont>\n",
             LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_WITHSIBLINGS);
     lyd_free_all(diff);
+    lyd_free_all(tree);
+
+    /* check data tree - when enabled node */
+    CHECK_PARSE_LYD_PARAM("<d xmlns=\"urn:tests:f\">666</d><cont xmlns=\"urn:tests:f\"><d>666</d></cont>",
+            LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_SUCCESS, tree);
+    CHECK_LYD_STRING_PARAM(tree,
+            "<ll1 xmlns=\"urn:tests:f\">def1</ll1>\n"
+            "<ll1 xmlns=\"urn:tests:f\">def2</ll1>\n"
+            "<ll1 xmlns=\"urn:tests:f\">def3</ll1>\n"
+            "<d xmlns=\"urn:tests:f\">666</d>\n"
+            "<dd xmlns=\"urn:tests:f\">15</dd>\n"
+            "<ll2 xmlns=\"urn:tests:f\">dflt1</ll2>\n"
+            "<ll2 xmlns=\"urn:tests:f\">dflt2</ll2>\n"
+            "<cont xmlns=\"urn:tests:f\">\n"
+            "  <ll1>def1</ll1>\n"
+            "  <ll1>def2</ll1>\n"
+            "  <ll1>def3</ll1>\n"
+            "  <d>666</d>\n"
+            "  <dd>15</dd>\n"
+            "  <ll2>dflt1</ll2>\n"
+            "  <ll2>dflt2</ll2>\n"
+            "</cont>\n",
+            LYD_XML, LYD_PRINT_WD_ALL | LYD_PRINT_WITHSIBLINGS);
     lyd_free_all(tree);
 }
 


### PR DESCRIPTION
When parsing data, the when in implicitely added default nodes were not
taken into the validation process.