### PR TITLE
yang-data extension support

### DIFF
--- a/doc/transition.dox
+++ b/doc/transition.dox
@@ -276,7 +276,9 @@
  * lyd_parse_fd()               | ::lyd_parse_data_fd()           | Renamed and limited to data trees only.
  * lyd_parse_mem()              | ::lyd_parse_data_mem()          | ^
  * lyd_parse_path()             | ::lyd_parse_data_path()         | ^
+ * -                            | ::lyd_parse_ext_data()          | Separated function for parsing data trees matching a schema tree of the given extension instance.
  * -                            | ::lyd_parse_op()                | Separated function for parsing RPCs, actions, replies, and notifications.
+ * -                            | ::lyd_parse_ext_op()            | Separated function for parsing RPCs, actions, replies, and notifications of the given extension instance.
  * -                            | ::lyd_print_all()               | New API accepting ::ly_out.
  * -                            | ::lyd_print_tree()              | ^
  *

--- a/doc/transition.dox
+++ b/doc/transition.dox
@@ -178,6 +178,7 @@
  * lys_set_enabled()            | -                               | It is not possible to change context this way (remove or disable modules).
  * lys_set_disabled()           | -                               | ^
  * -                            | ::lys_find_child()              | Helpers wrapper around ::lys_getnext().
+ * -                            | ::lys_getnext_ext()             | Alternative to ::lys_getnext() allowing processing schema trees inside extension instances.
  * -                            | ::lys_nodetype2str()            | New functionality.
  * -                            | ::lys_value_validate()          | Supplement functionality to ::lyd_value_validate().
  * lys_is_key()                 | ::lysc_is_key()                 | Renamed to connect with the compiled schema tree.

--- a/src/log.c
+++ b/src/log.c
@@ -567,7 +567,7 @@ lyext_log(const struct lysc_ext_instance *ext, LY_LOG_LEVEL level, LY_ERR err_no
     if (ly_ll < level) {
         return;
     }
-    ret = asprintf(&plugin_msg, "Extension plugin \"%s\": %s)", ext->def->plugin->id, format);
+    ret = asprintf(&plugin_msg, "Extension plugin \"%s\": %s", ext->def->plugin->id, format);
     if (ret == -1) {
         LOGMEM(ext->module->ctx);
         return;

--- a/src/lyb.h
+++ b/src/lyb.h
@@ -54,6 +54,7 @@ struct lylyb_ctx {
  * Note that the structure maps to the lyd_ctx which is common for all the data parsers
  */
 struct lyd_lyb_ctx {
+    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
     union {
         struct {
             uint32_t parse_opts;   /**< various @ref dataparseroptions. */

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -43,6 +43,7 @@ typedef void (*lyd_ctx_free_clb)(struct lyd_ctx *ctx);
  * @brief Internal (common) context for YANG data parsers.
  */
 struct lyd_ctx {
+    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
     uint32_t parse_opts;           /**< various @ref dataparseroptions. */
     uint32_t val_opts;             /**< various @ref datavalidationoptions. */
     uint32_t int_opts;             /**< internal parser options */
@@ -123,6 +124,7 @@ LY_ERR yin_parse_submodule(struct lys_yin_parser_ctx **yin_ctx, struct ly_ctx *c
  * @brief Parse XML string as a YANG data tree.
  *
  * @param[in] ctx libyang context.
+ * @param[in] ext Optional extenion instance to parse data following the schema tree specified in the extension instance
  * @param[in] parent Parent to connect the parsed nodes to, if any.
  * @param[in,out] first_p Pointer to the first top-level parsed node, used only if @p parent is NULL.
  * @param[in] in Input structure.
@@ -135,14 +137,15 @@ LY_ERR yin_parse_submodule(struct lys_yin_parser_ctx **yin_ctx, struct ly_ctx *c
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_xml(const struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_node **first_p, struct ly_in *in,
-        uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type, struct lyd_node **envp, struct ly_set *parsed,
-        struct lyd_ctx **lydctx_p);
+LY_ERR lyd_parse_xml(const struct ly_ctx *ctx, const struct lysc_ext_instance *ext, struct lyd_node *parent,
+        struct lyd_node **first_p, struct ly_in *in, uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type,
+        struct lyd_node **envp, struct ly_set *parsed, struct lyd_ctx **lydctx_p);
 
 /**
  * @brief Parse JSON string as a YANG data tree.
  *
  * @param[in] ctx libyang context.
+ * @param[in] ext Optional extenion instance to parse data following the schema tree specified in the extension instance
  * @param[in] parent Parent to connect the parsed nodes to, if any.
  * @param[in,out] first_p Pointer to the first top-level parsed node, used only if @p parent is NULL.
  * @param[in] in Input structure.
@@ -153,13 +156,15 @@ LY_ERR lyd_parse_xml(const struct ly_ctx *ctx, struct lyd_node *parent, struct l
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_json(const struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_node **first_p, struct ly_in *in,
-        uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type, struct ly_set *parsed, struct lyd_ctx **lydctx_p);
+LY_ERR lyd_parse_json(const struct ly_ctx *ctx, const struct lysc_ext_instance *ext, struct lyd_node *parent,
+        struct lyd_node **first_p, struct ly_in *in, uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type,
+        struct ly_set *parsed, struct lyd_ctx **lydctx_p);
 
 /**
  * @brief Parse binary LYB data as a YANG data tree.
  *
  * @param[in] ctx libyang context.
+ * @param[in] ext Optional extenion instance to parse data following the schema tree specified in the extension instance
  * @param[in] parent Parent to connect the parsed nodes to, if any.
  * @param[in,out] first_p Pointer to the first top-level parsed node, used only if @p parent is NULL.
  * @param[in] in Input structure.
@@ -170,8 +175,9 @@ LY_ERR lyd_parse_json(const struct ly_ctx *ctx, struct lyd_node *parent, struct 
  * @param[out] lydctx_p Data parser context to finish validation.
  * @return LY_ERR value.
  */
-LY_ERR lyd_parse_lyb(const struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_node **first_p, struct ly_in *in,
-        uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type, struct ly_set *parsed, struct lyd_ctx **lydctx_p);
+LY_ERR lyd_parse_lyb(const struct ly_ctx *ctx, const struct lysc_ext_instance *ext, struct lyd_node *parent,
+        struct lyd_node **first_p, struct ly_in *in, uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type,
+        struct ly_set *parsed, struct lyd_ctx **lydctx_p);
 
 /**
  * @brief Search all the parents for an operation node, check validity based on internal parser flags.

--- a/src/parser_stmt.c
+++ b/src/parser_stmt.c
@@ -31,6 +31,19 @@
 #include "tree_schema.h"
 #include "tree_schema_internal.h"
 
+static LY_ERR lysp_stmt_container(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node **siblings);
+static LY_ERR lysp_stmt_choice(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node **siblings);
+static LY_ERR lysp_stmt_case(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node **siblings);
+static LY_ERR lysp_stmt_uses(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node **siblings);
+static LY_ERR lysp_stmt_grouping(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node_grp **groupings);
+static LY_ERR lysp_stmt_list(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node **siblings);
+
 static LY_ERR
 lysp_stmt_validate_value(struct lys_parser_ctx *ctx, enum yang_arg val_type, const char *val)
 {
@@ -64,10 +77,8 @@ lysp_stmt_validate_value(struct lys_parser_ctx *ctx, enum yang_arg val_type, con
 /**
  * @brief Parse extension instance.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] ext_name Extension instance substatement name (keyword).
- * @param[in] ext_name_len Extension instance substatement name length.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in] insubstmt Type of the keyword this extension instance is a substatement of.
  * @param[in] insubstmt_index Index of the keyword instance this extension instance is a substatement of.
  * @param[in,out] exts Extension instances to add to.
@@ -100,9 +111,8 @@ lysp_stmt_ext(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SU
  * @brief Parse a generic text field without specific constraints. Those are contact, organization,
  * description, etc...
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in] stmt Statement structure.
- * @param[in] substmt Type of this substatement.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in] substmt_index Index of this substatement.
  * @param[in,out] value Place to store the parsed value.
  * @param[in] arg Type of the YANG keyword argument (of the value).
@@ -111,31 +121,24 @@ lysp_stmt_ext(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SU
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SUBSTMT substmt, uint32_t substmt_index,
+lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint32_t substmt_index,
         const char **value, enum yang_arg arg, struct lysp_ext_instance **exts)
 {
-    const struct lysp_stmt *child;
-
     if (*value) {
-        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, lyext_substmt2str(substmt));
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, lyext_substmt2str(stmt->kw));
         return LY_EVALID;
     }
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, arg, stmt->arg));
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, value));
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
-            LY_CHECK_RET(lysp_stmt_ext(ctx, child, substmt, substmt_index, exts));
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, stmt->kw, substmt_index, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), lyext_substmt2str(substmt));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), lyext_substmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -145,9 +148,8 @@ lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, L
 /**
  * @brief Parse a qname that can have more instances such as if-feature.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] substmt Type of this substatement.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] qnames Parsed qnames to add to.
  * @param[in] arg Type of the expected argument.
  * @param[in,out] exts Extension instances to add to.
@@ -155,11 +157,10 @@ lysp_stmt_text_field(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, L
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SUBSTMT substmt,
+lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
         struct lysp_qname **qnames, enum yang_arg arg, struct lysp_ext_instance **exts)
 {
     struct lysp_qname *item;
-    const struct lysp_stmt *child;
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, arg, stmt->arg));
 
@@ -168,18 +169,13 @@ lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &item->str));
     item->mod = ctx->parsed_mod;
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
-            LY_CHECK_RET(lysp_stmt_ext(ctx, child, substmt, LY_ARRAY_COUNT(*qnames) - 1, exts));
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, stmt->kw, LY_ARRAY_COUNT(*qnames) - 1, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), lyext_substmt2str(substmt));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), lyext_substmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -189,9 +185,8 @@ lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT
 /**
  * @brief Parse a generic text field that can have more instances such as base.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] substmt Type of this substatement.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] texts Parsed values to add to.
  * @param[in] arg Type of the expected argument.
  * @param[in,out] exts Extension instances to add to.
@@ -199,11 +194,10 @@ lysp_stmt_qnames(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, LYEXT_SUBSTMT substmt,
+lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
         const char ***texts, enum yang_arg arg, struct lysp_ext_instance **exts)
 {
     const char **item;
-    const struct lysp_stmt *child;
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, arg, stmt->arg));
 
@@ -211,18 +205,13 @@ lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, 
     LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *texts, item, LY_EMEM);
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, item));
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
-            LY_CHECK_RET(lysp_stmt_ext(ctx, child, substmt, LY_ARRAY_COUNT(*texts) - 1, exts));
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, stmt->kw, LY_ARRAY_COUNT(*texts) - 1, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), lyext_substmt2str(substmt));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), lyext_substmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -232,8 +221,8 @@ lysp_stmt_text_fields(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, 
 /**
  * @brief Parse the status statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] flags Flags to add to.
  * @param[in,out] exts Extension instances to add to.
  *
@@ -243,7 +232,6 @@ static LY_ERR
 lysp_stmt_status(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint16_t *flags, struct lysp_ext_instance **exts)
 {
     size_t arg_len;
-    const struct lysp_stmt *child;
 
     if (*flags & LYS_STATUS_MASK) {
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "status");
@@ -263,18 +251,13 @@ lysp_stmt_status(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint1
         return LY_EVALID;
     }
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_STATUS, 0, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "status");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "status");
             return LY_EVALID;
         }
     }
@@ -282,48 +265,177 @@ lysp_stmt_status(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint1
 }
 
 /**
- * @brief Parse a restriction such as range or length.
+ * @brief Parse the when statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] restr_kw Type of this particular restriction.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] when_p When pointer to parse to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_when(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_when **when_p)
+{
+    LY_ERR ret = LY_SUCCESS;
+    struct lysp_when *when;
+
+    if (*when_p) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "when");
+        return LY_EVALID;
+    }
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+
+    when = calloc(1, sizeof *when);
+    LY_CHECK_ERR_RET(!when, LOGMEM(PARSER_CTX(ctx)), LY_EMEM);
+    *when_p = when;
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &when->cond));
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &when->dsc, Y_STR_ARG, &when->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &when->ref, Y_STR_ARG, &when->exts));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &when->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "when");
+            return LY_EVALID;
+        }
+    }
+    return ret;
+}
+
+/**
+ * @brief Parse the config statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] flags Flags to add to.
  * @param[in,out] exts Extension instances to add to.
  *
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_restr(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt restr_kw, struct lysp_restr *restr)
+lysp_stmt_config(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint16_t *flags, struct lysp_ext_instance **exts)
 {
-    const struct lysp_stmt *child;
+    size_t arg_len;
 
+    if (*flags & LYS_CONFIG_MASK) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "config");
+        return LY_EVALID;
+    }
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+    arg_len = strlen(stmt->arg);
+    if ((arg_len == ly_strlen_const("true")) && !strncmp(stmt->arg, "true", arg_len)) {
+        *flags |= LYS_CONFIG_W;
+    } else if ((arg_len == ly_strlen_const("false")) && !strncmp(stmt->arg, "false", arg_len)) {
+        *flags |= LYS_CONFIG_R;
+    } else {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "config");
+        return LY_EVALID;
+    }
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_CONFIG, 0, exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "config");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the mandatory statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] flags Flags to add to.
+ * @param[in,out] exts Extension instances to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_mandatory(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint16_t *flags, struct lysp_ext_instance **exts)
+{
+    size_t arg_len;
+
+    if (*flags & LYS_MAND_MASK) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "mandatory");
+        return LY_EVALID;
+    }
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+    arg_len = strlen(stmt->arg);
+    if ((arg_len == ly_strlen_const("true")) && !strncmp(stmt->arg, "true", arg_len)) {
+        *flags |= LYS_MAND_TRUE;
+    } else if ((arg_len == ly_strlen_const("false")) && !strncmp(stmt->arg, "false", arg_len)) {
+        *flags |= LYS_MAND_FALSE;
+    } else {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "mandatory");
+        return LY_EVALID;
+    }
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_MANDATORY, 0, exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "mandatory");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse a restriction such as range or length.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] exts Extension instances to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_restr(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_restr *restr)
+{
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &restr->arg.str));
     restr->arg.mod = ctx->parsed_mod;
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_DESCRIPTION:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_DESCRIPTION, 0, &restr->dsc, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->dsc, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_REFERENCE:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_REFERENCE, 0, &restr->ref, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->ref, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_ERROR_APP_TAG:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_ERROR_APP_TAG, 0, &restr->eapptag, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->eapptag, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_ERROR_MESSAGE:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_ERROR_MESSAGE, 0, &restr->emsg, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->emsg, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &restr->exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), ly_stmt2str(restr_kw));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), ly_stmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -333,28 +445,90 @@ lysp_stmt_restr(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum l
 /**
  * @brief Parse a restriction that can have more instances such as must.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] restr_kw Type of this particular restriction.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] restrs Restrictions to add to.
  *
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_restrs(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt restr_kw, struct lysp_restr **restrs)
+lysp_stmt_restrs(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_restr **restrs)
 {
     struct lysp_restr *restr;
 
     LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *restrs, restr, LY_EMEM);
-    return lysp_stmt_restr(ctx, stmt, restr_kw, restr);
+    return lysp_stmt_restr(ctx, stmt, restr);
+}
+
+/**
+ * @brief Parse the anydata or anyxml statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_any(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_anydata *any;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new structure and insert into siblings */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, any, next, LY_EMEM);
+
+    any->nodetype = stmt->kw == LY_STMT_ANYDATA ? LYS_ANYDATA : LYS_ANYXML;
+    any->parent = parent;
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &any->name));
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &any->flags, &any->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &any->dsc, Y_STR_ARG, &any->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &any->iffeatures, Y_STR_ARG, &any->exts));
+            break;
+        case LY_STMT_MANDATORY:
+            LY_CHECK_RET(lysp_stmt_mandatory(ctx, child, &any->flags, &any->exts));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &any->musts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &any->ref, Y_STR_ARG, &any->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &any->flags, &any->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &any->when));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &any->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw),
+                    (any->nodetype & LYS_ANYDATA) == LYS_ANYDATA ? ly_stmt2str(LY_STMT_ANYDATA) : ly_stmt2str(LY_STMT_ANYXML));
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
 }
 
 /**
  * @brief Parse the value or position statement. Substatement of type enum statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] val_kw Type of this particular keyword.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] value Value to write to.
  * @param[in,out] flags Flags to write to.
  * @param[in,out] exts Extension instances to add to.
@@ -362,17 +536,16 @@ lysp_stmt_restrs(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum 
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_type_enum_value_pos(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt val_kw, int64_t *value, uint16_t *flags,
+lysp_stmt_type_enum_value_pos(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, int64_t *value, uint16_t *flags,
         struct lysp_ext_instance **exts)
 {
     size_t arg_len;
     char *ptr = NULL;
     long int num = 0;
     unsigned long int unum = 0;
-    struct lysp_stmt *child;
 
     if (*flags & LYS_SET_VALUE) {
-        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(val_kw));
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(stmt->kw));
         return LY_EVALID;
     }
     *flags |= LYS_SET_VALUE;
@@ -380,52 +553,48 @@ lysp_stmt_type_enum_value_pos(struct lys_parser_ctx *ctx, const struct lysp_stmt
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
 
     arg_len = strlen(stmt->arg);
-    if (!arg_len || (stmt->arg[0] == '+') || ((stmt->arg[0] == '0') && (arg_len > 1)) || ((val_kw == LY_STMT_POSITION) && !strncmp(stmt->arg, "-0", 2))) {
-        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(val_kw));
+    if (!arg_len || (stmt->arg[0] == '+') || ((stmt->arg[0] == '0') && (arg_len > 1)) ||
+            ((stmt->kw == LY_STMT_POSITION) && !strncmp(stmt->arg, "-0", 2))) {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(stmt->kw));
         goto error;
     }
 
     errno = 0;
-    if (val_kw == LY_STMT_VALUE) {
+    if (stmt->kw == LY_STMT_VALUE) {
         num = strtol(stmt->arg, &ptr, LY_BASE_DEC);
         if ((num < INT64_C(-2147483648)) || (num > INT64_C(2147483647))) {
-            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(val_kw));
+            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(stmt->kw));
             goto error;
         }
     } else {
         unum = strtoul(stmt->arg, &ptr, LY_BASE_DEC);
         if (unum > UINT64_C(4294967295)) {
-            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(val_kw));
+            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(stmt->kw));
             goto error;
         }
     }
     /* we have not parsed the whole argument */
     if ((size_t)(ptr - stmt->arg) != arg_len) {
-        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(val_kw));
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, ly_stmt2str(stmt->kw));
         goto error;
     }
     if (errno == ERANGE) {
-        LOGVAL_PARSER(ctx, LY_VCODE_OOB, arg_len, stmt->arg, ly_stmt2str(val_kw));
+        LOGVAL_PARSER(ctx, LY_VCODE_OOB, arg_len, stmt->arg, ly_stmt2str(stmt->kw));
         goto error;
     }
-    if (val_kw == LY_STMT_VALUE) {
+    if (stmt->kw == LY_STMT_VALUE) {
         *value = num;
     } else {
         *value = unum;
     }
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
-            LY_CHECK_RET(lysp_stmt_ext(ctx, child, val_kw == LY_STMT_VALUE ? LYEXT_SUBSTMT_VALUE : LYEXT_SUBSTMT_POSITION, 0, exts));
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, stmt->kw == LY_STMT_VALUE ? LYEXT_SUBSTMT_VALUE : LYEXT_SUBSTMT_POSITION, 0, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), ly_stmt2str(val_kw));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), ly_stmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -438,65 +607,58 @@ error:
 /**
  * @brief Parse the enum or bit statement. Substatement of type statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
- * @param[in] enum_kw Type of this particular keyword.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] enums Enums or bits to add to.
  *
  * @return LY_ERR values.
  */
 static LY_ERR
-lysp_stmt_type_enum(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt enum_kw, struct lysp_type_enum **enums)
+lysp_stmt_type_enum(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_type_enum **enums)
 {
     struct lysp_type_enum *enm;
-    const struct lysp_stmt *child;
 
-    LY_CHECK_RET(lysp_stmt_validate_value(ctx, enum_kw == LY_STMT_ENUM ? Y_STR_ARG : Y_IDENTIF_ARG, stmt->arg));
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, stmt->kw == LY_STMT_ENUM ? Y_STR_ARG : Y_IDENTIF_ARG, stmt->arg));
 
     LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *enums, enm, LY_EMEM);
 
-    if (enum_kw == LY_STMT_ENUM) {
+    if (stmt->kw == LY_STMT_ENUM) {
         LY_CHECK_RET(lysp_check_enum_name(ctx, stmt->arg, strlen(stmt->arg)));
     } /* else nothing specific for YANG_BIT */
 
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &enm->name));
-    CHECK_UNIQUENESS(ctx, *enums, name, ly_stmt2str(enum_kw), enm->name);
+    CHECK_UNIQUENESS(ctx, *enums, name, ly_stmt2str(stmt->kw), enm->name);
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_DESCRIPTION:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_DESCRIPTION, 0, &enm->dsc, Y_STR_ARG, &enm->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &enm->dsc, Y_STR_ARG, &enm->exts));
             break;
         case LY_STMT_IF_FEATURE:
-            PARSER_CHECK_STMTVER2_RET(ctx, "if-feature", ly_stmt2str(enum_kw));
-            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, LYEXT_SUBSTMT_IF_FEATURE, &enm->iffeatures, Y_STR_ARG, &enm->exts));
+            PARSER_CHECK_STMTVER2_RET(ctx, "if-feature", ly_stmt2str(stmt->kw));
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &enm->iffeatures, Y_STR_ARG, &enm->exts));
             break;
         case LY_STMT_REFERENCE:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_REFERENCE, 0, &enm->ref, Y_STR_ARG, &enm->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &enm->ref, Y_STR_ARG, &enm->exts));
             break;
         case LY_STMT_STATUS:
             LY_CHECK_RET(lysp_stmt_status(ctx, child, &enm->flags, &enm->exts));
             break;
         case LY_STMT_VALUE:
-            LY_CHECK_ERR_RET(enum_kw == LY_STMT_BIT, LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw),
-                    ly_stmt2str(enum_kw)), LY_EVALID);
-            LY_CHECK_RET(lysp_stmt_type_enum_value_pos(ctx, child, kw, &enm->value, &enm->flags, &enm->exts));
+            LY_CHECK_ERR_RET(stmt->kw == LY_STMT_BIT, LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw),
+                    ly_stmt2str(stmt->kw)), LY_EVALID);
+            LY_CHECK_RET(lysp_stmt_type_enum_value_pos(ctx, child, &enm->value, &enm->flags, &enm->exts));
             break;
         case LY_STMT_POSITION:
-            LY_CHECK_ERR_RET(enum_kw == LY_STMT_ENUM, LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw),
-                    ly_stmt2str(enum_kw)), LY_EVALID);
-            LY_CHECK_RET(lysp_stmt_type_enum_value_pos(ctx, child, kw, &enm->value, &enm->flags, &enm->exts));
+            LY_CHECK_ERR_RET(stmt->kw == LY_STMT_ENUM, LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw),
+                    ly_stmt2str(stmt->kw)), LY_EVALID);
+            LY_CHECK_RET(lysp_stmt_type_enum_value_pos(ctx, child, &enm->value, &enm->flags, &enm->exts));
             break;
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &enm->exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), ly_stmt2str(enum_kw));
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), ly_stmt2str(stmt->kw));
             return LY_EVALID;
         }
     }
@@ -506,8 +668,8 @@ lysp_stmt_type_enum(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, en
 /**
  * @brief Parse the fraction-digits statement. Substatement of type statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] fracdig Value to write to.
  * @param[in,out] exts Extension instances to add to.
  *
@@ -519,7 +681,6 @@ lysp_stmt_type_fracdigits(struct lys_parser_ctx *ctx, const struct lysp_stmt *st
     char *ptr;
     size_t arg_len;
     unsigned long int num;
-    const struct lysp_stmt *child;
 
     if (*fracdig) {
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "fraction-digits");
@@ -546,18 +707,13 @@ lysp_stmt_type_fracdigits(struct lys_parser_ctx *ctx, const struct lysp_stmt *st
     }
     *fracdig = num;
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_FRACTION_DIGITS, 0, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "fraction-digits");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "fraction-digits");
             return LY_EVALID;
         }
     }
@@ -567,8 +723,8 @@ lysp_stmt_type_fracdigits(struct lys_parser_ctx *ctx, const struct lysp_stmt *st
 /**
  * @brief Parse the require-instance statement. Substatement of type statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] reqinst Value to write to.
  * @param[in,out] flags Flags to write to.
  * @param[in,out] exts Extension instances to add to.
@@ -580,7 +736,6 @@ lysp_stmt_type_reqinstance(struct lys_parser_ctx *ctx, const struct lysp_stmt *s
         struct lysp_ext_instance **exts)
 {
     size_t arg_len;
-    struct lysp_stmt *child;
 
     if (*flags & LYS_SET_REQINST) {
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "require-instance");
@@ -597,18 +752,13 @@ lysp_stmt_type_reqinstance(struct lys_parser_ctx *ctx, const struct lysp_stmt *s
         return LY_EVALID;
     }
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_REQUIRE_INSTANCE, 0, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "require-instance");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "require-instance");
             return LY_EVALID;
         }
     }
@@ -618,8 +768,8 @@ lysp_stmt_type_reqinstance(struct lys_parser_ctx *ctx, const struct lysp_stmt *s
 /**
  * @brief Parse the modifier statement. Substatement of type pattern statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] pat Value to write to.
  * @param[in,out] exts Extension instances to add to.
  *
@@ -630,7 +780,6 @@ lysp_stmt_type_pattern_modifier(struct lys_parser_ctx *ctx, const struct lysp_st
 {
     size_t arg_len;
     char *buf;
-    const struct lysp_stmt *child;
 
     if ((*pat)[0] == LYSP_RESTR_PATTERN_NACK) {
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "modifier");
@@ -654,18 +803,13 @@ lysp_stmt_type_pattern_modifier(struct lys_parser_ctx *ctx, const struct lysp_st
     buf[0] = LYSP_RESTR_PATTERN_NACK;
     LY_CHECK_RET(lydict_insert_zc(PARSER_CTX(ctx), buf, pat));
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_EXTENSION_INSTANCE:
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_MODIFIER, 0, exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "modifier");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "modifier");
             return LY_EVALID;
         }
     }
@@ -675,8 +819,8 @@ lysp_stmt_type_pattern_modifier(struct lys_parser_ctx *ctx, const struct lysp_st
 /**
  * @brief Parse the pattern statement. Substatement of type statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] patterns Restrictions to add to.
  *
  * @return LY_ERR values.
@@ -686,7 +830,6 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
 {
     char *buf;
     size_t arg_len;
-    const struct lysp_stmt *child;
     struct lysp_restr *restr;
 
     LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
@@ -702,24 +845,19 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
     LY_CHECK_RET(lydict_insert_zc(PARSER_CTX(ctx), buf, &restr->arg.str));
     restr->arg.mod = ctx->parsed_mod;
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_DESCRIPTION:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_DESCRIPTION, 0, &restr->dsc, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->dsc, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_REFERENCE:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_REFERENCE, 0, &restr->ref, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->ref, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_ERROR_APP_TAG:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_ERROR_APP_TAG, 0, &restr->eapptag, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->eapptag, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_ERROR_MESSAGE:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_ERROR_MESSAGE, 0, &restr->emsg, Y_STR_ARG, &restr->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &restr->emsg, Y_STR_ARG, &restr->exts));
             break;
         case LY_STMT_MODIFIER:
             PARSER_CHECK_STMTVER2_RET(ctx, "modifier", "pattern");
@@ -729,7 +867,7 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &restr->exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "pattern");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "pattern");
             return LY_EVALID;
         }
     }
@@ -739,8 +877,8 @@ lysp_stmt_type_pattern(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
 /**
  * @brief Parse the type statement.
  *
- * @param[in] ctx yang parser context for logging.
- * @param[in,out] data Data to read from, always moved to currently handled character.
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
  * @param[in,out] type Type to wrote to.
  *
  * @return LY_ERR values.
@@ -749,7 +887,6 @@ static LY_ERR
 lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_type *type)
 {
     struct lysp_type *nest_type;
-    const struct lysp_stmt *child;
     const char *str_path = NULL;
     LY_ERR ret;
 
@@ -757,26 +894,23 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
         LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "type");
         return LY_EVALID;
     }
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_PREF_IDENTIF_ARG, stmt->arg));
     LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &type->name));
     type->pmod = ctx->parsed_mod;
 
-    for (child = stmt->child; child; child = child->next) {
-        struct ly_in *in;
-        LY_CHECK_RET(ly_in_new_memory(child->stmt, &in));
-        enum ly_stmt kw = lysp_match_kw(in, NULL);
-        ly_in_free(in, 0);
-
-        switch (kw) {
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
         case LY_STMT_BASE:
-            LY_CHECK_RET(lysp_stmt_text_fields(ctx, child, LYEXT_SUBSTMT_BASE, &type->bases, Y_PREF_IDENTIF_ARG, &type->exts));
+            LY_CHECK_RET(lysp_stmt_text_fields(ctx, child, &type->bases, Y_PREF_IDENTIF_ARG, &type->exts));
             type->flags |= LYS_SET_BASE;
             break;
         case LY_STMT_BIT:
-            LY_CHECK_RET(lysp_stmt_type_enum(ctx, child, kw, &type->bits));
+            LY_CHECK_RET(lysp_stmt_type_enum(ctx, child, &type->bits));
             type->flags |= LYS_SET_BIT;
             break;
         case LY_STMT_ENUM:
-            LY_CHECK_RET(lysp_stmt_type_enum(ctx, child, kw, &type->enums));
+            LY_CHECK_RET(lysp_stmt_type_enum(ctx, child, &type->enums));
             type->flags |= LYS_SET_ENUM;
             break;
         case LY_STMT_FRACTION_DIGITS:
@@ -785,17 +919,17 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
             break;
         case LY_STMT_LENGTH:
             if (type->length) {
-                LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(kw));
+                LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(child->kw));
                 return LY_EVALID;
             }
             type->length = calloc(1, sizeof *type->length);
             LY_CHECK_ERR_RET(!type->length, LOGMEM(PARSER_CTX(ctx)), LY_EMEM);
 
-            LY_CHECK_RET(lysp_stmt_restr(ctx, child, kw, type->length));
+            LY_CHECK_RET(lysp_stmt_restr(ctx, child, type->length));
             type->flags |= LYS_SET_LENGTH;
             break;
         case LY_STMT_PATH:
-            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, LYEXT_SUBSTMT_PATH, 0, &str_path, Y_STR_ARG, &type->exts));
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &str_path, Y_STR_ARG, &type->exts));
             ret = ly_path_parse(PARSER_CTX(ctx), NULL, str_path, 0, LY_PATH_BEGIN_EITHER, LY_PATH_LREF_TRUE,
                     LY_PATH_PREFIX_OPTIONAL, LY_PATH_PRED_LEAFREF, &type->path);
             lydict_remove(PARSER_CTX(ctx), str_path);
@@ -808,18 +942,18 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
             break;
         case LY_STMT_RANGE:
             if (type->range) {
-                LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(kw));
+                LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(child->kw));
                 return LY_EVALID;
             }
             type->range = calloc(1, sizeof *type->range);
             LY_CHECK_ERR_RET(!type->range, LOGMEM(PARSER_CTX(ctx)), LY_EMEM);
 
-            LY_CHECK_RET(lysp_stmt_restr(ctx, child, kw, type->range));
+            LY_CHECK_RET(lysp_stmt_restr(ctx, child, type->range));
             type->flags |= LYS_SET_RANGE;
             break;
         case LY_STMT_REQUIRE_INSTANCE:
             LY_CHECK_RET(lysp_stmt_type_reqinstance(ctx, child, &type->require_instance, &type->flags, &type->exts));
-            /* LYS_SET_REQINST checked and set inside parse_type_reqinstance() */
+            /* LYS_SET_REQINST checked and set inside lysp_stmt_type_reqinstance() */
             break;
         case LY_STMT_TYPE:
             LY_ARRAY_NEW_RET(PARSER_CTX(ctx), type->types, nest_type, LY_EMEM);
@@ -830,36 +964,1500 @@ lysp_stmt_type(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct 
             LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &type->exts));
             break;
         default:
-            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(kw), "type");
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "type");
             return LY_EVALID;
         }
     }
     return LY_SUCCESS;
 }
 
+/**
+ * @brief Parse the leaf statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_leaf(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_leaf *leaf;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new leaf structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, leaf, next, LY_EMEM);
+    leaf->nodetype = LYS_LEAF;
+    leaf->parent = parent;
+
+    /* get name */
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &leaf->name));
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &leaf->flags, &leaf->exts));
+            break;
+        case LY_STMT_DEFAULT:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &leaf->dflt.str, Y_STR_ARG, &leaf->exts));
+            leaf->dflt.mod = ctx->parsed_mod;
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &leaf->dsc, Y_STR_ARG, &leaf->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &leaf->iffeatures, Y_STR_ARG, &leaf->exts));
+            break;
+        case LY_STMT_MANDATORY:
+            LY_CHECK_RET(lysp_stmt_mandatory(ctx, child, &leaf->flags, &leaf->exts));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &leaf->musts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &leaf->ref, Y_STR_ARG, &leaf->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &leaf->flags, &leaf->exts));
+            break;
+        case LY_STMT_TYPE:
+            LY_CHECK_RET(lysp_stmt_type(ctx, child, &leaf->type));
+            break;
+        case LY_STMT_UNITS:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &leaf->units, Y_STR_ARG, &leaf->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &leaf->when));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &leaf->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "leaf");
+            return LY_EVALID;
+        }
+    }
+
+    /* mandatory substatements */
+    if (!leaf->type.name) {
+        LOGVAL_PARSER(ctx, LY_VCODE_MISSTMT, "type", "leaf");
+        return LY_EVALID;
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the max-elements statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] max Value to write to.
+ * @param[in,out] flags Flags to write to.
+ * @param[in,out] exts Extension instances to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_maxelements(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
+        uint32_t *max, uint16_t *flags, struct lysp_ext_instance **exts)
+{
+    size_t arg_len;
+    char *ptr;
+    unsigned long int num;
+
+    if (*flags & LYS_SET_MAX) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "max-elements");
+        return LY_EVALID;
+    }
+    *flags |= LYS_SET_MAX;
+
+    /* get value */
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+    arg_len = strlen(stmt->arg);
+
+    if (!arg_len || (stmt->arg[0] == '0') || ((stmt->arg[0] != 'u') && !isdigit(stmt->arg[0]))) {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "max-elements");
+        return LY_EVALID;
+    }
+
+    if ((arg_len != ly_strlen_const("unbounded")) || strncmp(stmt->arg, "unbounded", arg_len)) {
+        errno = 0;
+        num = strtoul(stmt->arg, &ptr, LY_BASE_DEC);
+        /* we have not parsed the whole argument */
+        if ((size_t)(ptr - stmt->arg) != arg_len) {
+            LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "max-elements");
+            return LY_EVALID;
+        }
+        if ((errno == ERANGE) || (num > UINT32_MAX)) {
+            LOGVAL_PARSER(ctx, LY_VCODE_OOB, arg_len, stmt->arg, "max-elements");
+            return LY_EVALID;
+        }
+
+        *max = num;
+    } else {
+        /* unbounded */
+        *max = 0;
+    }
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_MAX_ELEMENTS, 0, exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "max-elements");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the min-elements statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] min Value to write to.
+ * @param[in,out] flags Flags to write to.
+ * @param[in,out] exts Extension instances to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_minelements(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt,
+        uint32_t *min, uint16_t *flags, struct lysp_ext_instance **exts)
+{
+    size_t arg_len;
+    char *ptr;
+    unsigned long int num;
+
+    if (*flags & LYS_SET_MIN) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "min-elements");
+        return LY_EVALID;
+    }
+    *flags |= LYS_SET_MIN;
+
+    /* get value */
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+    arg_len = strlen(stmt->arg);
+
+    if (!arg_len || !isdigit(stmt->arg[0]) || ((stmt->arg[0] == '0') && (arg_len > 1))) {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "min-elements");
+        return LY_EVALID;
+    }
+
+    errno = 0;
+    num = strtoul(stmt->arg, &ptr, LY_BASE_DEC);
+    /* we have not parsed the whole argument */
+    if ((size_t)(ptr - stmt->arg) != arg_len) {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "min-elements");
+        return LY_EVALID;
+    }
+    if ((errno == ERANGE) || (num > UINT32_MAX)) {
+        LOGVAL_PARSER(ctx, LY_VCODE_OOB, arg_len, stmt->arg, "min-elements");
+        return LY_EVALID;
+    }
+    *min = num;
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_MIN_ELEMENTS, 0, exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "min-elements");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the ordered-by statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] flags Flags to write to.
+ * @param[in,out] exts Extension instances to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_orderedby(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, uint16_t *flags, struct lysp_ext_instance **exts)
+{
+    size_t arg_len;
+
+    if (*flags & LYS_ORDBY_MASK) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, "ordered-by");
+        return LY_EVALID;
+    }
+
+    /* get value */
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+    arg_len = strlen(stmt->arg);
+    if ((arg_len == ly_strlen_const("system")) && !strncmp(stmt->arg, "system", arg_len)) {
+        *flags |= LYS_MAND_TRUE;
+    } else if ((arg_len == ly_strlen_const("user")) && !strncmp(stmt->arg, "user", arg_len)) {
+        *flags |= LYS_MAND_FALSE;
+    } else {
+        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, arg_len, stmt->arg, "ordered-by");
+        return LY_EVALID;
+    }
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_ORDERED_BY, 0, exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "ordered-by");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the leaf-list statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_leaflist(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_leaflist *llist;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new leaf-list structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, llist, next, LY_EMEM);
+    llist->nodetype = LYS_LEAFLIST;
+    llist->parent = parent;
+
+    /* get name */
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &llist->name));
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &llist->flags, &llist->exts));
+            break;
+        case LY_STMT_DEFAULT:
+            PARSER_CHECK_STMTVER2_RET(ctx, "default", "leaf-list");
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &llist->dflts, Y_STR_ARG, &llist->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &llist->dsc, Y_STR_ARG, &llist->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &llist->iffeatures, Y_STR_ARG, &llist->exts));
+            break;
+        case LY_STMT_MAX_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_maxelements(ctx, child, &llist->max, &llist->flags, &llist->exts));
+            break;
+        case LY_STMT_MIN_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_minelements(ctx, child, &llist->min, &llist->flags, &llist->exts));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &llist->musts));
+            break;
+        case LY_STMT_ORDERED_BY:
+            LY_CHECK_RET(lysp_stmt_orderedby(ctx, child, &llist->flags, &llist->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &llist->ref, Y_STR_ARG, &llist->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &llist->flags, &llist->exts));
+            break;
+        case LY_STMT_TYPE:
+            LY_CHECK_RET(lysp_stmt_type(ctx, child, &llist->type));
+            break;
+        case LY_STMT_UNITS:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &llist->units, Y_STR_ARG, &llist->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &llist->when));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &llist->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "llist");
+            return LY_EVALID;
+        }
+    }
+
+    /* mandatory substatements */
+    if (!llist->type.name) {
+        LOGVAL_PARSER(ctx, LY_VCODE_MISSTMT, "type", "leaf-list");
+        return LY_EVALID;
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the refine statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in,out] refines Refines to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_refine(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_refine **refines)
+{
+    struct lysp_refine *rf;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+
+    LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *refines, rf, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &rf->nodeid));
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &rf->flags, &rf->exts));
+            break;
+        case LY_STMT_DEFAULT:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &rf->dflts, Y_STR_ARG, &rf->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &rf->dsc, Y_STR_ARG, &rf->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            PARSER_CHECK_STMTVER2_RET(ctx, "if-feature", "refine");
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &rf->iffeatures, Y_STR_ARG, &rf->exts));
+            break;
+        case LY_STMT_MAX_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_maxelements(ctx, child, &rf->max, &rf->flags, &rf->exts));
+            break;
+        case LY_STMT_MIN_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_minelements(ctx, child, &rf->min, &rf->flags, &rf->exts));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &rf->musts));
+            break;
+        case LY_STMT_MANDATORY:
+            LY_CHECK_RET(lysp_stmt_mandatory(ctx, child, &rf->flags, &rf->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &rf->ref, Y_STR_ARG, &rf->exts));
+            break;
+        case LY_STMT_PRESENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &rf->presence, Y_STR_ARG, &rf->exts));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &rf->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "refine");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the typedef statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] typedefs Typedefs to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_typedef(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_tpdf **typedefs)
+{
+    struct lysp_tpdf *tpdf;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    LY_ARRAY_NEW_RET(PARSER_CTX(ctx), *typedefs, tpdf, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &tpdf->name));
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DEFAULT:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &tpdf->dflt.str, Y_STR_ARG, &tpdf->exts));
+            tpdf->dflt.mod = ctx->parsed_mod;
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &tpdf->dsc, Y_STR_ARG, &tpdf->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &tpdf->ref, Y_STR_ARG, &tpdf->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &tpdf->flags, &tpdf->exts));
+            break;
+        case LY_STMT_TYPE:
+            LY_CHECK_RET(lysp_stmt_type(ctx, child, &tpdf->type));
+            break;
+        case LY_STMT_UNITS:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &tpdf->units, Y_STR_ARG, &tpdf->exts));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &tpdf->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "typedef");
+            return LY_EVALID;
+        }
+    }
+
+    /* mandatory substatements */
+    if (!tpdf->type.name) {
+        LOGVAL_PARSER(ctx, LY_VCODE_MISSTMT, "type", "typedef");
+        return LY_EVALID;
+    }
+
+    /* store data for collision check */
+    if (parent && !(parent->nodetype & (LYS_GROUPING | LYS_RPC | LYS_ACTION | LYS_INPUT | LYS_OUTPUT | LYS_NOTIF))) {
+        LY_CHECK_RET(ly_set_add(&ctx->tpdfs_nodes, parent, 0, NULL));
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the input or output statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] inout_p Input/output pointer to write to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_inout(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent,
+        struct lysp_node_action_inout *inout_p)
+{
+    if (inout_p->nodetype) {
+        LOGVAL_PARSER(ctx, LY_VCODE_DUPSTMT, ly_stmt2str(stmt->kw));
+        return LY_EVALID;
+    }
+
+    /* initiate structure */
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->kw == LY_STMT_INPUT ? "input" : "output", 0, &inout_p->name));
+    inout_p->nodetype = stmt->kw == LY_STMT_INPUT ? LYS_INPUT : LYS_OUTPUT;
+    inout_p->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", ly_stmt2str(stmt->kw));
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &inout_p->node, &inout_p->child));
+            break;
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &inout_p->node, &inout_p->typedefs));
+            break;
+        case LY_STMT_MUST:
+            PARSER_CHECK_STMTVER2_RET(ctx, "must", ly_stmt2str(stmt->kw));
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &inout_p->musts));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &inout_p->node, &inout_p->groupings));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &inout_p->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), ly_stmt2str(stmt->kw));
+            return LY_EVALID;
+        }
+    }
+
+    if (!inout_p->child) {
+        LOGVAL_PARSER(ctx, LY_VCODE_MISSTMT, "data-def-stmt", ly_stmt2str(stmt->kw));
+        return LY_EVALID;
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the action statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] actions Actions to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_action(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node_action **actions)
+{
+    struct lysp_node_action *act;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), actions, act, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &act->name));
+    act->nodetype = parent ? LYS_ACTION : LYS_RPC;
+    act->parent = parent;
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &act->dsc, Y_STR_ARG, &act->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &act->iffeatures, Y_STR_ARG, &act->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &act->ref, Y_STR_ARG, &act->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &act->flags, &act->exts));
+            break;
+
+        case LY_STMT_INPUT:
+            LY_CHECK_RET(lysp_stmt_inout(ctx, child, &act->node, &act->input));
+            break;
+        case LY_STMT_OUTPUT:
+            LY_CHECK_RET(lysp_stmt_inout(ctx, child, &act->node, &act->output));
+            break;
+
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &act->node, &act->typedefs));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &act->node, &act->groupings));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &act->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), parent ? "action" : "rpc");
+            return LY_EVALID;
+        }
+    }
+
+    /* always initialize inout, they are technically present (needed for later deviations/refines) */
+    if (!act->input.nodetype) {
+        act->input.nodetype = LYS_INPUT;
+        act->input.parent = &act->node;
+        LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), "input", 0, &act->input.name));
+    }
+    if (!act->output.nodetype) {
+        act->output.nodetype = LYS_OUTPUT;
+        act->output.parent = &act->node;
+        LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), "output", 0, &act->output.name));
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the notification statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] notifs Notifications to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_notif(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node_notif **notifs)
+{
+    struct lysp_node_notif *notif;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), notifs, notif, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &notif->name));
+    notif->nodetype = LYS_NOTIF;
+    notif->parent = parent;
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &notif->dsc, Y_STR_ARG, &notif->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &notif->iffeatures, Y_STR_ARG, &notif->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &notif->ref, Y_STR_ARG, &notif->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &notif->flags, &notif->exts));
+            break;
+
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "notification");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_case(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &notif->node, &notif->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &notif->node, &notif->child));
+            break;
+
+        case LY_STMT_MUST:
+            PARSER_CHECK_STMTVER2_RET(ctx, "must", "notification");
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &notif->musts));
+            break;
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &notif->node, &notif->typedefs));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &notif->node, &notif->groupings));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &notif->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "notification");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the grouping statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] groupings Groupings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_grouping(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node_grp **groupings)
+{
+    struct lysp_node_grp *grp;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), groupings, grp, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &grp->name));
+    grp->nodetype = LYS_GROUPING;
+    grp->parent = parent;
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &grp->dsc, Y_STR_ARG, &grp->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &grp->ref, Y_STR_ARG, &grp->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &grp->flags, &grp->exts));
+            break;
+
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "grouping");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &grp->node, &grp->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &grp->node, &grp->child));
+            break;
+
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &grp->node, &grp->typedefs));
+            break;
+        case LY_STMT_ACTION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "action", "grouping");
+            LY_CHECK_RET(lysp_stmt_action(ctx, child, &grp->node, &grp->actions));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &grp->node, &grp->groupings));
+            break;
+        case LY_STMT_NOTIFICATION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "notification", "grouping");
+            LY_CHECK_RET(lysp_stmt_notif(ctx, child, &grp->node, &grp->notifs));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &grp->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "grouping");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the augment statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] augments Augments to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_augment(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node_augment **augments)
+{
+    struct lysp_node_augment *aug;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_STR_ARG, stmt->arg));
+
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), augments, aug, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &aug->nodeid));
+    aug->nodetype = LYS_AUGMENT;
+    aug->parent = parent;
+
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &aug->dsc, Y_STR_ARG, &aug->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &aug->iffeatures, Y_STR_ARG, &aug->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &aug->ref, Y_STR_ARG, &aug->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &aug->flags, &aug->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &aug->when));
+            break;
+
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "augment");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_CASE:
+            LY_CHECK_RET(lysp_stmt_case(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &aug->node, &aug->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &aug->node, &aug->child));
+            break;
+
+        case LY_STMT_ACTION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "action", "augment");
+            LY_CHECK_RET(lysp_stmt_action(ctx, child, &aug->node, &aug->actions));
+            break;
+        case LY_STMT_NOTIFICATION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "notification", "augment");
+            LY_CHECK_RET(lysp_stmt_notif(ctx, child, &aug->node, &aug->notifs));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &aug->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "augment");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the uses statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_uses(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_uses *uses;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_PREF_IDENTIF_ARG, stmt->arg));
+
+    /* create uses structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, uses, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &uses->name));
+    uses->nodetype = LYS_USES;
+    uses->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &uses->dsc, Y_STR_ARG, &uses->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &uses->iffeatures, Y_STR_ARG, &uses->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &uses->ref, Y_STR_ARG, &uses->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &uses->flags, &uses->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &uses->when));
+            break;
+
+        case LY_STMT_REFINE:
+            LY_CHECK_RET(lysp_stmt_refine(ctx, child, &uses->refines));
+            break;
+        case LY_STMT_AUGMENT:
+            LY_CHECK_RET(lysp_stmt_augment(ctx, child, &uses->node, &uses->augments));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &uses->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "uses");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the case statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_case(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_case *cas;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new case structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, cas, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &cas->name));
+    cas->nodetype = LYS_CASE;
+    cas->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &cas->dsc, Y_STR_ARG, &cas->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &cas->iffeatures, Y_STR_ARG, &cas->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &cas->ref, Y_STR_ARG, &cas->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &cas->flags, &cas->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &cas->when));
+            break;
+
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "case");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &cas->node, &cas->child));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &cas->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "case");
+            return LY_EVALID;
+        }
+    }
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the choice statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_choice(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_choice *choice;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new choice structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, choice, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &choice->name));
+    choice->nodetype = LYS_CHOICE;
+    choice->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &choice->flags, &choice->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &choice->dsc, Y_STR_ARG, &choice->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &choice->iffeatures, Y_STR_ARG, &choice->exts));
+            break;
+        case LY_STMT_MANDATORY:
+            LY_CHECK_RET(lysp_stmt_mandatory(ctx, child, &choice->flags, &choice->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &choice->ref, Y_STR_ARG, &choice->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &choice->flags, &choice->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &choice->when));
+            break;
+        case LY_STMT_DEFAULT:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &choice->dflt.str, Y_PREF_IDENTIF_ARG, &choice->exts));
+            choice->dflt.mod = ctx->parsed_mod;
+            break;
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "choice");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_CASE:
+            LY_CHECK_RET(lysp_stmt_case(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_CHOICE:
+            PARSER_CHECK_STMTVER2_RET(ctx, "choice", "choice");
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &choice->node, &choice->child));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &choice->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "choice");
+            return LY_EVALID;
+        }
+    }
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the container statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_container(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_container *cont;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new container structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, cont, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &cont->name));
+    cont->nodetype = LYS_CONTAINER;
+    cont->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &cont->flags, &cont->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &cont->dsc, Y_STR_ARG, &cont->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &cont->iffeatures, Y_STR_ARG, &cont->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &cont->ref, Y_STR_ARG, &cont->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &cont->flags, &cont->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &cont->when));
+            break;
+        case LY_STMT_PRESENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &cont->presence, Y_STR_ARG, &cont->exts));
+            break;
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "container");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &cont->node, &cont->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &cont->node, &cont->child));
+            break;
+
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &cont->node, &cont->typedefs));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &cont->musts));
+            break;
+        case LY_STMT_ACTION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "action", "container");
+            LY_CHECK_RET(lysp_stmt_action(ctx, child, &cont->node, &cont->actions));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &cont->node, &cont->groupings));
+            break;
+        case LY_STMT_NOTIFICATION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "notification", "container");
+            LY_CHECK_RET(lysp_stmt_notif(ctx, child, &cont->node, &cont->notifs));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &cont->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "container");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Parse the list statement.
+ *
+ * @param[in] ctx parser context.
+ * @param[in] stmt Source statement data from the parsed extension instance.
+ * @param[in] parent Parent node to connect to (not into).
+ * @param[in,out] siblings Siblings to add to.
+ *
+ * @return LY_ERR values.
+ */
+static LY_ERR
+lysp_stmt_list(struct lys_parser_ctx *ctx, const struct lysp_stmt *stmt, struct lysp_node *parent, struct lysp_node **siblings)
+{
+    struct lysp_node_list *list;
+
+    LY_CHECK_RET(lysp_stmt_validate_value(ctx, Y_IDENTIF_ARG, stmt->arg));
+
+    /* create new list structure */
+    LY_LIST_NEW_RET(PARSER_CTX(ctx), siblings, list, next, LY_EMEM);
+
+    LY_CHECK_RET(lydict_insert(PARSER_CTX(ctx), stmt->arg, 0, &list->name));
+    list->nodetype = LYS_LIST;
+    list->parent = parent;
+
+    /* parse substatements */
+    for (const struct lysp_stmt *child = stmt->child; child; child = child->next) {
+        switch (child->kw) {
+        case LY_STMT_CONFIG:
+            LY_CHECK_RET(lysp_stmt_config(ctx, child, &list->flags, &list->exts));
+            break;
+        case LY_STMT_DESCRIPTION:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &list->dsc, Y_STR_ARG, &list->exts));
+            break;
+        case LY_STMT_IF_FEATURE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &list->iffeatures, Y_STR_ARG, &list->exts));
+            break;
+        case LY_STMT_REFERENCE:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &list->ref, Y_STR_ARG, &list->exts));
+            break;
+        case LY_STMT_STATUS:
+            LY_CHECK_RET(lysp_stmt_status(ctx, child, &list->flags, &list->exts));
+            break;
+        case LY_STMT_WHEN:
+            LY_CHECK_RET(lysp_stmt_when(ctx, child, &list->when));
+            break;
+        case LY_STMT_KEY:
+            LY_CHECK_RET(lysp_stmt_text_field(ctx, child, 0, &list->key, Y_STR_ARG, &list->exts));
+            break;
+        case LY_STMT_MAX_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_maxelements(ctx, child, &list->max, &list->flags, &list->exts));
+            break;
+        case LY_STMT_MIN_ELEMENTS:
+            LY_CHECK_RET(lysp_stmt_minelements(ctx, child, &list->min, &list->flags, &list->exts));
+            break;
+        case LY_STMT_ORDERED_BY:
+            LY_CHECK_RET(lysp_stmt_orderedby(ctx, child, &list->flags, &list->exts));
+            break;
+        case LY_STMT_UNIQUE:
+            LY_CHECK_RET(lysp_stmt_qnames(ctx, child, &list->uniques, Y_STR_ARG, &list->exts));
+            break;
+
+        case LY_STMT_ANYDATA:
+            PARSER_CHECK_STMTVER2_RET(ctx, "anydata", "list");
+        /* fall through */
+        case LY_STMT_ANYXML:
+            LY_CHECK_RET(lysp_stmt_any(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_CHOICE:
+            LY_CHECK_RET(lysp_stmt_choice(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_CONTAINER:
+            LY_CHECK_RET(lysp_stmt_container(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_LEAF:
+            LY_CHECK_RET(lysp_stmt_leaf(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_LEAF_LIST:
+            LY_CHECK_RET(lysp_stmt_leaflist(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_LIST:
+            LY_CHECK_RET(lysp_stmt_list(ctx, child, &list->node, &list->child));
+            break;
+        case LY_STMT_USES:
+            LY_CHECK_RET(lysp_stmt_uses(ctx, child, &list->node, &list->child));
+            break;
+
+        case LY_STMT_TYPEDEF:
+            LY_CHECK_RET(lysp_stmt_typedef(ctx, child, &list->node, &list->typedefs));
+            break;
+        case LY_STMT_MUST:
+            LY_CHECK_RET(lysp_stmt_restrs(ctx, child, &list->musts));
+            break;
+        case LY_STMT_ACTION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "action", "list");
+            LY_CHECK_RET(lysp_stmt_action(ctx, child, &list->node, &list->actions));
+            break;
+        case LY_STMT_GROUPING:
+            LY_CHECK_RET(lysp_stmt_grouping(ctx, child, &list->node, &list->groupings));
+            break;
+        case LY_STMT_NOTIFICATION:
+            PARSER_CHECK_STMTVER2_RET(ctx, "notification", "list");
+            LY_CHECK_RET(lysp_stmt_notif(ctx, child, &list->node, &list->notifs));
+            break;
+        case LY_STMT_EXTENSION_INSTANCE:
+            LY_CHECK_RET(lysp_stmt_ext(ctx, child, LYEXT_SUBSTMT_SELF, 0, &list->exts));
+            break;
+        default:
+            LOGVAL_PARSER(ctx, LY_VCODE_INCHILDSTMT, ly_stmt2str(child->kw), "list");
+            return LY_EVALID;
+        }
+    }
+
+    return LY_SUCCESS;
+}
+
 LY_ERR
-lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt kw, void **result, struct lysp_ext_instance **exts)
+lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, void **result, struct lysp_ext_instance **exts)
 {
     LY_ERR ret = LY_SUCCESS;
-    struct lys_yang_parser_ctx pctx = {0};
+    uint16_t flags;
+    struct lys_parser_ctx pctx = {0};
 
     pctx.format = LYS_IN_YANG;
     pctx.parsed_mod = ctx->pmod;
 
     LOG_LOCSET(NULL, NULL, ctx->path, NULL);
 
-    switch (kw) {
+    switch (stmt->kw) {
+    case LY_STMT_ACTION:
+    case LY_STMT_RPC:
+        ret = lysp_stmt_action(&pctx, stmt, NULL, (struct lysp_node_action **)result);
+        break;
+    case LY_STMT_ANYDATA:
+    case LY_STMT_ANYXML:
+        ret = lysp_stmt_any(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_AUGMENT:
+        ret = lysp_stmt_augment(&pctx, stmt, NULL, (struct lysp_node_augment **)result);
+        break;
+    case LY_STMT_BASE:
+        ret = lysp_stmt_text_fields(&pctx, stmt, (const char ***)result, Y_PREF_IDENTIF_ARG, exts);
+        break;
+    case LY_STMT_BIT:
+    case LY_STMT_ENUM:
+        ret = lysp_stmt_type_enum(&pctx, stmt, (struct lysp_type_enum **)result);
+        break;
+    case LY_STMT_CASE:
+        ret = lysp_stmt_case(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_CHOICE:
+        ret = lysp_stmt_choice(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_CONFIG:
+        ret = lysp_stmt_config(&pctx, stmt, *(uint16_t **)result, exts);
+        break;
+    case LY_STMT_CONTACT:
+    case LY_STMT_DESCRIPTION:
+    case LY_STMT_ERROR_APP_TAG:
+    case LY_STMT_ERROR_MESSAGE:
+    case LY_STMT_KEY:
+    case LY_STMT_NAMESPACE:
+    case LY_STMT_ORGANIZATION:
+    case LY_STMT_PRESENCE:
+    case LY_STMT_REFERENCE:
+    case LY_STMT_UNITS:
+        ret = lysp_stmt_text_field(&pctx, stmt, 0, (const char **)result, Y_STR_ARG, exts);
+        break;
+    case LY_STMT_CONTAINER:
+        ret = lysp_stmt_container(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_DEFAULT:
+    case LY_STMT_IF_FEATURE:
+    case LY_STMT_UNIQUE:
+        ret = lysp_stmt_qnames(&pctx, stmt, (struct lysp_qname **)result, Y_STR_ARG, exts);
+        break;
+    case LY_STMT_EXTENSION_INSTANCE:
+        ret = lysp_stmt_ext(&pctx, stmt, LYEXT_SUBSTMT_SELF, 0, exts);
+        break;
+    case LY_STMT_FRACTION_DIGITS:
+        ret = lysp_stmt_type_fracdigits(&pctx, stmt, *(uint8_t **)result, exts);
+        break;
+    case LY_STMT_GROUPING:
+        ret = lysp_stmt_grouping(&pctx, stmt, NULL, (struct lysp_node_grp **)result);
+        break;
+    case LY_STMT_INPUT:
+    case LY_STMT_OUTPUT: {
+        struct lysp_node_action_inout *inout;
+
+        *result = inout = calloc(1, sizeof *inout);
+        LY_CHECK_ERR_RET(!inout, LOGMEM(ctx->ctx), LY_EMEM);
+        ret = lysp_stmt_inout(&pctx, stmt, NULL, inout);
+        break;
+    }
+    case LY_STMT_LEAF:
+        ret = lysp_stmt_leaf(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_LEAF_LIST:
+        ret = lysp_stmt_leaflist(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_LENGTH:
+    case LY_STMT_MUST:
+    case LY_STMT_RANGE:
+        ret = lysp_stmt_restrs(&pctx, stmt, (struct lysp_restr **)result);
+        break;
+    case LY_STMT_LIST:
+        ret = lysp_stmt_list(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_MANDATORY:
+        ret = lysp_stmt_mandatory(&pctx, stmt, *(uint16_t **)result, exts);
+        break;
+    case LY_STMT_MAX_ELEMENTS:
+        flags = 0;
+        ret = lysp_stmt_maxelements(&pctx, stmt, *(uint32_t **)result, &flags, exts);
+        break;
+    case LY_STMT_MIN_ELEMENTS:
+        flags = 0;
+        ret = lysp_stmt_minelements(&pctx, stmt, *(uint32_t **)result, &flags, exts);
+        break;
+    case LY_STMT_MODIFIER:
+        ret = lysp_stmt_type_pattern_modifier(&pctx, stmt, (const char **)result, exts);
+        break;
+    case LY_STMT_NOTIFICATION:
+        ret = lysp_stmt_notif(&pctx, stmt, NULL, (struct lysp_node_notif **)result);
+        break;
+    case LY_STMT_ORDERED_BY:
+        ret = lysp_stmt_orderedby(&pctx, stmt, *(uint16_t **)result, exts);
+        break;
+    case LY_STMT_PATH: {
+        const char *str_path = NULL;
+
+        LY_CHECK_RET(lysp_stmt_text_field(&pctx, stmt, 0, &str_path, Y_STR_ARG, exts));
+        ret = ly_path_parse(ctx->ctx, NULL, str_path, 0, LY_PATH_BEGIN_EITHER, LY_PATH_LREF_TRUE,
+                LY_PATH_PREFIX_OPTIONAL, LY_PATH_PRED_LEAFREF, (struct lyxp_expr **)result);
+        lydict_remove(ctx->ctx, str_path);
+        break;
+    }
+    case LY_STMT_PATTERN:
+        ret = lysp_stmt_type_pattern(&pctx, stmt, (struct lysp_restr **)result);
+        break;
+    case LY_STMT_POSITION:
+    case LY_STMT_VALUE:
+        flags = 0;
+        ret = lysp_stmt_type_enum_value_pos(&pctx, stmt, *(int64_t **)result, &flags, exts);
+        break;
+    case LY_STMT_PREFIX:
+        ret = lysp_stmt_text_field(&pctx, stmt, 0, (const char **)result, Y_IDENTIF_ARG, exts);
+        break;
+    case LY_STMT_REFINE:
+        ret = lysp_stmt_refine(&pctx, stmt, (struct lysp_refine **)result);
+        break;
+    case LY_STMT_REQUIRE_INSTANCE:
+        flags = 0;
+        ret = lysp_stmt_type_reqinstance(&pctx, stmt, *(uint8_t **)result, &flags, exts);
+        break;
     case LY_STMT_STATUS:
-        ret = lysp_stmt_status((struct lys_parser_ctx *)&pctx, stmt, *(uint16_t **)result, exts);
+        ret = lysp_stmt_status(&pctx, stmt, *(uint16_t **)result, exts);
         break;
     case LY_STMT_TYPE: {
         struct lysp_type *type;
-        type = calloc(1, sizeof *type);
 
-        ret = lysp_stmt_type((struct lys_parser_ctx *)&pctx, stmt, type);
-        (*result) = type;
+        *result = type = calloc(1, sizeof *type);
+        LY_CHECK_ERR_RET(!type, LOGMEM(ctx->ctx), LY_EMEM);
+        ret = lysp_stmt_type(&pctx, stmt, type);
         break;
     }
+    case LY_STMT_TYPEDEF:
+        ret = lysp_stmt_typedef(&pctx, stmt, NULL, (struct lysp_tpdf **)result);
+        break;
+    case LY_STMT_USES:
+        ret = lysp_stmt_uses(&pctx, stmt, NULL, (struct lysp_node **)result);
+        break;
+    case LY_STMT_WHEN:
+        ret = lysp_stmt_when(&pctx, stmt, (struct lysp_when **)result);
+        break;
     default:
         LOGINT(ctx->ctx);
         return LY_EINT;

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -23,6 +23,7 @@
 #include "log.h"
 #include "parser_data.h"
 #include "parser_internal.h"
+#include "plugins_exts.h"
 #include "set.h"
 #include "tree_data.h"
 #include "tree_data_internal.h"
@@ -36,6 +37,7 @@
  * Note that the structure maps to the lyd_ctx which is common for all the data parsers
  */
 struct lyd_xml_ctx {
+    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
     uint32_t parse_opts;           /**< various @ref dataparseroptions. */
     uint32_t val_opts;             /**< various @ref datavalidationoptions. */
     uint32_t int_opts;             /**< internal data parser options */
@@ -429,12 +431,24 @@ lydxml_subtree_r(struct lyd_xml_ctx *lydctx, struct lyd_node *parent, struct lyd
     /* get the schema node */
     snode = NULL;
     if (mod && (!parent || parent->schema)) {
-        snode = lys_find_child(parent ? parent->schema : NULL, mod, name, name_len, 0, getnext_opts);
+        if (!parent && lydctx->ext) {
+            snode = lys_find_ext_instance_node(lydctx->ext, mod, name, name_len, 0, getnext_opts);
+        } else {
+            snode = lys_find_child(parent ? parent->schema : NULL, mod, name, name_len, 0, getnext_opts);
+        }
         if (!snode) {
             if (lydctx->parse_opts & LYD_PARSE_STRICT) {
                 if (parent) {
                     LOGVAL(ctx, LYVE_REFERENCE, "Node \"%.*s\" not found as a child of \"%s\" node.", name_len, name,
                             parent->schema->name);
+                } else if (lydctx->ext) {
+                    if (lydctx->ext->argument) {
+                        LOGVAL(ctx, LYVE_REFERENCE, "Node \"%.*s\" not found in the \"%s\" %s extension instance.", name_len, name,
+                                lydctx->ext->argument, lydctx->ext->def->name);
+                    } else {
+                        LOGVAL(ctx, LYVE_REFERENCE, "Node \"%.*s\" not found in the %s extension instance.", name_len, name,
+                                lydctx->ext->def->name);
+                    }
                 } else {
                     LOGVAL(ctx, LYVE_REFERENCE, "Node \"%.*s\" not found in the \"%s\" module.", name_len, name,
                             mod->name);
@@ -1284,9 +1298,9 @@ cleanup:
 }
 
 LY_ERR
-lyd_parse_xml(const struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_node **first_p, struct ly_in *in,
-        uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type, struct lyd_node **envp, struct ly_set *parsed,
-        struct lyd_ctx **lydctx_p)
+lyd_parse_xml(const struct ly_ctx *ctx, const struct lysc_ext_instance *ext, struct lyd_node *parent,
+        struct lyd_node **first_p, struct ly_in *in, uint32_t parse_opts, uint32_t val_opts, enum lyd_type data_type,
+        struct lyd_node **envp, struct ly_set *parsed, struct lyd_ctx **lydctx_p)
 {
     LY_ERR rc = LY_SUCCESS;
     struct lyd_xml_ctx *lydctx;
@@ -1304,6 +1318,7 @@ lyd_parse_xml(const struct ly_ctx *ctx, struct lyd_node *parent, struct lyd_node
     lydctx->parse_opts = parse_opts;
     lydctx->val_opts = val_opts;
     lydctx->free = lyd_xml_ctx_free;
+    lydctx->ext = ext;
 
     switch (data_type) {
     case LYD_TYPE_DATA_YANG:

--- a/src/plugins_exts.c
+++ b/src/plugins_exts.c
@@ -20,6 +20,7 @@
 #include "common.h"
 #include "plugins_exts_metadata.c"
 #include "plugins_exts_nacm.c"
+#include "plugins_exts_yangdata.c"
 
 /**
  * @brief list of all extension plugins implemented internally
@@ -30,6 +31,7 @@ struct lyext_plugins_list lyext_plugins_internal[] = {
     {"ietf-netconf-acm", "2012-02-22", "default-deny-all", &nacm_plugin},
     {"ietf-netconf-acm", "2018-02-14", "default-deny-all", &nacm_plugin},
     {"ietf-yang-metadata", "2016-08-05", "annotation", &metadata_plugin},
+    {"ietf-restconf", "2017-01-26", "yang-data", &yangdata_plugin},
     {NULL, NULL, NULL, NULL} /* terminating item */
 };
 

--- a/src/plugins_exts.h
+++ b/src/plugins_exts.h
@@ -86,7 +86,7 @@ struct lysc_ext_substmt {
  * TODO
  * @return LY_ENOT if the extension is disabled and should be ignored.
  */
-LY_ERR lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_instance *ext, struct lysc_ext_substmt *substmts);
+LY_ERR lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_instance *ext_p, struct lysc_ext_instance *ext);
 
 /**
  * @brief Free the extension instance's data compiled with ::lys_compile_extension_instance().

--- a/src/plugins_exts.h
+++ b/src/plugins_exts.h
@@ -157,6 +157,9 @@ struct lysc_ext *lysc_ext_dup(struct lysc_ext *orig);
 LY_ERR lysc_ext_substmt(const struct lysc_ext_instance *ext, enum ly_stmt substmt,
         void **instance_p, enum ly_stmt_cardinality *cardinality_p);
 
+const struct lysc_node *lys_find_ext_instance_node(const struct lysc_ext_instance *ext, const struct lys_module *module,
+        const char *name, size_t name_len, uint16_t nodetype, uint32_t options);
+
 /**
  * @brief Update path in the compile context, which is used for logging where the compilation failed.
  *

--- a/src/plugins_exts.h
+++ b/src/plugins_exts.h
@@ -90,9 +90,12 @@ LY_ERR lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ex
 
 /**
  * @brief Free the extension instance's data compiled with ::lys_compile_extension_instance().
- * TODO
+ *
+ * @param[in] libyang context
+ * @param[in] substmts The sized array of extension instance's substatements. The whole array is freed except the storage
+ * places which are expected to be covered by the extension plugin.
  */
-void lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substmts);
+void lysc_extension_instance_substatements_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substmts);
 
 /**
  * @brief Duplicate the compiled extension (definition) structure.
@@ -103,6 +106,25 @@ void lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *s
  * @return The duplicated structure to use.
  */
 struct lysc_ext *lysc_ext_dup(struct lysc_ext *orig);
+
+/**
+ * @brief Get pointer to the storage of the specified substatement in the given extension instance.
+ *
+ * The function simplifies access into the ::lysc_ext_instance.substmts sized array.
+ *
+ * @param[in] ext Compiled extension instance to process.
+ * @param[in] substmt Extension substatement to search for.
+ * @param[out] instance_p Pointer where the storage of the @p substmt will be provided. The specific type returned depends
+ * on the @p substmt and can be found in the documentation of each ::ly_stmt value. Also note that some of the substatements
+ * (::lysc_node based or flags) can share the storage with other substatements. In case the pointer is NULL, still the return
+ * code can be used to at least know if the substatement is allowed for the extension.
+ * @param[out] cardinality_p Pointer to provide allowed cardinality of the substatements in the extension. Note that in some
+ * cases, the type of the storage depends also on the cardinality of the substatement.
+ * @return LY_SUCCESS if the @p substmt found.
+ * @return LY_ENOT in case the @p ext is not able to store (does not allow) the specified @p substmt.
+ */
+LY_ERR lysc_ext_substmt(const struct lysc_ext_instance *ext, enum ly_stmt substmt,
+        void **instance_p, enum ly_stmt_cardinality *cardinality_p);
 
 /**
  * @brief Update path in the compile context, which is used for logging where the compilation failed.

--- a/src/plugins_exts_internal.h
+++ b/src/plugins_exts_internal.h
@@ -31,6 +31,11 @@ extern struct lyext_plugins_list lyext_plugins_internal[];
 #define LYEXT_PLUGIN_INTERNAL_ANNOTATION 4
 
 /**
+ * @brief Index of yang-data extension plugin in lyext_plugins_internal
+ */
+#define LYEXT_PLUGIN_INTERNAL_YANGDATA 5
+
+/**
  * @brief Find the extension plugin for the specified extension instance.
  *
  * @param[in] mod YANG module where the

--- a/src/plugins_exts_metadata.c
+++ b/src/plugins_exts_metadata.c
@@ -121,9 +121,22 @@ annotation_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext,
 }
 
 /**
+ * @brief INFO printer
+ *
+ * Implementation of lyext_clb_schema_printer set as ::lyext_plugin::sprinter
+ */
+LY_ERR
+annotation_schema_printer(struct lys_ypr_ctx *ctx, struct lysc_ext_instance *ext, ly_bool *flag)
+{
+    lysc_print_extension_instance(ctx, ext, flag);
+
+    return LY_SUCCESS;
+}
+
+/**
  * @brief Free annotation extension instances' data.
  *
- * Implementation of lyext_clb_free callback set as lyext_plugin::free.
+ * Implementation of lyext_clb_free callback set as ::lyext_plugin::free.
  */
 void
 annotation_free(struct ly_ctx *ctx, struct lysc_ext_instance *ext)
@@ -143,5 +156,6 @@ struct lyext_plugin metadata_plugin = {
     .id = "libyang 2 - metadata, version 1",
     .compile = &annotation_compile,
     .validate = NULL,
+    .sprinter = &annotation_schema_printer,
     .free = annotation_free
 };

--- a/src/plugins_exts_metadata.c
+++ b/src/plugins_exts_metadata.c
@@ -115,7 +115,7 @@ annotation_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext,
     c_ext->substmts[ANNOTATION_SUBSTMT_REF].cardinality = LY_STMT_CARD_OPT;
     c_ext->substmts[ANNOTATION_SUBSTMT_REF].storage = &annotation->ref;
 
-    LY_CHECK_RET(lys_compile_extension_instance(cctx, p_ext, c_ext->substmts));
+    LY_CHECK_RET(lys_compile_extension_instance(cctx, p_ext, c_ext));
 
     return LY_SUCCESS;
 }

--- a/src/plugins_exts_metadata.h
+++ b/src/plugins_exts_metadata.h
@@ -21,15 +21,12 @@
 extern "C" {
 #endif
 
-/**
- * @brief Representation of the compiled metadata substatements as provided by libyang 2 metadata extension plugin.
- */
-struct lyext_metadata {
-    struct lysc_type *type;            /**< type of the metadata (mandatory) */
-    const char *units;                 /**< units of the leaf's type */
-    struct lysc_iffeature *iffeatures; /**< list of if-feature expressions ([sized array](@ref sizedarrays)) */
-    uint16_t flags;                    /**< [schema node flags](@ref snodeflags) - only LYS_STATUS_* values are allowed */
-};
+#define ANNOTATION_SUBSTMT_IFF     0 /**< index for the LY_STMT_IF_FEATURE substatement in annotation's ::lysc_ext_instance.substmts */
+#define ANNOTATION_SUBSTMT_UNITS   1 /**< index for the LY_STMT_UNITS substatement in annotation's ::lysc_ext_instance.substmts */
+#define ANNOTATION_SUBSTMT_STATUS  2 /**< index for the LY_STMT_STATUS substatement in annotation's ::lysc_ext_instance.substmts */
+#define ANNOTATION_SUBSTMT_TYPE    3 /**< index for the LY_STMT_TYPE substatement in annotation's ::lysc_ext_instance.substmts */
+#define ANNOTATION_SUBSTMT_DSC     4 /**< index for the LY_STMT_DSC substatement in annotation's ::lysc_ext_instance.substmts */
+#define ANNOTATION_SUBSTMT_REF     5 /**< index for the LY_STMT_REF substatement in annotation's ::lysc_ext_instance.substmts */
 
 #ifdef __cplusplus
 }

--- a/src/plugins_exts_nacm.c
+++ b/src/plugins_exts_nacm.c
@@ -142,5 +142,6 @@ struct lyext_plugin nacm_plugin = {
     .id = "libyang 2 - NACM, version 1",
     .compile = &nacm_compile,
     .validate = NULL,
+    .sprinter = NULL,
     .free = NULL
 };

--- a/src/plugins_exts_nacm.c
+++ b/src/plugins_exts_nacm.c
@@ -93,9 +93,9 @@ nacm_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext, struc
 
     /* check that the extension is instantiated at an allowed place - data node */
     if (c_ext->parent_type != LYEXT_PAR_NODE) {
-        lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path, "Extension %s is allowed only in a data nodes, but it is placed in \"%s\" statement.",
+        lyext_log(c_ext, LY_LLWRN, 0, cctx->path, "Extension %s is allowed only in a data nodes, but it is placed in \"%s\" statement.",
                 p_ext->name, lyext_parent2str(c_ext->parent_type));
-        return LY_EVALID;
+        return LY_ENOT;
     } else {
         parent = (struct lysc_node *)c_ext->parent;
         if (!(parent->nodetype & (LYS_CONTAINER | LYS_LEAF | LYS_LEAFLIST | LYS_LIST | LYS_CHOICE | LYS_ANYDATA |
@@ -103,9 +103,9 @@ nacm_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext, struc
             /* note LYS_AUGMENT and LYS_USES is not in the list since they are not present in the compiled tree. Instead, libyang
              * passes all their extensions to their children nodes */
 invalid_parent:
-            lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+            lyext_log(c_ext, LY_LLWRN, 0, cctx->path,
                     "Extension %s is not allowed in %s statement.", p_ext->name, lys_nodetype2str(parent->nodetype));
-            return LY_EVALID;
+            return LY_ENOT;
         }
         if ((c_ext->data == (void *)&nacm_deny_write) && (parent->nodetype & (LYS_RPC | LYS_ACTION | LYS_NOTIF))) {
             goto invalid_parent;

--- a/src/plugins_exts_yangdata.c
+++ b/src/plugins_exts_yangdata.c
@@ -1,0 +1,163 @@
+/**
+ * @file plugins_exts_yangdata.c
+ * @author Radek Krejci <rkrejci@cesnet.cz>
+ * @brief libyang extension plugin - yang-data (RFC 8040)
+ *
+ * Copyright (c) 2021 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include <stdlib.h>
+
+#include "common.h"
+#include "plugins_exts.h"
+#include "schema_compile.h"
+#include "tree_schema.h"
+
+/**
+ * @brief Storage for ID used to check plugin API version compatibility.
+ * Ignored here in the internal plugin.
+LYEXT_VERSION_CHECK
+ */
+
+/**
+ * @brief Free yang-data extension instances' data.
+ *
+ * Implementation of ::lyext_clb_free callback set as lyext_plugin::free.
+ */
+void
+yangdata_free(struct ly_ctx *ctx, struct lysc_ext_instance *ext)
+{
+    lysc_extension_instance_substatements_free(ctx, ext->substmts);
+}
+
+/**
+ * @brief Compile yang-data extension instances.
+ *
+ * Implementation of lyext_clb_compile callback set as lyext_plugin::compile.
+ */
+LY_ERR
+yangdata_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext, struct lysc_ext_instance *c_ext)
+{
+    LY_ERR ret;
+    LY_ARRAY_COUNT_TYPE u;
+    struct lysc_module *mod_c;
+    const struct lysc_node *child;
+    ly_bool valid = 1;
+    uint32_t prev_options = cctx->options;
+
+    /* yang-data can appear only at the top level of a YANG module or submodule */
+    if (c_ext->parent_type != LYEXT_PAR_MODULE) {
+        lyext_log(c_ext, LY_LLWRN, 0, cctx->path,
+                "Extension %s is ignored since it appears as a non top-level statement in \"%s\" statement.",
+                p_ext->name, lyext_parent2str(c_ext->parent_type));
+        return LY_ENOT;
+    }
+    /* check mandatory argument */
+    if (!c_ext->argument) {
+        lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                "Extension %s is instantiated without mandatory argument representing YANG data template name.",
+                p_ext->name);
+        return LY_EVALID;
+    }
+
+    mod_c = (struct lysc_module *)c_ext->parent;
+
+    /* check for duplication */
+    LY_ARRAY_FOR(mod_c->exts, u) {
+        if ((&mod_c->exts[u] != c_ext) && (mod_c->exts[u].def == c_ext->def) && !strcmp(mod_c->exts[u].argument, c_ext->argument)) {
+            /* duplication of the same yang-data extension in a single module */
+            lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path, "Extension %s is instantiated multiple times.", p_ext->name);
+            return LY_EVALID;
+        }
+    }
+
+    /* compile annotation substatements
+     * To let the compilation accept different statements possibly leading to the container top-level node, there are 3
+     * allowed substatements pointing to a single storage. But when compiled, the substaments list is compressed just to
+     * a single item providing the schema tree. */
+    LY_ARRAY_CREATE_RET(cctx->ctx, c_ext->substmts, 3, LY_EMEM);
+    LY_ARRAY_INCREMENT(c_ext->substmts);
+    c_ext->substmts[0].stmt = LY_STMT_CONTAINER;
+    c_ext->substmts[0].cardinality = LY_STMT_CARD_OPT;
+    c_ext->substmts[0].storage = &c_ext->data;
+
+    LY_ARRAY_INCREMENT(c_ext->substmts);
+    c_ext->substmts[1].stmt = LY_STMT_CHOICE;
+    c_ext->substmts[1].cardinality = LY_STMT_CARD_OPT;
+    c_ext->substmts[1].storage = &c_ext->data;
+
+    LY_ARRAY_INCREMENT(c_ext->substmts);
+    c_ext->substmts[2].stmt = LY_STMT_USES;
+    c_ext->substmts[2].cardinality = LY_STMT_CARD_OPT;
+    c_ext->substmts[2].storage = &c_ext->data;
+
+    cctx->options |= LYS_COMPILE_NO_CONFIG | LYS_COMPILE_NO_DISABLED;
+    ret = lys_compile_extension_instance(cctx, p_ext, c_ext);
+    cctx->options = prev_options;
+    LY_ARRAY_DECREMENT(c_ext->substmts);
+    LY_ARRAY_DECREMENT(c_ext->substmts);
+    LY_CHECK_RET(ret);
+
+    /* check that we have really just a single container data definition in the top */
+    child = *(struct lysc_node **)c_ext->substmts[0].storage;
+    if (!child) {
+        valid = 0;
+        lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                "Extension %s is instantiated without any top level data node, but exactly one container data node is expected.",
+                p_ext->name);
+    } else if (child->next) {
+        valid = 0;
+        lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                "Extension %s is instantiated with multiple top level data nodes, but only a single container data node is allowed.",
+                p_ext->name);
+    } else if (child->nodetype == LYS_CHOICE) {
+        /* all the choice's case are expected to result to a single container node */
+        const struct lysc_node *snode = NULL;
+
+        while ((snode = lys_getnext(snode, child, mod_c, 0))) {
+            if (snode->next) {
+                valid = 0;
+                lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                        "Extension %s is instantiated with multiple top level data nodes (inside a single choice's case), "
+                        "but only a single container data node is allowed.", p_ext->name);
+                break;
+            } else if (snode->nodetype != LYS_CONTAINER) {
+                valid = 0;
+                lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                        "Extension %s is instantiated with %s top level data node (inside a choice), "
+                        "but only a single container data node is allowed.", p_ext->name, lys_nodetype2str(snode->nodetype));
+                break;
+            }
+        }
+    } else if (child->nodetype != LYS_CONTAINER) {
+        /* via uses */
+        valid = 0;
+        lyext_log(c_ext, LY_LLERR, LY_EVALID, cctx->path,
+                "Extension %s is instantiated with %s top level data node, but only a single container data node is allowed.",
+                p_ext->name, lys_nodetype2str(child->nodetype));
+    }
+
+    if (!valid) {
+        yangdata_free(cctx->ctx, c_ext);
+        c_ext->data = c_ext->substmts = NULL;
+        return LY_EVALID;
+    }
+
+    return LY_SUCCESS;
+}
+
+/**
+ * @brief Plugin for the yang-data extension
+ */
+struct lyext_plugin yangdata_plugin = {
+    .id = "libyang 2 - yang-data, version 1",
+    .compile = &yangdata_compile,
+    .validate = NULL,
+    .free = yangdata_free
+};

--- a/src/plugins_exts_yangdata.c
+++ b/src/plugins_exts_yangdata.c
@@ -153,11 +153,24 @@ yangdata_compile(struct lysc_ctx *cctx, const struct lysp_ext_instance *p_ext, s
 }
 
 /**
+ * @brief INFO printer
+ *
+ * Implementation of ::lyext_clb_schema_printer set as ::lyext_plugin::sprinter
+ */
+LY_ERR
+yangdata_schema_printer(struct lys_ypr_ctx *ctx, struct lysc_ext_instance *ext, ly_bool *flag)
+{
+    lysc_print_extension_instance(ctx, ext, flag);
+    return LY_SUCCESS;
+}
+
+/**
  * @brief Plugin for the yang-data extension
  */
 struct lyext_plugin yangdata_plugin = {
     .id = "libyang 2 - yang-data, version 1",
     .compile = &yangdata_compile,
     .validate = NULL,
+    .sprinter = &yangdata_schema_printer,
     .free = yangdata_free
 };

--- a/src/printer_yin.c
+++ b/src/printer_yin.c
@@ -33,18 +33,18 @@
 /**
  * @brief YIN printer context.
  */
-struct ypr_ctx {
+struct lys_ypr_ctx {
     struct ly_out *out;              /**< output specification */
     uint16_t level;                  /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
     uint32_t options;                /**< Schema output options (see @ref schemaprinterflags). */
     const struct lys_module *module; /**< schema to print */
 };
 
-static void yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
+static void yprp_extension_instances(struct lys_ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
         struct lysp_ext_instance *ext, int8_t *flag, LY_ARRAY_COUNT_TYPE count);
 
 static void
-ypr_open(struct ypr_ctx *ctx, const char *elem_name, const char *attr_name, const char *attr_value, int8_t flag)
+ypr_open(struct lys_ypr_ctx *ctx, const char *elem_name, const char *attr_name, const char *attr_value, int8_t flag)
 {
     ly_print_(ctx->out, "%*s<%s", INDENT, elem_name);
 
@@ -58,7 +58,7 @@ ypr_open(struct ypr_ctx *ctx, const char *elem_name, const char *attr_name, cons
 }
 
 static void
-ypr_close(struct ypr_ctx *ctx, const char *elem_name, int8_t flag)
+ypr_close(struct lys_ypr_ctx *ctx, const char *elem_name, int8_t flag)
 {
     if (flag) {
         ly_print_(ctx->out, "%*s</%s>\n", INDENT, elem_name);
@@ -73,7 +73,7 @@ ypr_close(struct ypr_ctx *ctx, const char *elem_name, int8_t flag)
  * 1 or NULL - parent already closed, do nothing
  */
 static void
-ypr_close_parent(struct ypr_ctx *ctx, int8_t *par_close_flag)
+ypr_close_parent(struct lys_ypr_ctx *ctx, int8_t *par_close_flag)
 {
     if (par_close_flag && !(*par_close_flag)) {
         (*par_close_flag) = 1;
@@ -82,7 +82,7 @@ ypr_close_parent(struct ypr_ctx *ctx, int8_t *par_close_flag)
 }
 
 static void
-ypr_yin_arg(struct ypr_ctx *ctx, const char *arg, const char *text)
+ypr_yin_arg(struct lys_ypr_ctx *ctx, const char *arg, const char *text)
 {
     ly_print_(ctx->out, "%*s<%s>", INDENT, arg);
     lyxml_dump_text(ctx->out, text, 0);
@@ -90,7 +90,7 @@ ypr_yin_arg(struct ypr_ctx *ctx, const char *arg, const char *text)
 }
 
 static void
-ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, const char *text, void *ext)
+ypr_substmt(struct lys_ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, const char *text, void *ext)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t extflag = 0;
@@ -125,7 +125,7 @@ ypr_substmt(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, c
 }
 
 static void
-ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned long int attr_value)
+ypr_unsigned(struct lys_ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, unsigned long int attr_value)
 {
     char *str;
 
@@ -138,7 +138,7 @@ ypr_unsigned(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, 
 }
 
 static void
-ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed long int attr_value)
+ypr_signed(struct lys_ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, void *exts, signed long int attr_value)
 {
     char *str;
 
@@ -151,7 +151,7 @@ ypr_signed(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index, vo
 }
 
 static void
-yprp_revision(struct ypr_ctx *ctx, const struct lysp_revision *rev)
+yprp_revision(struct lys_ypr_ctx *ctx, const struct lysp_revision *rev)
 {
     if (rev->dsc || rev->ref || rev->exts) {
         ypr_open(ctx, "revision", "date", rev->date, 1);
@@ -167,7 +167,7 @@ yprp_revision(struct ypr_ctx *ctx, const struct lysp_revision *rev)
 }
 
 static void
-ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
+ypr_mandatory(struct lys_ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     if (flags & LYS_MAND_MASK) {
         ypr_close_parent(ctx, flag);
@@ -176,7 +176,7 @@ ypr_mandatory(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 }
 
 static void
-ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
+ypr_config(struct lys_ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     if (flags & LYS_CONFIG_MASK) {
         ypr_close_parent(ctx, flag);
@@ -185,7 +185,7 @@ ypr_config(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 }
 
 static void
-ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
+ypr_status(struct lys_ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 {
     const char *status = NULL;
 
@@ -204,7 +204,7 @@ ypr_status(struct ypr_ctx *ctx, uint16_t flags, void *exts, int8_t *flag)
 }
 
 static void
-ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, int8_t *flag)
+ypr_description(struct lys_ypr_ctx *ctx, const char *dsc, void *exts, int8_t *flag)
 {
     if (dsc) {
         ypr_close_parent(ctx, flag);
@@ -213,7 +213,7 @@ ypr_description(struct ypr_ctx *ctx, const char *dsc, void *exts, int8_t *flag)
 }
 
 static void
-ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, int8_t *flag)
+ypr_reference(struct lys_ypr_ctx *ctx, const char *ref, void *exts, int8_t *flag)
 {
     if (ref) {
         ypr_close_parent(ctx, flag);
@@ -222,7 +222,7 @@ ypr_reference(struct ypr_ctx *ctx, const char *ref, void *exts, int8_t *flag)
 }
 
 static void
-yprp_iffeatures(struct ypr_ctx *ctx, struct lysp_qname *iffs, struct lysp_ext_instance *exts, int8_t *flag)
+yprp_iffeatures(struct lys_ypr_ctx *ctx, struct lysp_qname *iffs, struct lysp_ext_instance *exts, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u, v;
     int8_t extflag;
@@ -244,7 +244,7 @@ yprp_iffeatures(struct ypr_ctx *ctx, struct lysp_qname *iffs, struct lysp_ext_in
 }
 
 static void
-yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
+yprp_extension(struct lys_ypr_ctx *ctx, const struct lysp_ext *ext)
 {
     int8_t flag = 0, flag2 = 0;
     LY_ARRAY_COUNT_TYPE u;
@@ -287,7 +287,7 @@ yprp_extension(struct ypr_ctx *ctx, const struct lysp_ext *ext)
 }
 
 static void
-yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
+yprp_feature(struct lys_ypr_ctx *ctx, const struct lysp_feature *feat)
 {
     int8_t flag = 0;
 
@@ -303,7 +303,7 @@ yprp_feature(struct ypr_ctx *ctx, const struct lysp_feature *feat)
 }
 
 static void
-yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
+yprp_identity(struct lys_ypr_ctx *ctx, const struct lysp_ident *ident)
 {
     int8_t flag = 0;
     LY_ARRAY_COUNT_TYPE u;
@@ -328,7 +328,7 @@ yprp_identity(struct ypr_ctx *ctx, const struct lysp_ident *ident)
 }
 
 static void
-yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, const char *attr, int8_t *flag)
+yprp_restr(struct lys_ypr_ctx *ctx, const struct lysp_restr *restr, const char *name, const char *attr, int8_t *flag)
 {
     (void)flag;
     int8_t inner_flag = 0;
@@ -366,7 +366,7 @@ yprp_restr(struct ypr_ctx *ctx, const struct lysp_restr *restr, const char *name
 }
 
 static void
-yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int8_t *flag)
+yprp_when(struct lys_ypr_ctx *ctx, struct lysp_when *when, int8_t *flag)
 {
     int8_t inner_flag = 0;
 
@@ -389,7 +389,7 @@ yprp_when(struct ypr_ctx *ctx, struct lysp_when *when, int8_t *flag)
 }
 
 static void
-yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, int8_t *flag)
+yprp_enum(struct lys_ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE type, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t inner_flag;
@@ -428,7 +428,7 @@ yprp_enum(struct ypr_ctx *ctx, const struct lysp_type_enum *items, LY_DATA_TYPE 
 }
 
 static void
-yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
+yprp_type(struct lys_ypr_ctx *ctx, const struct lysp_type *type)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -479,7 +479,7 @@ yprp_type(struct ypr_ctx *ctx, const struct lysp_type *type)
 }
 
 static void
-yprp_typedef(struct ypr_ctx *ctx, const struct lysp_tpdf *tpdf)
+yprp_typedef(struct lys_ypr_ctx *ctx, const struct lysp_tpdf *tpdf)
 {
     ypr_open(ctx, "typedef", "name", tpdf->name, 1);
     LEVEL++;
@@ -503,12 +503,12 @@ yprp_typedef(struct ypr_ctx *ctx, const struct lysp_tpdf *tpdf)
     ypr_close(ctx, "typedef", 1);
 }
 
-static void yprp_node(struct ypr_ctx *ctx, const struct lysp_node *node);
-static void yprp_action(struct ypr_ctx *ctx, const struct lysp_node_action *action);
-static void yprp_notification(struct ypr_ctx *ctx, const struct lysp_node_notif *notif);
+static void yprp_node(struct lys_ypr_ctx *ctx, const struct lysp_node *node);
+static void yprp_action(struct lys_ypr_ctx *ctx, const struct lysp_node_action *action);
+static void yprp_notification(struct lys_ypr_ctx *ctx, const struct lysp_node_notif *notif);
 
 static void
-yprp_grouping(struct ypr_ctx *ctx, const struct lysp_node_grp *grp)
+yprp_grouping(struct lys_ypr_ctx *ctx, const struct lysp_node_grp *grp)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -555,7 +555,7 @@ yprp_grouping(struct ypr_ctx *ctx, const struct lysp_node_grp *grp)
 }
 
 static void
-yprp_inout(struct ypr_ctx *ctx, const struct lysp_node_action_inout *inout, int8_t *flag)
+yprp_inout(struct lys_ypr_ctx *ctx, const struct lysp_node_action_inout *inout, int8_t *flag)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node *data;
@@ -590,7 +590,7 @@ yprp_inout(struct ypr_ctx *ctx, const struct lysp_node_action_inout *inout, int8
 }
 
 static void
-yprp_notification(struct ypr_ctx *ctx, const struct lysp_node_notif *notif)
+yprp_notification(struct lys_ypr_ctx *ctx, const struct lysp_node_notif *notif)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -631,7 +631,7 @@ yprp_notification(struct ypr_ctx *ctx, const struct lysp_node_notif *notif)
 }
 
 static void
-yprp_action(struct ypr_ctx *ctx, const struct lysp_node_action *action)
+yprp_action(struct lys_ypr_ctx *ctx, const struct lysp_node_action *action)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -664,7 +664,7 @@ yprp_action(struct ypr_ctx *ctx, const struct lysp_node_action *action)
 }
 
 static void
-yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
+yprp_node_common1(struct lys_ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
 {
     ypr_open(ctx, lys_nodetype2str(node->nodetype), "name", node->name, *flag);
     LEVEL++;
@@ -675,7 +675,7 @@ yprp_node_common1(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *fla
 }
 
 static void
-yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
+yprp_node_common2(struct lys_ypr_ctx *ctx, const struct lysp_node *node, int8_t *flag)
 {
     ypr_config(ctx, node->flags, node->exts, flag);
     if (node->nodetype & (LYS_CHOICE | LYS_LEAF | LYS_ANYDATA)) {
@@ -687,7 +687,7 @@ yprp_node_common2(struct ypr_ctx *ctx, const struct lysp_node *node, int8_t *fla
 }
 
 static void
-yprp_container(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_container(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -740,7 +740,7 @@ yprp_container(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_case(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     int8_t flag = 0;
     struct lysp_node *child;
@@ -759,7 +759,7 @@ yprp_case(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_choice(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_choice(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     int8_t flag = 0;
     struct lysp_node *child;
@@ -784,7 +784,7 @@ yprp_choice(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_leaf(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_leaf(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node_leaf *leaf = (struct lysp_node_leaf *)node;
@@ -807,7 +807,7 @@ yprp_leaf(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_leaflist(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_leaflist(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node_leaflist *llist = (struct lysp_node_leaflist *)node;
@@ -850,7 +850,7 @@ yprp_leaflist(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_list(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_list(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -927,7 +927,7 @@ yprp_list(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_refine(struct ypr_ctx *ctx, struct lysp_refine *refine)
+yprp_refine(struct lys_ypr_ctx *ctx, struct lysp_refine *refine)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -977,7 +977,7 @@ yprp_refine(struct ypr_ctx *ctx, struct lysp_refine *refine)
 }
 
 static void
-yprp_augment(struct ypr_ctx *ctx, const struct lysp_node_augment *aug)
+yprp_augment(struct lys_ypr_ctx *ctx, const struct lysp_node_augment *aug)
 {
     struct lysp_node *child;
     struct lysp_node_action *action;
@@ -1010,7 +1010,7 @@ yprp_augment(struct ypr_ctx *ctx, const struct lysp_node_augment *aug)
 }
 
 static void
-yprp_uses(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_uses(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -1035,7 +1035,7 @@ yprp_uses(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_anydata(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_anydata(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     LY_ARRAY_COUNT_TYPE u;
     int8_t flag = 0;
@@ -1055,7 +1055,7 @@ yprp_anydata(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_node(struct ypr_ctx *ctx, const struct lysp_node *node)
+yprp_node(struct lys_ypr_ctx *ctx, const struct lysp_node *node)
 {
     switch (node->nodetype) {
     case LYS_CONTAINER:
@@ -1089,7 +1089,7 @@ yprp_node(struct ypr_ctx *ctx, const struct lysp_node *node)
 }
 
 static void
-yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
+yprp_deviation(struct lys_ypr_ctx *ctx, const struct lysp_deviation *deviation)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_deviate_add *add;
@@ -1194,14 +1194,14 @@ yprp_deviation(struct ypr_ctx *ctx, const struct lysp_deviation *deviation)
 }
 
 static void
-ypr_xmlns(struct ypr_ctx *ctx, const struct lys_module *module, uint16_t indent)
+ypr_xmlns(struct lys_ypr_ctx *ctx, const struct lys_module *module, uint16_t indent)
 {
     ly_print_(ctx->out, "%*sxmlns=\"%s\"", indent + INDENT, YIN_NS_URI);
     ly_print_(ctx->out, "\n%*sxmlns:%s=\"%s\"", indent + INDENT, module->prefix, module->ns);
 }
 
 static void
-ypr_import_xmlns(struct ypr_ctx *ctx, const struct lysp_module *modp, uint16_t indent)
+ypr_import_xmlns(struct lys_ypr_ctx *ctx, const struct lysp_module *modp, uint16_t indent)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -1211,7 +1211,7 @@ ypr_import_xmlns(struct ypr_ctx *ctx, const struct lysp_module *modp, uint16_t i
 }
 
 static void
-yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
+yprp_stmt(struct lys_ypr_ctx *ctx, struct lysp_stmt *stmt)
 {
     struct lysp_stmt *childstmt;
     int8_t flag = stmt->child ? 1 : -1;
@@ -1243,7 +1243,7 @@ yprp_stmt(struct ypr_ctx *ctx, struct lysp_stmt *stmt)
  * @param[in] count Number of extensions to print, 0 to print them all.
  */
 static void
-yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
+yprp_extension_instances(struct lys_ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t substmt_index,
         struct lysp_ext_instance *ext, int8_t *flag, LY_ARRAY_COUNT_TYPE count)
 {
     LY_ARRAY_COUNT_TYPE u;
@@ -1289,7 +1289,7 @@ yprp_extension_instances(struct ypr_ctx *ctx, LYEXT_SUBSTMT substmt, uint8_t sub
 }
 
 static void
-yin_print_parsed_linkage(struct ypr_ctx *ctx, const struct lysp_module *modp)
+yin_print_parsed_linkage(struct lys_ypr_ctx *ctx, const struct lysp_module *modp)
 {
     LY_ARRAY_COUNT_TYPE u;
 
@@ -1333,7 +1333,7 @@ yin_print_parsed_linkage(struct ypr_ctx *ctx, const struct lysp_module *modp)
 }
 
 static void
-yin_print_parsed_body(struct ypr_ctx *ctx, const struct lysp_module *modp)
+yin_print_parsed_body(struct lys_ypr_ctx *ctx, const struct lysp_module *modp)
 {
     LY_ARRAY_COUNT_TYPE u;
     struct lysp_node *data;
@@ -1393,7 +1393,7 @@ yin_print_parsed_module(struct ly_out *out, const struct lysp_module *modp, uint
 {
     LY_ARRAY_COUNT_TYPE u;
     const struct lys_module *module = modp->mod;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
+    struct lys_ypr_ctx ctx_ = {.out = out, .level = 0, .module = module, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     ly_print_(ctx->out, "%*s<module name=\"%s\"\n", INDENT, module->name);
@@ -1441,7 +1441,7 @@ yin_print_parsed_module(struct ly_out *out, const struct lysp_module *modp, uint
 }
 
 static void
-yprp_belongsto(struct ypr_ctx *ctx, const struct lysp_submodule *submodp)
+yprp_belongsto(struct lys_ypr_ctx *ctx, const struct lysp_submodule *submodp)
 {
     ypr_open(ctx, "belongs-to", "module", submodp->mod->name, 1);
     LEVEL++;
@@ -1455,7 +1455,7 @@ LY_ERR
 yin_print_parsed_submodule(struct ly_out *out, const struct lysp_submodule *submodp, uint32_t options)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct ypr_ctx ctx_ = {.out = out, .level = 0, .module = submodp->mod, .options = options}, *ctx = &ctx_;
+    struct lys_ypr_ctx ctx_ = {.out = out, .level = 0, .module = submodp->mod, .options = options}, *ctx = &ctx_;
 
     ly_print_(ctx->out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     ly_print_(ctx->out, "%*s<submodule name=\"%s\"\n", INDENT, submodp->name);

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -205,6 +205,37 @@ lysc_ext_dup(struct lysc_ext *orig)
     return orig;
 }
 
+LY_ERR
+lysc_ext_substmt(const struct lysc_ext_instance *ext, enum ly_stmt substmt, void **instance_p, enum ly_stmt_cardinality *cardinality_p)
+{
+    LY_ARRAY_COUNT_TYPE u;
+
+    LY_ARRAY_FOR(ext->substmts, u) {
+        if (LY_STMT_IS_NODE(substmt)) {
+            if (!LY_STMT_IS_NODE(ext->substmts[u].stmt)) {
+                continue;
+            }
+        } else if (LY_STMT_IS_OP(substmt)) {
+            if (!LY_STMT_IS_OP(ext->substmts[u].stmt)) {
+                continue;
+            }
+        } else if (ext->substmts[u].stmt != substmt) {
+            continue;
+        }
+
+        /* match */
+        if (cardinality_p) {
+            *cardinality_p = ext->substmts[u].cardinality;
+        }
+        if (instance_p) {
+            *instance_p = ext->substmts[u].storage;
+        }
+        return LY_SUCCESS;
+    }
+
+    return LY_ENOT;
+}
+
 static void
 lysc_unres_dflt_free(const struct ly_ctx *ctx, struct lysc_unres_dflt *r)
 {
@@ -602,12 +633,12 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
         if (stmt->flags & (LYS_YIN_ATTR | LYS_YIN_ARGUMENT)) {
             continue;
         }
-        for (u = 0; substmts[u].stmt; ++u) {
+        LY_ARRAY_FOR(substmts, u) {
             if (substmts[u].stmt == stmt->kw) {
                 break;
             }
         }
-        if (!substmts[u].stmt) {
+        if (u == LY_ARRAY_COUNT(substmts)) {
             LOGVAL(ctx->ctx, LYVE_SYNTAX_YANG, "Invalid keyword \"%s\" as a child of \"%s%s%s\" extension instance.",
                     stmt->stmt, ext->name, ext->argument ? " " : "", ext->argument ? ext->argument : "");
             goto cleanup;
@@ -618,7 +649,7 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
 
     /* keep order of the processing the same as the order in the defined substmts,
      * the order is important for some of the statements depending on others (e.g. type needs status and units) */
-    for (u = 0; substmts[u].stmt; ++u) {
+    LY_ARRAY_FOR(substmts, u) {
         ly_bool stmt_present = 0;
 
         for (stmt = ext->child; stmt; stmt = stmt->next) {
@@ -633,6 +664,8 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
                     assert(substmts[u].cardinality < LY_STMT_CARD_SOME);
                     LY_CHECK_ERR_GOTO(r = lysp_stmt_parse(ctx, stmt, &substmts[u].storage, /* TODO */ NULL), ret = r, cleanup);
                     break;
+                case LY_STMT_DESCRIPTION:
+                case LY_STMT_REFERENCE:
                 case LY_STMT_UNITS: {
                     const char **units;
 

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -631,7 +631,7 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
                 switch (stmt->kw) {
                 case LY_STMT_STATUS:
                     assert(substmts[u].cardinality < LY_STMT_CARD_SOME);
-                    LY_CHECK_ERR_GOTO(r = lysp_stmt_parse(ctx, stmt, stmt->kw, &substmts[u].storage, /* TODO */ NULL), ret = r, cleanup);
+                    LY_CHECK_ERR_GOTO(r = lysp_stmt_parse(ctx, stmt, &substmts[u].storage, /* TODO */ NULL), ret = r, cleanup);
                     break;
                 case LY_STMT_UNITS: {
                     const char **units;
@@ -670,7 +670,7 @@ lys_compile_extension_instance(struct lysc_ctx *ctx, const struct lysp_ext_insta
                         compiled = (void *)type;
                     }
 
-                    r = lysp_stmt_parse(ctx, stmt, stmt->kw, &parsed, NULL);
+                    r = lysp_stmt_parse(ctx, stmt, &parsed, NULL);
                     LY_CHECK_ERR_GOTO(r, ret = r, cleanup);
                     r = lys_compile_type(ctx, NULL, flags ? *flags : 0, ext->name, parsed, (struct lysc_type **)compiled,
                             units && !*units ? units : NULL, NULL);

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -181,6 +181,9 @@ lys_compile_ext(struct lysc_ctx *ctx, struct lysp_ext_instance *ext_p, struct ly
             lysc_update_path(ctx, (struct lysc_node *)ext, ext->argument);
         }
         ret = ext->def->plugin->compile(ctx, ext_p, ext);
+        if (ret == LY_ENOT) {
+            lysc_ext_instance_free(ctx->ctx, ext);
+        }
         if (ext->argument) {
             lysc_update_path(ctx, NULL, NULL);
         }

--- a/src/schema_compile.h
+++ b/src/schema_compile.h
@@ -67,6 +67,8 @@ struct lysc_ctx {
                                      - augment - module where the augment is defined
                                      - deviation - module where the deviation is defined
                                      - uses - module where the grouping is defined */
+    struct lysc_ext_instance *ext; /**< extension instance being processed and serving as a source for its substatements
+                                     instead of the module itself */
     struct ly_set groupings;    /**< stack for groupings circular check */
     struct ly_set tpdf_chain;
     struct ly_set disabled;     /**< set of compiled nodes whose if-feature(s) was not satisifed */

--- a/src/schema_compile.h
+++ b/src/schema_compile.h
@@ -45,6 +45,7 @@ struct lyxp_expr;
                                                       it will be removed at the end of compilation and should not be
                                                       added to any unres sets. */
 #define LYS_COMPILE_NO_CONFIG       0x04            /**< ignore config statements, neither inherit config value */
+#define LYS_COMPILE_NO_DISABLED     0x08            /**< ignore if-feature statements */
 
 #define LYS_COMPILE_RPC_INPUT       (LYS_IS_INPUT | LYS_COMPILE_NO_CONFIG)  /**< Internal option when compiling schema tree of RPC/action input */
 #define LYS_COMPILE_RPC_OUTPUT      (LYS_IS_OUTPUT | LYS_COMPILE_NO_CONFIG) /**< Internal option when compiling schema tree of RPC/action output */

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2201,7 +2201,9 @@ lys_compile_node_connect(struct lysc_ctx *ctx, struct lysc_node *parent, struct 
         /* top-level element */
         struct lysc_node **list;
 
-        if (node->nodetype == LYS_RPC) {
+        if (ctx->ext) {
+            lysc_ext_substmt(ctx->ext, LY_STMT_CONTAINER /* matches all data nodes */, (void **)&list, NULL);
+        } else if (node->nodetype == LYS_RPC) {
             list = (struct lysc_node **)&ctx->cur_mod->compiled->rpcs;
         } else if (node->nodetype == LYS_NOTIF) {
             list = (struct lysc_node **)&ctx->cur_mod->compiled->notifs;

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2322,7 +2322,7 @@ lys_compile_node_(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc_nod
 
     /* if-features */
     LY_CHECK_GOTO(ret = lys_eval_iffeatures(ctx->ctx, pnode->iffeatures, &enabled), error);
-    if (!enabled && !(ctx->options & (LYS_COMPILE_DISABLED | LYS_COMPILE_GROUPING))) {
+    if (!enabled && !(ctx->options & (LYS_COMPILE_NO_DISABLED | LYS_COMPILE_DISABLED | LYS_COMPILE_GROUPING))) {
         ly_set_add(&ctx->disabled, node, 1, NULL);
         ctx->options |= LYS_COMPILE_DISABLED;
     }

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -2412,8 +2412,8 @@ lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct ly
     LY_CHECK_ERR_GOTO(!mt, LOGMEM(mod->ctx); ret = LY_EMEM, cleanup);
     mt->parent = parent;
     mt->annotation = ant;
-    ret = lyd_value_store(mod->ctx, &mt->value, ((struct lyext_metadata *)ant->data)->type, value, value_len, dynamic,
-            format, prefix_data, hints, parent ? parent->schema : NULL, incomplete);
+    ret = lyd_value_store(mod->ctx, &mt->value,  *(const struct lysc_type **)ant->substmts[ANNOTATION_SUBSTMT_TYPE].storage,
+            value, value_len, dynamic, format, prefix_data, hints, parent ? parent->schema : NULL, incomplete);
     LY_CHECK_ERR_GOTO(ret, free(mt), cleanup);
     ret = lydict_insert(mod->ctx, name, name_len, &mt->name);
     LY_CHECK_ERR_GOTO(ret, free(mt), cleanup);

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -38,6 +38,7 @@
 #include "parser_internal.h"
 #include "parser_schema.h"
 #include "path.h"
+#include "plugins_exts.h"
 #include "schema_compile.h"
 #include "schema_compile_amend.h"
 #include "schema_features.h"
@@ -51,81 +52,81 @@
  * @brief information about YANG statements
  */
 struct stmt_info_s stmt_attr_info[] = {
-    {NULL,               NULL,          0},            /**< LY_STMT_NONE */
-    {"action",           "name",        STMT_FLAG_ID}, /**< LY_STMT_ACTION */
-    {"anydata",          "name",        STMT_FLAG_ID}, /**< LY_STMT_ANYDATA */
-    {"anyxml",           "name",        STMT_FLAG_ID}, /**< LY_STMT_ANYXML */
-    {"argument",         "name",        STMT_FLAG_ID}, /**< LY_STMT_ARGUMENT */
-    {"text",             NULL,          0},            /**< LY_STMT_ARG_TEXT */
-    {"value",            NULL,          0},            /**< LY_STMT_ARG_VALUE */
-    {"augment",          "target-node", STMT_FLAG_ID}, /**< LY_STMT_AUGMENT */
-    {"base",             "name",        STMT_FLAG_ID}, /**< LY_STMT_BASE */
-    {"belongs-to",       "module",      STMT_FLAG_ID}, /**< LY_STMT_BELONGS_TO */
-    {"bit",              "name",        STMT_FLAG_ID}, /**< LY_STMT_BIT */
-    {"case",             "name",        STMT_FLAG_ID}, /**< LY_STMT_CASE */
-    {"choice",           "name",        STMT_FLAG_ID}, /**< LY_STMT_CHOICE */
-    {"config",           "value",       STMT_FLAG_ID}, /**< LY_STMT_CONFIG */
-    {"contact",          "text",        STMT_FLAG_YIN},/**< LY_STMT_CONTACT */
-    {"container",        "name",        STMT_FLAG_ID}, /**< LY_STMT_CONTAINER */
-    {"default",          "value",       0},            /**< LY_STMT_DEFAULT */
-    {"description",      "text",        STMT_FLAG_YIN},/**< LY_STMT_DESCRIPTION */
-    {"deviate",          "value",       STMT_FLAG_ID}, /**< LY_STMT_DEVIATE */
-    {"deviation",        "target-node", STMT_FLAG_ID}, /**< LY_STMT_DEVIATION */
-    {"enum",             "name",        STMT_FLAG_ID}, /**< LY_STMT_ENUM */
-    {"error-app-tag",    "value",       0},            /**< LY_STMT_ERRTAG */
-    {"error-message",    "value",       STMT_FLAG_YIN},/**< LY_STMT_ERRMSG */
-    {"extension",        "name",        STMT_FLAG_ID}, /**< LY_STMT_EXTENSION */
-    {NULL,               NULL,          0},            /**< LY_STMT_EXTENSION_INSTANCE */
-    {"feature",          "name",        STMT_FLAG_ID}, /**< LY_STMT_FEATURE */
-    {"fraction-digits",  "value",       STMT_FLAG_ID}, /**< LY_STMT_FRACTION_DIGITS */
-    {"grouping",         "name",        STMT_FLAG_ID}, /**< LY_STMT_GROUPING */
-    {"identity",         "name",        STMT_FLAG_ID}, /**< LY_STMT_IDENTITY */
-    {"if-feature",       "name",        0},            /**< LY_STMT_IF_FEATURE */
-    {"import",           "module",      STMT_FLAG_ID}, /**< LY_STMT_IMPORT */
-    {"include",          "module",      STMT_FLAG_ID}, /**< LY_STMT_INCLUDE */
-    {"input",            NULL,          0},            /**< LY_STMT_INPUT */
-    {"key",              "value",       0},            /**< LY_STMT_KEY */
-    {"leaf",             "name",        STMT_FLAG_ID}, /**< LY_STMT_LEAF */
-    {"leaf-list",        "name",        STMT_FLAG_ID}, /**< LY_STMT_LEAF_LIST */
-    {"length",           "value",       0},            /**< LY_STMT_LENGTH */
-    {"list",             "name",        STMT_FLAG_ID}, /**< LY_STMT_LIST */
-    {"mandatory",        "value",       STMT_FLAG_ID}, /**< LY_STMT_MANDATORY */
-    {"max-elements",     "value",       STMT_FLAG_ID}, /**< LY_STMT_MAX_ELEMENTS */
-    {"min-elements",     "value",       STMT_FLAG_ID}, /**< LY_STMT_MIN_ELEMENTS */
-    {"modifier",         "value",       STMT_FLAG_ID}, /**< LY_STMT_MODIFIER */
-    {"module",           "name",        STMT_FLAG_ID}, /**< LY_STMT_MODULE */
-    {"must",             "condition",   0},            /**< LY_STMT_MUST */
-    {"namespace",        "uri",         0},            /**< LY_STMT_NAMESPACE */
-    {"notification",     "name",        STMT_FLAG_ID}, /**< LY_STMT_NOTIFICATION */
-    {"ordered-by",       "value",       STMT_FLAG_ID}, /**< LY_STMT_ORDERED_BY */
-    {"organization",     "text",        STMT_FLAG_YIN},/**< LY_STMT_ORGANIZATION */
-    {"output",           NULL,          0},            /**< LY_STMT_OUTPUT */
-    {"path",             "value",       0},            /**< LY_STMT_PATH */
-    {"pattern",          "value",       0},            /**< LY_STMT_PATTERN */
-    {"position",         "value",       STMT_FLAG_ID}, /**< LY_STMT_POSITION */
-    {"prefix",           "value",       STMT_FLAG_ID}, /**< LY_STMT_PREFIX */
-    {"presence",         "value",       0},            /**< LY_STMT_PRESENCE */
-    {"range",            "value",       0},            /**< LY_STMT_RANGE */
-    {"reference",        "text",        STMT_FLAG_YIN},/**< LY_STMT_REFERENCE */
-    {"refine",           "target-node", STMT_FLAG_ID}, /**< LY_STMT_REFINE */
-    {"require-instance", "value",       STMT_FLAG_ID}, /**< LY_STMT_REQUIRE_INSTANCE */
-    {"revision",         "date",        STMT_FLAG_ID}, /**< LY_STMT_REVISION */
-    {"revision-date",    "date",        STMT_FLAG_ID}, /**< LY_STMT_REVISION_DATE */
-    {"rpc",              "name",        STMT_FLAG_ID}, /**< LY_STMT_RPC */
-    {"status",           "value",       STMT_FLAG_ID}, /**< LY_STMT_STATUS */
-    {"submodule",        "name",        STMT_FLAG_ID}, /**< LY_STMT_SUBMODULE */
-    {"{",                NULL,          0},            /**< LY_STMT_SYNTAX_LEFT_BRACE */
-    {"}",                NULL,          0},            /**< LY_STMT_SYNTAX_RIGHT_BRACE */
-    {";",                NULL,          0},            /**< LY_STMT_SYNTAX_SEMICOLON */
-    {"type",             "name",        STMT_FLAG_ID}, /**< LY_STMT_TYPE */
-    {"typedef",          "name",        STMT_FLAG_ID}, /**< LY_STMT_TYPEDEF */
-    {"unique",           "tag",         0},            /**< LY_STMT_UNIQUE */
-    {"units",            "name",        0},            /**< LY_STMT_UNITS */
-    {"uses",             "name",        STMT_FLAG_ID}, /**< LY_STMT_USES */
-    {"value",            "value",       STMT_FLAG_ID}, /**< LY_STMT_VALUE */
-    {"when",             "condition",   0},            /**< LY_STMT_WHEN */
-    {"yang-version",     "value",       STMT_FLAG_ID}, /**< LY_STMT_YANG_VERSION */
-    {"yin-element",      "value",       STMT_FLAG_ID}, /**< LY_STMT_YIN_ELEMENT */
+    [LY_STMT_NONE] = {NULL, NULL, 0},
+    [LY_STMT_ACTION] = {"action", "name", STMT_FLAG_ID},
+    [LY_STMT_ANYDATA] = {"anydata", "name", STMT_FLAG_ID},
+    [LY_STMT_ANYXML] = {"anyxml", "name", STMT_FLAG_ID},
+    [LY_STMT_ARGUMENT] = {"argument", "name", STMT_FLAG_ID},
+    [LY_STMT_ARG_TEXT] = {"text", NULL, 0},
+    [LY_STMT_ARG_VALUE] = {"value", NULL, 0},
+    [LY_STMT_AUGMENT] = {"augment", "target-node", STMT_FLAG_ID},
+    [LY_STMT_BASE] = {"base", "name", STMT_FLAG_ID},
+    [LY_STMT_BELONGS_TO] = {"belongs-to", "module", STMT_FLAG_ID},
+    [LY_STMT_BIT] = {"bit", "name", STMT_FLAG_ID},
+    [LY_STMT_CASE] = {"case", "name", STMT_FLAG_ID},
+    [LY_STMT_CHOICE] = {"choice", "name", STMT_FLAG_ID},
+    [LY_STMT_CONFIG] = {"config", "value", STMT_FLAG_ID},
+    [LY_STMT_CONTACT] = {"contact", "text", STMT_FLAG_YIN},
+    [LY_STMT_CONTAINER] = {"container", "name", STMT_FLAG_ID},
+    [LY_STMT_DEFAULT] = {"default", "value", 0},
+    [LY_STMT_DESCRIPTION] = {"description", "text", STMT_FLAG_YIN},
+    [LY_STMT_DEVIATE] = {"deviate", "value", STMT_FLAG_ID},
+    [LY_STMT_DEVIATION] = {"deviation", "target-node", STMT_FLAG_ID},
+    [LY_STMT_ENUM] = {"enum", "name", STMT_FLAG_ID},
+    [LY_STMT_ERROR_APP_TAG] = {"error-app-tag", "value", 0},
+    [LY_STMT_ERROR_MESSAGE] = {"error-message", "value", STMT_FLAG_YIN},
+    [LY_STMT_EXTENSION] = {"extension", "name", STMT_FLAG_ID},
+    [LY_STMT_EXTENSION_INSTANCE] = {NULL, NULL, 0},
+    [LY_STMT_FEATURE] = {"feature", "name", STMT_FLAG_ID},
+    [LY_STMT_FRACTION_DIGITS] = {"fraction-digits", "value", STMT_FLAG_ID},
+    [LY_STMT_GROUPING] = {"grouping", "name", STMT_FLAG_ID},
+    [LY_STMT_IDENTITY] = {"identity", "name", STMT_FLAG_ID},
+    [LY_STMT_IF_FEATURE] = {"if-feature", "name", 0},
+    [LY_STMT_IMPORT] = {"import", "module", STMT_FLAG_ID},
+    [LY_STMT_INCLUDE] = {"include", "module", STMT_FLAG_ID},
+    [LY_STMT_INPUT] = {"input", NULL, 0},
+    [LY_STMT_KEY] = {"key", "value", 0},
+    [LY_STMT_LEAF] = {"leaf", "name", STMT_FLAG_ID},
+    [LY_STMT_LEAF_LIST] = {"leaf-list", "name", STMT_FLAG_ID},
+    [LY_STMT_LENGTH] = {"length", "value", 0},
+    [LY_STMT_LIST] = {"list", "name", STMT_FLAG_ID},
+    [LY_STMT_MANDATORY] = {"mandatory", "value", STMT_FLAG_ID},
+    [LY_STMT_MAX_ELEMENTS] = {"max-elements", "value", STMT_FLAG_ID},
+    [LY_STMT_MIN_ELEMENTS] = {"min-elements", "value", STMT_FLAG_ID},
+    [LY_STMT_MODIFIER] = {"modifier", "value", STMT_FLAG_ID},
+    [LY_STMT_MODULE] = {"module", "name", STMT_FLAG_ID},
+    [LY_STMT_MUST] = {"must", "condition", 0},
+    [LY_STMT_NAMESPACE] = {"namespace", "uri", 0},
+    [LY_STMT_NOTIFICATION] = {"notification", "name", STMT_FLAG_ID},
+    [LY_STMT_ORDERED_BY] = {"ordered-by", "value", STMT_FLAG_ID},
+    [LY_STMT_ORGANIZATION] = {"organization", "text", STMT_FLAG_YIN},
+    [LY_STMT_OUTPUT] = {"output", NULL, 0},
+    [LY_STMT_PATH] = {"path", "value", 0},
+    [LY_STMT_PATTERN] = {"pattern", "value", 0},
+    [LY_STMT_POSITION] = {"position", "value", STMT_FLAG_ID},
+    [LY_STMT_PREFIX] = {"prefix", "value", STMT_FLAG_ID},
+    [LY_STMT_PRESENCE] = {"presence", "value", 0},
+    [LY_STMT_RANGE] = {"range", "value", 0},
+    [LY_STMT_REFERENCE] = {"reference", "text", STMT_FLAG_YIN},
+    [LY_STMT_REFINE] = {"refine", "target-node", STMT_FLAG_ID},
+    [LY_STMT_REQUIRE_INSTANCE] = {"require-instance", "value", STMT_FLAG_ID},
+    [LY_STMT_REVISION] = {"revision", "date", STMT_FLAG_ID},
+    [LY_STMT_REVISION_DATE] = {"revision-date", "date", STMT_FLAG_ID},
+    [LY_STMT_RPC] = {"rpc", "name", STMT_FLAG_ID},
+    [LY_STMT_STATUS] = {"status", "value", STMT_FLAG_ID},
+    [LY_STMT_SUBMODULE] = {"submodule", "name", STMT_FLAG_ID},
+    [LY_STMT_SYNTAX_LEFT_BRACE] = {"{", NULL, 0},
+    [LY_STMT_SYNTAX_RIGHT_BRACE] = {"}", NULL, 0},
+    [LY_STMT_SYNTAX_SEMICOLON] = {";", NULL, 0},
+    [LY_STMT_TYPE] = {"type", "name", STMT_FLAG_ID},
+    [LY_STMT_TYPEDEF] = {"typedef", "name", STMT_FLAG_ID},
+    [LY_STMT_UNIQUE] = {"unique", "tag", 0},
+    [LY_STMT_UNITS] = {"units", "name", 0},
+    [LY_STMT_USES] = {"uses", "name", STMT_FLAG_ID},
+    [LY_STMT_VALUE] = {"value", "value", STMT_FLAG_ID},
+    [LY_STMT_WHEN] = {"when", "condition", 0},
+    [LY_STMT_YANG_VERSION] = {"yang-version", "value", STMT_FLAG_ID},
+    [LY_STMT_YIN_ELEMENT] = {"yin-element", "value", STMT_FLAG_ID},
 };
 
 const char * const ly_devmod_list[] = {

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -400,6 +400,39 @@ lys_getnext_ext(const struct lysc_node *last, const struct lysc_node *parent, co
     return lys_getnext_(last, parent, NULL, ext, options);
 }
 
+const struct lysc_node *
+lys_find_ext_instance_node(const struct lysc_ext_instance *ext, const struct lys_module *module, const char *name, size_t name_len,
+        uint16_t nodetype, uint32_t options)
+{
+    const struct lysc_node *node = NULL;
+
+    LY_CHECK_ARG_RET(NULL, ext, name, NULL);
+    if (!nodetype) {
+        nodetype = LYS_NODETYPE_MASK;
+    }
+
+    if (module && (module != ext->module)) {
+        return NULL;
+    }
+
+    while ((node = lys_getnext_ext(node, NULL, ext, options))) {
+        if (!(node->nodetype & nodetype)) {
+            continue;
+        }
+
+        if (name_len) {
+            if (!ly_strncmp(node->name, name, name_len)) {
+                return node;
+            }
+        } else {
+            if (!strcmp(node->name, name)) {
+                return node;
+            }
+        }
+    }
+    return NULL;
+}
+
 API const struct lysc_node *
 lys_find_child(const struct lysc_node *parent, const struct lys_module *module, const char *name, size_t name_len,
         uint16_t nodetype, uint32_t options)

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -251,37 +251,93 @@ struct lyxp_expr;
 #define LYS_NODETYPE_MASK 0xffff  /**< Mask for nodetypes, the value is limited for 16 bits */
 
 /**
+ * @brief Generic test for operation (RPC or Action) statements.
+ */
+#define LY_STMT_IS_OP(STMT) (((STMT) == LY_STMT_ACTION) || ((STMT) == LY_STMT_RPC))
+
+/**
+ * @brief Generic test for schema node (anydata, anyxml, augment, case, choice, container, grouping,
+ * leaf, leaf-list, list and uses) statements.
+ *
+ * Covers the statements that maps to a common ::lysc_node or ::lysp_node structures. Note that the
+ * list of statements that can appear in parsed or compiled schema trees differs (e.g. no uses in compiled tree).
+ *
+ * The operations (action/RPC) and notification statements are not included since they are used to be stored
+ * in a separated lists in schema node structures.
+ */
+#define LY_STMT_IS_NODE(STMT) (((STMT) >= LY_STMT_ANYDATA) && ((STMT) <= LY_STMT_LIST))
+
+/**
  * @brief List of YANG statements
  */
 enum ly_stmt {
     LY_STMT_NONE = 0,
+
+    LY_STMT_NOTIFICATION,       /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node_notif *`.
+                                     The RPCs/Actions and Notifications are expected in a separated lists than the rest of
+                                     data definition nodes as it is done in generic structures of libyang. */
+
+/* LY_STMT_IS_OP */
     LY_STMT_ACTION,             /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node_action *`.
-                                     Note that due to compatibility with `struct lysc_node *`, the compiled actions can be actually
-                                     mixed in the linked list with other ::lysc_node based nodes if the storage is shared. */
+                                     The RPCs/Actions and Notifications are expected in a separated lists than the rest of
+                                     data definition nodes as it is done in generic structures of libyang. */
+    LY_STMT_RPC,                /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node_action *`.
+                                     The RPCs/Actions and Notifications are expected in a separated lists than the rest of
+                                     data definition nodes as it is done in generic structures of libyang. */
+
+/* LY_STMT_IS_NODE */
     LY_STMT_ANYDATA,            /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
-                                     Note that due to ::lysc_node compatibility the anydata can be actually mixed in
-                                     the linked list with other ::lysc_node based nodes if the storage is shared. */
+                                     Note that due to ::lysc_node compatibility the anydata is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
     LY_STMT_ANYXML,             /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
-                                     Note that due to ::lysc_node compatibility the anyxml can be actually mixed in
-                                     the linked list with other ::lysc_node based nodes if the storage is shared. */
+                                     Note that due to ::lysc_node compatibility the anyxml is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_AUGMENT,
+    LY_STMT_CASE,               /**< TODO is it possible to compile cases without the parent choice? */
+    LY_STMT_CHOICE,             /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
+                                     Note that due to ::lysc_node compatibility the choice is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_CONTAINER,          /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
+                                     Note that due to ::lysc_node compatibility the container is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_GROUPING,
+    LY_STMT_LEAF,               /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
+                                     Note that due to ::lysc_node compatibility the leaf is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_LEAF_LIST,          /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
+                                     Note that due to ::lysc_node compatibility the leaf-list is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_LIST,               /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
+                                     Note that due to ::lysc_node compatibility the list is expected to be actually
+                                     mixed in the linked list with other ::lysc_node based nodes. The RPCs/Actions and
+                                     Notifications are expected in a separated lists as it is done in generic structures
+                                     of libyang. */
+    LY_STMT_USES,
+
+/* rest */
     LY_STMT_ARGUMENT,
     LY_STMT_ARG_TEXT,
     LY_STMT_ARG_VALUE,
-    LY_STMT_AUGMENT,
     LY_STMT_BASE,
     LY_STMT_BELONGS_TO,
     LY_STMT_BIT,
-    LY_STMT_CASE,               /**< TODO is it possible to compile cases without the parent choice? */
-    LY_STMT_CHOICE,             /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
-                                     Note that due to ::lysc_node compatibility the choice can be actually mixed in
-                                     the linked list with other ::lysc_node based nodes if the storage is shared. */
     LY_STMT_CONFIG,             /**< in ::lysc_ext_substmt.storage stored as a pointer to `uint16_t`, only cardinality < #LY_STMT_CARD_SOME is allowed */
     LY_STMT_CONTACT,
-    LY_STMT_CONTAINER,          /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
-                                     Note that due to ::lysc_node compatibility the container can be actually mixed in
-                                     the linked list with other ::lysc_node based nodes if the storage is shared. */
     LY_STMT_DEFAULT,
-    LY_STMT_DESCRIPTION,
+    LY_STMT_DESCRIPTION,        /**< in ::lysc_ext_substmt.storage stored as a pointer to `const char *` (cardinality < #LY_STMT_CARD_SOME)
+                                     or as a pointer to a [sized array](@ref sizedarrays) `const char **` */
     LY_STMT_DEVIATE,
     LY_STMT_DEVIATION,
     LY_STMT_ENUM,
@@ -291,20 +347,15 @@ enum ly_stmt {
     LY_STMT_EXTENSION_INSTANCE,
     LY_STMT_FEATURE,
     LY_STMT_FRACTION_DIGITS,
-    LY_STMT_GROUPING,
     LY_STMT_IDENTITY,
-    LY_STMT_IF_FEATURE,         /**< in ::lysc_ext_substmt.storage stored as a pointer to `struct lysc_iffeature` (cardinality < #LY_STMT_CARD_SOME)
-                                     or as a pointer to a [sized array](@ref sizedarrays) `struct lysc_iffeature *` */
+    LY_STMT_IF_FEATURE,         /**< if-feature statements are not compiled, they are evaluated and the parent statement is
+                                     preserved only in case the evaluation of all the if-feature statements is true.
+                                     Therefore there is no storage expected. */
     LY_STMT_IMPORT,
     LY_STMT_INCLUDE,
     LY_STMT_INPUT,
     LY_STMT_KEY,
-    LY_STMT_LEAF,
-    LY_STMT_LEAF_LIST,
     LY_STMT_LENGTH,
-    LY_STMT_LIST,               /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node *`.
-                                     Note that due to ::lysc_node compatibility the list can be actually mixed in
-                                     the linked list with other ::lysc_node based nodes if the storage is shared. */
     LY_STMT_MANDATORY,          /**< in ::lysc_ext_substmt.storage stored as a pointer to `uint16_t`, only cardinality < #LY_STMT_CARD_SOME is allowed */
     LY_STMT_MAX_ELEMENTS,
     LY_STMT_MIN_ELEMENTS,
@@ -312,7 +363,6 @@ enum ly_stmt {
     LY_STMT_MODULE,
     LY_STMT_MUST,
     LY_STMT_NAMESPACE,
-    LY_STMT_NOTIFICATION,
     LY_STMT_ORDERED_BY,
     LY_STMT_ORGANIZATION,
     LY_STMT_OUTPUT,
@@ -322,14 +372,12 @@ enum ly_stmt {
     LY_STMT_PREFIX,
     LY_STMT_PRESENCE,
     LY_STMT_RANGE,
-    LY_STMT_REFERENCE,
+    LY_STMT_REFERENCE,          /**< in ::lysc_ext_substmt.storage stored as a pointer to `const char *` (cardinality < #LY_STMT_CARD_SOME)
+                                     or as a pointer to a [sized array](@ref sizedarrays) `const char **` */
     LY_STMT_REFINE,
     LY_STMT_REQUIRE_INSTANCE,
     LY_STMT_REVISION,
     LY_STMT_REVISION_DATE,
-    LY_STMT_RPC,                /**< in ::lysc_ext_substmt.storage stored as a pointer to linked list of `struct lysc_node_action *`.
-                                     Note that due to compatibility with `struct lysc_node *`, the compiled RPCs can be actually
-                                     mixed in the linked list with other ::lysc_node based nodes if the storage is shared. */
     LY_STMT_STATUS,             /**< in ::lysc_ext_substmt.storage stored as a pointer to `uint16_t`, only cardinality < #LY_STMT_CARD_SOME is allowed */
     LY_STMT_SUBMODULE,
     LY_STMT_SYNTAX_SEMICOLON,
@@ -341,7 +389,6 @@ enum ly_stmt {
     LY_STMT_UNIQUE,
     LY_STMT_UNITS,              /**< in ::lysc_ext_substmt.storage stored as a pointer to `const char *` (cardinality < #LY_STMT_CARD_SOME)
                                      or as a pointer to a [sized array](@ref sizedarrays) `const char **` */
-    LY_STMT_USES,
     LY_STMT_VALUE,
     LY_STMT_WHEN,
     LY_STMT_YANG_VERSION,

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -1395,6 +1395,8 @@ struct lysc_ext_instance {
     LYEXT_SUBSTMT insubstmt;         /**< value identifying placement of the extension instance */
     LYEXT_PARENT parent_type;        /**< type of the parent structure */
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
+
+    struct lysc_ext_substmt *substmts; /**< list of allowed substatements with the storage to access the present substatements */
     void *data;                      /**< private plugins's data, not used by libyang */
 };
 

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -2352,9 +2352,35 @@ const struct lysc_node *lys_getnext(const struct lysc_node *last, const struct l
         const struct lysc_module *module, uint32_t options);
 
 /**
- * @defgroup sgetnextflags Options for ::lys_getnext().
+ * @brief Get next schema tree (sibling) node element that can be instantiated in a data tree.
  *
- * Various options setting behavior of ::lys_getnext().
+ * In contrast to ::lys_getnext(), ::lys_getnext_ext() is limited by the given @p ext instance as a schema tree root.
+ * If the extension does not contain any schema node, NULL is returned. If the @p parent is provided, the functionality
+ * is completely the same as ::lys_getnext().
+ *
+ * ::lys_getnext_ext() is supposed to be called sequentially. In the first call, the \p last parameter is usually NULL
+ * and function starts returning i) the first \p parent's child or ii) the first top level element of the given  @p ext
+ * instance. Consequent calls suppose to provide the previously returned node as the \p last parameter and still the same
+ * \p parent and \p ext parameters.
+ *
+ * Without options, the function is used to traverse only the schema nodes that can be paired with corresponding
+ * data nodes in a data tree. By setting some \p options the behavior can be modified to the extent that
+ * all the schema nodes are iteratively returned.
+ *
+ * @param[in] last Previously returned schema tree node, or NULL in case of the first call.
+ * @param[in] parent Parent of the subtree where the function starts processing.
+ * @param[in] ext The extension instance to provide a separate schema tree. To consider the top level elements in the tree,
+ * the \p parent must be NULL. anyway, at least one of @p parent and @p ext parameters must be specified.
+ * @param[in] options [ORed options](@ref sgetnextflags).
+ * @return Next schema tree node that can be instantiated in a data tree, NULL in case there is no such element.
+ */
+const struct lysc_node *lys_getnext_ext(const struct lysc_node *last, const struct lysc_node *parent,
+        const struct lysc_ext_instance *ext, uint32_t options);
+
+/**
+ * @defgroup sgetnextflags Options for ::lys_getnext() and ::lys_getnext_ext().
+ *
+ * Various options setting behavior of ::lys_getnext() and ::lys_getnext_ext().
  *
  * @{
  */

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -987,9 +987,11 @@ lys_module_free(struct lys_module *module, void (*private_destructor)(const stru
 }
 
 API void
-lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substmts)
+lysc_extension_instance_substatements_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substmts)
 {
-    for (LY_ARRAY_COUNT_TYPE u = 0; substmts[u].stmt; ++u) {
+    LY_ARRAY_COUNT_TYPE u;
+
+    LY_ARRAY_FOR(substmts, u) {
         if (!substmts[u].storage) {
             continue;
         }
@@ -1012,6 +1014,8 @@ lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substm
                 FREE_ARRAY(ctx, types, lysc_type2_free);
             }
             break;
+        case LY_STMT_DESCRIPTION:
+        case LY_STMT_REFERENCE:
         case LY_STMT_UNITS:
             if (substmts[u].cardinality < LY_STMT_CARD_SOME) {
                 /* single item */
@@ -1054,6 +1058,8 @@ lysc_extension_instance_free(struct ly_ctx *ctx, struct lysc_ext_substmt *substm
             LOGINT(ctx);
         }
     }
+
+    LY_ARRAY_FREE(substmts);
 }
 
 void

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -997,22 +997,27 @@ lysc_extension_instance_substatements_free(struct ly_ctx *ctx, struct lysc_ext_s
         }
 
         switch (substmts[u].stmt) {
-        case LY_STMT_TYPE:
-            if (substmts[u].cardinality < LY_STMT_CARD_SOME) {
-                /* single item */
-                struct lysc_type *type = *((struct lysc_type **)substmts[u].storage);
-                if (!type) {
-                    break;
-                }
-                lysc_type_free(ctx, type);
-            } else {
-                /* multiple items */
-                struct lysc_type **types = *((struct lysc_type ***)substmts[u].storage);
-                if (!types) {
-                    break;
-                }
-                FREE_ARRAY(ctx, types, lysc_type2_free);
+        case LY_STMT_ACTION:
+        case LY_STMT_ANYDATA:
+        case LY_STMT_ANYXML:
+        case LY_STMT_CONTAINER:
+        case LY_STMT_CHOICE:
+        case LY_STMT_LEAF:
+        case LY_STMT_LEAF_LIST:
+        case LY_STMT_LIST:
+        case LY_STMT_NOTIFICATION:
+        case LY_STMT_RPC:
+        case LY_STMT_USES: {
+            struct lysc_node *child, *child_next;
+
+            LY_LIST_FOR_SAFE(*((struct lysc_node **)substmts[u].storage), child_next, child) {
+                lysc_node_free_(ctx, child);
             }
+            break;
+        }
+        case LY_STMT_CONFIG:
+        case LY_STMT_STATUS:
+            /* nothing to do */
             break;
         case LY_STMT_DESCRIPTION:
         case LY_STMT_REFERENCE:
@@ -1033,10 +1038,6 @@ lysc_extension_instance_substatements_free(struct ly_ctx *ctx, struct lysc_ext_s
                 FREE_STRINGS(ctx, strs);
             }
             break;
-        case LY_STMT_STATUS:
-        case LY_STMT_CONFIG:
-            /* nothing to do */
-            break;
         case LY_STMT_IF_FEATURE: {
             struct lysc_iffeature *iff = *((struct lysc_iffeature **)substmts[u].storage);
             if (!iff) {
@@ -1049,6 +1050,23 @@ lysc_extension_instance_substatements_free(struct ly_ctx *ctx, struct lysc_ext_s
             } else {
                 /* multiple items */
                 FREE_ARRAY(ctx, iff, lysc_iffeature_free);
+            }
+            break;
+        case LY_STMT_TYPE:
+            if (substmts[u].cardinality < LY_STMT_CARD_SOME) {
+                /* single item */
+                struct lysc_type *type = *((struct lysc_type **)substmts[u].storage);
+                if (!type) {
+                    break;
+                }
+                lysc_type_free(ctx, type);
+            } else {
+                /* multiple items */
+                struct lysc_type **types = *((struct lysc_type ***)substmts[u].storage);
+                if (!types) {
+                    break;
+                }
+                FREE_ARRAY(ctx, types, lysc_type2_free);
             }
             break;
         }

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -614,7 +614,7 @@ void lysp_ext_instance_free(struct ly_ctx *ctx, struct lysp_ext_instance *ext);
 /**
  * @param[in,out] exts [sized array](@ref sizedarrays) For extension instances in case of statements that do not store extension instances in their own list.
  */
-LY_ERR lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, enum ly_stmt kw, void **result, struct lysp_ext_instance **exts);
+LY_ERR lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, void **result, struct lysp_ext_instance **exts);
 
 /**
  * @brief Free a parsed node.

--- a/src/validation.c
+++ b/src/validation.c
@@ -27,6 +27,7 @@
 #include "hash_table.h"
 #include "log.h"
 #include "parser_data.h"
+#include "plugins_exts.h"
 #include "plugins_exts_metadata.h"
 #include "plugins_types.h"
 #include "set.h"
@@ -269,7 +270,7 @@ lyd_validate_unres(struct lyd_node **tree, const struct lys_module *mod, struct 
             --i;
 
             struct lyd_meta *meta = meta_types->objs[i];
-            struct lysc_type *type = ((struct lyext_metadata *)meta->annotation->data)->type;
+            struct lysc_type *type = *(struct lysc_type **)meta->annotation->substmts[ANNOTATION_SUBSTMT_TYPE].storage;
 
             /* validate and store the value of the metadata */
             ret = lyd_value_validate_incomplete(LYD_CTX(meta->parent), type, &meta->value, meta->parent, *tree);
@@ -1322,7 +1323,7 @@ lyd_validate_subtree(struct lyd_node *root, struct ly_set *node_when, struct ly_
 
     LYD_TREE_DFS_BEGIN(root, node) {
         LY_LIST_FOR(node->meta, meta) {
-            if (((struct lyext_metadata *)meta->annotation->data)->type->plugin->validate) {
+            if ((*(const struct lysc_type **)meta->annotation->substmts[ANNOTATION_SUBSTMT_TYPE].storage)->plugin->validate) {
                 /* metadata type resolution */
                 LY_CHECK_RET(ly_set_add(meta_types, (void *)meta, 1, NULL));
             }

--- a/tests/modules/yang/ietf-restconf@2017-01-26.yang
+++ b/tests/modules/yang/ietf-restconf@2017-01-26.yang
@@ -1,0 +1,278 @@
+module ietf-restconf {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-restconf";
+  prefix "rc";
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+
+  description
+    "This module contains conceptual YANG specifications
+     for basic RESTCONF media type definitions used in
+     RESTCONF protocol messages.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The 'restconf-media-type' YANG extension statement
+     provides a normative syntax for XML and JSON
+     message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8040; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-01-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8040: RESTCONF Protocol.";
+  }
+
+  extension yang-data {
+    argument name {
+      yin-element true;
+    }
+    description
+      "This extension is used to specify a YANG data template that
+       represents conceptual data defined in YANG.  It is
+       intended to describe hierarchical data independent of
+       protocol context or specific message-encoding format.
+       Data definition statements within a yang-data extension
+       specify the generic syntax for the specific YANG data
+       template, whose name is the argument of the 'yang-data'
+       extension statement.
+
+       Note that this extension does not define a media type.
+       A specification using this extension MUST specify the
+       message-encoding rules, including the content media type.
+
+       The mandatory 'name' parameter value identifies the YANG
+       data template that is being defined.  It contains the
+       template name.
+
+       This extension is ignored unless it appears as a top-level
+       statement.  It MUST contain data definition statements
+       that result in exactly one container data node definition.
+       An instance of a YANG data template can thus be translated
+       into an XML instance document, whose top-level element
+       corresponds to the top-level container.
+       The module name and namespace values for the YANG module using
+       the extension statement are assigned to instance document data
+       conforming to the data definition statements within
+       this extension.
+
+       The substatements of this extension MUST follow the
+       'data-def-stmt' rule in the YANG ABNF.
+
+       The XPath document root is the extension statement itself,
+       such that the child nodes of the document root are
+       represented by the data-def-stmt substatements within
+       this extension.  This conceptual document is the context
+       for the following YANG statements:
+
+         - must-stmt
+         - when-stmt
+         - path-stmt
+         - min-elements-stmt
+         - max-elements-stmt
+         - mandatory-stmt
+         - unique-stmt
+         - ordered-by
+         - instance-identifier data type
+
+       The following data-def-stmt substatements are constrained
+       when used within a 'yang-data' extension statement.
+
+         - The list-stmt is not required to have a key-stmt defined.
+         - The if-feature-stmt is ignored if present.
+         - The config-stmt is ignored if present.
+         - The available identity values for any 'identityref'
+           leaf or leaf-list nodes are limited to the module
+           containing this extension statement and the modules
+           imported into that module.
+      ";
+  }
+
+  rc:yang-data yang-errors {
+    uses errors;
+  }
+
+  rc:yang-data yang-api {
+    uses restconf;
+  }
+
+  grouping errors {
+    description
+      "A grouping that contains a YANG container
+       representing the syntax and semantics of a
+       YANG Patch error report within a response message.";
+
+    container errors {
+      description
+        "Represents an error report returned by the server if
+         a request results in an error.";
+
+      list error {
+        description
+          "An entry containing information about one
+           specific error that occurred while processing
+           a RESTCONF request.";
+        reference
+          "RFC 6241, Section 4.3.";
+
+        leaf error-type {
+          type enumeration {
+            enum transport {
+              description
+                "The transport layer.";
+            }
+            enum rpc {
+              description
+                "The rpc or notification layer.";
+            }
+            enum protocol {
+              description
+                "The protocol operation layer.";
+            }
+            enum application {
+              description
+                "The server application layer.";
+            }
+          }
+          mandatory true;
+          description
+            "The protocol layer where the error occurred.";
+        }
+
+        leaf error-tag {
+          type string;
+          mandatory true;
+          description
+            "The enumerated error-tag.";
+        }
+
+        leaf error-app-tag {
+          type string;
+          description
+            "The application-specific error-tag.";
+        }
+
+        leaf error-path {
+          type instance-identifier;
+          description
+            "The YANG instance identifier associated
+             with the error node.";
+        }
+
+        leaf error-message {
+          type string;
+          description
+            "A message describing the error.";
+        }
+
+        anydata error-info {
+           description
+             "This anydata value MUST represent a container with
+              zero or more data nodes representing additional
+              error information.";
+        }
+      }
+    }
+  }
+
+  grouping restconf {
+    description
+      "Conceptual grouping representing the RESTCONF
+       root resource.";
+
+    container restconf {
+      description
+        "Conceptual container representing the RESTCONF
+         root resource.";
+
+      container data {
+        description
+          "Container representing the datastore resource.
+           Represents the conceptual root of all state data
+           and configuration data supported by the server.
+           The child nodes of this container can be any data
+           resources that are defined as top-level data nodes
+           from the YANG modules advertised by the server in
+           the 'ietf-yang-library' module.";
+      }
+
+      container operations {
+        description
+          "Container for all operation resources.
+
+           Each resource is represented as an empty leaf with the
+           name of the RPC operation from the YANG 'rpc' statement.
+
+           For example, the 'system-restart' RPC operation defined
+           in the 'ietf-system' module would be represented as
+           an empty leaf in the 'ietf-system' namespace.  This is
+           a conceptual leaf and will not actually be found in
+           the module:
+
+              module ietf-system {
+                leaf system-reset {
+                  type empty;
+                }
+              }
+
+           To invoke the 'system-restart' RPC operation:
+
+              POST /restconf/operations/ietf-system:system-restart
+
+           To discover the RPC operations supported by the server:
+
+              GET /restconf/operations
+
+           In XML, the YANG module namespace identifies the module:
+
+             <system-restart
+                xmlns='urn:ietf:params:xml:ns:yang:ietf-system'/>
+
+           In JSON, the YANG module name identifies the module:
+
+             { 'ietf-system:system-restart' : [null] }
+          ";
+      }
+      leaf yang-library-version {
+        type string {
+          pattern '\d{4}-\d{2}-\d{2}';
+        }
+        config false;
+        mandatory true;
+        description
+          "Identifies the revision date of the 'ietf-yang-library'
+           module that is implemented by this RESTCONF server.
+           Indicates the year, month, and day in YYYY-MM-DD
+           numeric format.";
+      }
+    }
+  }
+
+}

--- a/tests/utests/CMakeLists.txt
+++ b/tests/utests/CMakeLists.txt
@@ -45,3 +45,4 @@ ly_add_utest(NAME diff SOURCES data/test_diff.c)
 
 ly_add_utest(NAME metadata SOURCES extensions/test_metadata.c)
 ly_add_utest(NAME nacm SOURCES extensions/test_nacm.c)
+ly_add_utest(NAME yangdata SOURCES extensions/test_yangdata.c)

--- a/tests/utests/extensions/test_metadata.c
+++ b/tests/utests/extensions/test_metadata.c
@@ -85,7 +85,7 @@ test_yang(void **state)
             "md:annotation aa {type string;} md:annotation aa {type uint8;}}";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - metadata, version 1\": "
-            "Extension md:annotation is instantiated multiple times.)", "/aa:{extension='md:annotation'}/aa");
+            "Extension md:annotation is instantiated multiple times.", "/aa:{extension='md:annotation'}/aa");
 }
 
 static void
@@ -182,7 +182,7 @@ test_yin(void **state)
             "</md:annotation></module>";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YIN, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - metadata, version 1\": "
-            "Extension md:annotation is instantiated multiple times.)", "/aa:{extension='md:annotation'}/aa");
+            "Extension md:annotation is instantiated multiple times.", "/aa:{extension='md:annotation'}/aa");
 }
 
 int

--- a/tests/utests/extensions/test_metadata.c
+++ b/tests/utests/extensions/test_metadata.c
@@ -15,6 +15,7 @@
 #include "utests.h"
 
 #include "libyang.h"
+#include "plugins_exts.h"
 #include "plugins_exts_metadata.h"
 
 static void
@@ -22,7 +23,6 @@ test_yang(void **state)
 {
     const struct lys_module *mod;
     struct lysc_ext_instance *e;
-    struct lyext_metadata *ant;
 
     const char *data = "module a {yang-version 1.1; namespace urn:tests:extensions:metadata:a; prefix a;"
             "import ietf-yang-metadata {prefix md;}"
@@ -40,8 +40,9 @@ test_yang(void **state)
     UTEST_ADD_MODULE(data, LYS_IN_YANG, feats, &mod);
     assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->exts));
     e = &mod->compiled->exts[0];
-    assert_non_null(ant = (struct lyext_metadata *)e->data);
-    assert_string_equal("meters", ant->units);
+    assert_non_null(e->data);
+    assert_non_null(e->substmts);
+    assert_string_equal("meters", *(const char **)e->substmts[ANNOTATION_SUBSTMT_UNITS].storage);
 
     /* invalid */
     /* missing mandatory type substatement */
@@ -93,7 +94,6 @@ test_yin(void **state)
 {
     const struct lys_module *mod;
     struct lysc_ext_instance *e;
-    struct lyext_metadata *ant;
     const char *data;
 
     data = "<module xmlns=\"urn:ietf:params:xml:ns:yang:yin:1\" xmlns:md=\"urn:ietf:params:xml:ns:yang:ietf-yang-metadata\" name=\"a\">\n"
@@ -113,8 +113,9 @@ test_yin(void **state)
     UTEST_ADD_MODULE(data, LYS_IN_YIN, feats, &mod);
     assert_int_equal(1, LY_ARRAY_COUNT(mod->compiled->exts));
     e = &mod->compiled->exts[0];
-    assert_non_null(ant = (struct lyext_metadata*)e->data);
-    assert_string_equal("meters", ant->units);
+    assert_non_null(e->data);
+    assert_non_null(e->substmts);
+    assert_string_equal("meters", *(const char **)e->substmts[ANNOTATION_SUBSTMT_UNITS].storage);
 
     /* invalid */
     /* missing mandatory type substatement */

--- a/tests/utests/extensions/test_nacm.c
+++ b/tests/utests/extensions/test_nacm.c
@@ -57,7 +57,7 @@ test_deny_all(void **state)
             "nacm:default-deny-all;}";
     assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
-            "Extension nacm:default-deny-all is allowed only in a data nodes, but it is placed in \"module\" statement.)",
+            "Extension nacm:default-deny-all is allowed only in a data nodes, but it is placed in \"module\" statement.",
             "/b:{extension='nacm:default-deny-all'}");
 
     /* invalid */
@@ -66,7 +66,7 @@ test_deny_all(void **state)
             "leaf l { type string; nacm:default-deny-all; nacm:default-deny-write;}}";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
-            "Extension nacm:default-deny-write is mixed with nacm:default-deny-all.)",
+            "Extension nacm:default-deny-write is mixed with nacm:default-deny-all.",
             "/aa:l/{extension='nacm:default-deny-write'}");
 }
 
@@ -99,7 +99,7 @@ test_deny_write(void **state)
             "notification notif {nacm:default-deny-write;}}";
     assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
-            "Extension nacm:default-deny-write is not allowed in notification statement.)",
+            "Extension nacm:default-deny-write is not allowed in notification statement.",
             "/b:notif/{extension='nacm:default-deny-write'}");
 
     /* invalid */
@@ -108,7 +108,7 @@ test_deny_write(void **state)
             "leaf l { type string; nacm:default-deny-write; nacm:default-deny-write;}}";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
-            "Extension nacm:default-deny-write is instantiated multiple times.)",
+            "Extension nacm:default-deny-write is instantiated multiple times.",
             "/aa:l/{extension='nacm:default-deny-write'}");
 }
 

--- a/tests/utests/extensions/test_nacm.c
+++ b/tests/utests/extensions/test_nacm.c
@@ -51,15 +51,16 @@ test_deny_all(void **state)
     assert_int_equal(1, *((uint8_t *)e->data)); /* plugin's value for default-deny-all */
     assert_null(cont->next->exts);
 
-    /* invalid */
-    data = "module aa {yang-version 1.1; namespace urn:tests:extensions:nacm:aa; prefix en;"
+    /* ignored - valid with warning */
+    data = "module b {yang-version 1.1; namespace urn:tests:extensions:nacm:b; prefix en;"
             "import ietf-netconf-acm {revision-date 2018-02-14; prefix nacm;}"
             "nacm:default-deny-all;}";
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
             "Extension nacm:default-deny-all is allowed only in a data nodes, but it is placed in \"module\" statement.)",
-            "/aa:{extension='nacm:default-deny-all'}");
+            "/b:{extension='nacm:default-deny-all'}");
 
+    /* invalid */
     data = "module aa {yang-version 1.1; namespace urn:tests:extensions:nacm:aa; prefix en;"
             "import ietf-netconf-acm {revision-date 2018-02-14; prefix nacm;}"
             "leaf l { type string; nacm:default-deny-all; nacm:default-deny-write;}}";
@@ -91,17 +92,17 @@ test_deny_write(void **state)
     assert_int_equal(LY_ARRAY_COUNT(leaf->exts), 1); /* NACM extensions inherit */
     assert_ptr_equal(e->def, leaf->exts[0].def);
     assert_int_equal(2, *((uint8_t *)e->data)); /* plugin's value for default-deny-write */
-    assert_null(cont->next->exts);
 
-    /* invalid */
-    data = "module aa {yang-version 1.1; namespace urn:tests:extensions:nacm:aa; prefix en;"
+    /* ignored - valid with warning */
+    data = "module b {yang-version 1.1; namespace urn:tests:extensions:nacm:b; prefix en;"
             "import ietf-netconf-acm {revision-date 2018-02-14; prefix nacm;}"
             "notification notif {nacm:default-deny-write;}}";
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Extension plugin \"libyang 2 - NACM, version 1\": "
             "Extension nacm:default-deny-write is not allowed in notification statement.)",
-            "/aa:notif/{extension='nacm:default-deny-write'}");
+            "/b:notif/{extension='nacm:default-deny-write'}");
 
+    /* invalid */
     data = "module aa {yang-version 1.1; namespace urn:tests:extensions:nacm:aa; prefix en;"
             "import ietf-netconf-acm {revision-date 2018-02-14; prefix nacm;}"
             "leaf l { type string; nacm:default-deny-write; nacm:default-deny-write;}}";

--- a/tests/utests/extensions/test_yangdata.c
+++ b/tests/utests/extensions/test_yangdata.c
@@ -1,0 +1,246 @@
+/*
+ * @file test_yangdata.c
+ * @author: Radek Krejci <rkrejci@cesnet.cz>
+ * @brief unit tests for yang-data extensions support
+ *
+ * Copyright (c) 2019-2021 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+#define _UTEST_MAIN_
+#include "utests.h"
+
+#include "libyang.h"
+
+static int
+setup(void **state)
+{
+    UTEST_SETUP;
+
+    assert_int_equal(LY_SUCCESS, ly_ctx_set_searchdir(UTEST_LYCTX, TESTS_DIR_MODULES_YANG));
+    assert_non_null(ly_ctx_load_module(UTEST_LYCTX, "ietf-restconf", "2017-01-26", NULL));
+
+    return 0;
+}
+
+static void
+test_schema(void **state)
+{
+    const struct lys_module *mod;
+    struct lysc_ext_instance *e;
+    char *printed = NULL;
+    const char *data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "feature x;"
+            "rc:yang-data template { container x { list l { leaf x { type string;}} leaf y {if-feature x; type string; config false;}}}}";
+    const char *info = "module a {\n"
+            "  namespace \"urn:tests:extensions:yangdata:a\";\n"
+            "  prefix self;\n\n"
+            "  ietf-restconf:yang-data \"template\" {\n"
+            "    container x {\n"
+            "      status current;\n"
+            "      list l {\n" /* no key */
+            "        min-elements 0;\n"
+            "        max-elements 4294967295;\n"
+            "        ordered-by system;\n"
+            "        status current;\n"
+            "        leaf x {\n"
+            "          type string;\n"
+            "          status current;\n"
+            "        }\n"
+            "      }\n"
+            "      leaf y {\n" /* config and if-feature are ignored */
+            "        type string;\n"
+            "        status current;\n"
+            "      }\n"
+            "    }\n"
+            "  }\n"
+            "}\n";
+
+    /* valid data */
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, &mod));
+    assert_non_null(e = mod->compiled->exts);
+    assert_int_equal(LY_ARRAY_COUNT(mod->compiled->exts), 1);
+    assert_int_equal(LY_SUCCESS, lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0));
+    assert_string_equal(printed, info);
+    free(printed);
+
+    data = "module c {yang-version 1.1; namespace urn:tests:extensions:yangdata:c; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "grouping g { choice ch { container a {presence a; config false;} container b {presence b; config true;}}}"
+            "rc:yang-data template { uses g;}}";
+    info = "module c {\n"
+            "  namespace \"urn:tests:extensions:yangdata:c\";\n"
+            "  prefix self;\n\n"
+            "  ietf-restconf:yang-data \"template\" {\n"
+            "    choice ch {\n"
+            "      status current;\n"
+            "      case a {\n"
+            "        status current;\n"
+            "        container a {\n"
+            "          presence \"true\";\n"
+            "          status current;\n"
+            "        }\n"
+            "      }\n"
+            "      case b {\n"
+            "        status current;\n"
+            "        container b {\n"
+            "          presence \"true\";\n"
+            "          status current;\n"
+            "        }\n"
+            "      }\n"
+            "    }\n"
+            "  }\n"
+            "}\n";
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, &mod));
+    assert_non_null(e = mod->compiled->exts);
+    assert_int_equal(LY_ARRAY_COUNT(mod->compiled->exts), 1);
+    assert_int_equal(LY_SUCCESS, lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0));
+    assert_string_equal(printed, info);
+    free(printed);
+
+    /* ignored - valid with warning */
+    data = "module b {yang-version 1.1; namespace urn:tests:extensions:yangdata:b; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "container b { rc:yang-data template { container x { leaf x {type string;}}}}}";
+    info = "module b {\n"
+            "  namespace \"urn:tests:extensions:yangdata:b\";\n"
+            "  prefix self;\n"
+            "  container b {\n"
+            "    config true;\n"
+            "    status current;\n"
+            "  }\n"
+            "}\n";
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, &mod));
+    assert_null(mod->compiled->exts);
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is ignored since it appears as a non top-level statement in \"data node\" statement.",
+            "/b:b/{extension='rc:yang-data'}/template");
+    assert_int_equal(LY_SUCCESS, lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0));
+    assert_string_equal(printed, info);
+    free(printed);
+
+    /* sama data nodes name, but not conflicting */
+    data = "module d {yang-version 1.1; namespace urn:tests:extensions:yangdata:d; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "leaf d { type string;}"
+            "rc:yang-data template1 { container d {presence d;}}"
+            "rc:yang-data template2 { container d {presence d;}}}";
+    info = "module d {\n"
+            "  namespace \"urn:tests:extensions:yangdata:d\";\n"
+            "  prefix self;\n\n"
+            "  ietf-restconf:yang-data \"template1\" {\n"
+            "    container d {\n"
+            "      presence \"true\";\n"
+            "      status current;\n"
+            "    }\n"
+            "  }\n"
+            "  ietf-restconf:yang-data \"template2\" {\n"
+            "    container d {\n"
+            "      presence \"true\";\n"
+            "      status current;\n"
+            "    }\n"
+            "  }\n"
+            "  leaf d {\n"
+            "    type string;\n"
+            "    config true;\n"
+            "    status current;\n"
+            "  }\n"
+            "}\n";
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, &mod));
+    assert_non_null(e = mod->compiled->exts);
+    assert_int_equal(LY_ARRAY_COUNT(mod->compiled->exts), 2);
+    assert_int_equal(LY_SUCCESS, lys_print_mem(&printed, mod, LYS_OUT_YANG_COMPILED, 0));
+    assert_string_equal(printed, info);
+    free(printed);
+}
+
+static void
+test_schema_invalid(void **state)
+{
+    const char *data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template { leaf x {type string;}}}";
+
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Invalid keyword \"leaf\" as a child of \"rc:yang-data template\" extension instance.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template { choice x { leaf x {type string;}}}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated with leaf top level data node (inside a choice), "
+            "but only a single container data node is allowed.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template { choice x { case x { container z {presence ppp;} leaf x {type string;}}}}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated with multiple top level data nodes (inside a single choice's case), "
+            "but only a single container data node is allowed.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template { container x { leaf x {type string;}} container y { leaf y {type string;}}}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated with multiple top level data nodes, "
+            "but only a single container data node is allowed.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template;}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated without any top level data node, "
+            "but exactly one container data node is expected.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data { container x { leaf x {type string;}}}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated without mandatory argument representing YANG data template name.",
+            "/a:{extension='rc:yang-data'}");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "rc:yang-data template { container x { leaf x {type string;}}}"
+            "rc:yang-data template { container y { leaf y {type string;}}}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated multiple times.",
+            "/a:{extension='rc:yang-data'}/template");
+
+    data = "module a {yang-version 1.1; namespace urn:tests:extensions:yangdata:a; prefix self;"
+            "import ietf-restconf {revision-date 2017-01-26; prefix rc;}"
+            "grouping t { leaf-list x {type string;}}"
+            "rc:yang-data template { uses t;}}";
+    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, data, LYS_IN_YANG, NULL));
+    CHECK_LOG_CTX("Extension plugin \"libyang 2 - yang-data, version 1\": "
+            "Extension rc:yang-data is instantiated with leaf-list top level data node, "
+            "but only a single container data node is allowed.",
+            "/a:{extension='rc:yang-data'}/template");
+}
+
+int
+main(void)
+{
+    const struct CMUnitTest tests[] = {
+        UTEST(test_schema, setup),
+        UTEST(test_schema_invalid, setup),
+    };
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
The set of patches finishes the statement parser for schema and add support for yang-data extension defined in RFC 8040. 

There are also some changes in extensions API, but the API itself is still target to cleanup and finish in some future PR.