### PR TITLE
resolve BUGFIX must validation raises 2 errors if there is an error-message defined in it

### DIFF
--- a/src/common.h.in
+++ b/src/common.h.in
@@ -66,6 +66,7 @@ void ly_err_free_next(struct ly_ctx *ctx, struct ly_err_item *last_eitem);
 void ly_ilo_change(struct ly_ctx *ctx, enum int_log_opts new_ilo, enum int_log_opts *prev_ilo, struct ly_err_item **prev_last_eitem);
 void ly_ilo_restore(struct ly_ctx *ctx, enum int_log_opts prev_ilo, struct ly_err_item *prev_last_eitem, int keep_and_print);
 void ly_err_last_set_apptag(const struct ly_ctx *ctx, const char *apptag);
+void ly_err_last_set_msg(const struct ly_ctx *ctx, const char *msg);
 extern THREAD_LOCAL enum int_log_opts log_opt;
 
 /*

--- a/src/log.c
+++ b/src/log.c
@@ -1074,3 +1074,18 @@ ly_err_last_set_apptag(const struct ly_ctx *ctx, const char *apptag)
         }
     }
 }
+
+void
+ly_err_last_set_msg(const struct ly_ctx *ctx, const char *msg)
+{
+    struct ly_err_item *i;
+
+    if (log_opt != ILO_IGNORE) {
+        i = ly_err_first(ctx);
+        if (i) {
+            i = i->prev;
+            free(i->msg);
+            i->msg = strdup(msg);
+        }
+    }
+}

--- a/src/resolve.c
+++ b/src/resolve.c
@@ -6353,7 +6353,7 @@ resolve_must(struct lyd_node *node, int inout_parent, int ignore_fail, int multi
             } else {
                 LOGVAL(ctx, LYE_NOMUST, LY_VLOG_LYD, node, must[i].expr);
                 if (must[i].emsg) {
-                    ly_vlog_str(ctx, LY_VLOG_PREV, must[i].emsg);
+                    ly_err_last_set_msg(ctx, must[i].emsg);
                 }
                 if (must[i].eapptag) {
                     ly_err_last_set_apptag(ctx, must[i].eapptag);


### PR DESCRIPTION
Hi,
I had created a PR to make libyang support multiple validation errors in #1341. However, I find that the `must` validation will raise 2 errors if there is an error-message defined in it. This PR is to fix this issue.

This issue could be reproduced with following module:
```
list T{
	key f1;
	leaf f1 {
		type string;
	}

	must "./f1='12'"{
		error-app-tag "ttttt";
		error-message "eeeee";
	}
}
```
current libyang raise following 2 errors, while expected is only the last one.
```
1: (null), Must condition "./f1='12'" not satisfied., /A:T[f1='1.0']
2: ttttt, eeeee, /A:T[f1='1.0']
```