### PR TITLE
libyang2: json BUGFIX invalid BMP character oob LOGVAL read

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -153,7 +153,7 @@ lyjson_string_(struct lyjson_ctx *jsonctx)
     while (in[offset]) {
         if (in[offset] == '\\') {
             /* escape sequence */
-            size_t slash = offset;
+            const char *slash = &in[offset];
             uint32_t value;
             uint8_t i = 1;
 
@@ -221,7 +221,7 @@ lyjson_string_(struct lyjson_ctx *jsonctx)
                 offset++;
                 for (value = i = 0; i < 4; i++) {
                     if (!in[offset + i]) {
-                        LOGVAL(jsonctx->ctx, LYVE_SYNTAX, "Invalid basic multilingual plane character \"%s\".", &in[slash]);
+                        LOGVAL(jsonctx->ctx, LYVE_SYNTAX, "Invalid basic multilingual plane character \"%s\".", slash);
                         goto error;
                     } else if (isdigit(in[offset + i])) {
                         u = (in[offset + i] - '0');
@@ -243,7 +243,7 @@ lyjson_string_(struct lyjson_ctx *jsonctx)
             offset += i;   /* add read escaped characters */
             LY_CHECK_ERR_GOTO(ly_pututf8(&buf[len], value, &u),
                     LOGVAL(jsonctx->ctx, LYVE_SYNTAX, "Invalid character reference \"%.*s\" (0x%08x).",
-                    (int)(offset - slash), &in[slash], value),
+                    (int)(&in[offset] - slash), slash, value),
                     error);
             len += u;      /* update number of bytes in buffer */
             in += offset;  /* move the input by the processed bytes stored in the buffer ... */

--- a/tests/fuzz/corpus/lyd_parse_mem_json/pull1460
+++ b/tests/fuzz/corpus/lyd_parse_mem_json/pull1460
@@ -1,0 +1,1 @@
+"viøonisionp\u\

--- a/tests/fuzz/corpus/lyd_parse_mem_json/pull1460_2
+++ b/tests/fuzz/corpus/lyd_parse_mem_json/pull1460_2
@@ -1,0 +1,1 @@
+"viøonisionp\uGAAA"


### PR DESCRIPTION
Hello,

This PR fixes an issue that was found by OSSFuzz in `lyd_parse_mem_json`.
It caused an oob read in `LOGVAL`, as invalid BMP values were logged using an offset from the `in` pointer, which is moved around while strings are parsed in `lyjson_string_`. Replacing it with the `start` pointer which doesn't move around fixes the issue.

I've also added the file that causes the issue to the fuzz regression tests.