### PR TITLE
context FEATURE use module hash as the context ID

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -301,7 +301,7 @@ struct ly_ctx {
     struct ly_set list;               /**< set of loaded YANG schemas */
     ly_module_imp_clb imp_clb;        /**< Optional callback for retrieving missing included or imported models in a custom way. */
     void *imp_clb_data;               /**< Optional private data for ::ly_ctx.imp_clb */
-    uint16_t module_set_id;           /**< ID of the current set of schemas */
+    uint32_t module_set_id;           /**< ID (hash) of the current set of schemas */
     uint16_t flags;                   /**< context settings, see @ref contextoptions. */
     pthread_key_t errlist_key;        /**< key for the thread-specific list of errors related to the context */
 };

--- a/src/context.c
+++ b/src/context.c
@@ -262,7 +262,6 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
             goto error;
         }
     }
-    ctx->module_set_id = 1;
 
     /* create dummy in */
     rc = ly_in_new_memory(internal_modules[0].data, &in);
@@ -321,7 +320,7 @@ ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option)
     return LY_SUCCESS;
 }
 
-API uint16_t
+API uint32_t
 ly_ctx_get_module_set_id(const struct ly_ctx *ctx)
 {
     LY_CHECK_ARG_RET(ctx, ctx, 0);
@@ -740,7 +739,7 @@ ylib_submodules(struct lyd_node *parent, const struct lysp_module *pmod, ly_bool
     return LY_SUCCESS;
 }
 
-API uint16_t
+API uint32_t
 ly_ctx_get_yanglib_id(const struct ly_ctx *ctx)
 {
     return ctx->module_set_id;
@@ -858,7 +857,7 @@ ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root_p)
     }
 
     /* IDs */
-    r = asprintf(&str, "%u", ctx->module_set_id);
+    r = asprintf(&str, "%08X", ctx->module_set_id);
     LY_CHECK_ERR_GOTO(r == -1, LOGMEM(ctx); ret = LY_EMEM, error);
     ret = lyd_new_term(root, NULL, "module-set-id", str, 0, NULL);
     LY_CHECK_ERR_GOTO(ret, free(str), error);

--- a/src/context.h
+++ b/src/context.h
@@ -287,9 +287,9 @@ LY_ERR ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option);
  * as module-set-id in ::ly_ctx_get_yanglib_data() result.
  *
  * @param[in] ctx Context to be examined.
- * @return Numeric identifier of the current context's modules set.
+ * @return Numeric hash identifier of the current context's modules set.
  */
-uint16_t ly_ctx_get_module_set_id(const struct ly_ctx *ctx);
+uint32_t ly_ctx_get_module_set_id(const struct ly_ctx *ctx);
 
 /**
  * @brief Callback for freeing returned module data in #ly_module_imp_clb.
@@ -517,7 +517,7 @@ const struct lys_module *ly_ctx_load_module(struct ly_ctx *ctx, const char *name
  * @param[in] ctx Context to be examined.
  * @return Numeric identifier of the current context's modules set.
  */
-uint16_t ly_ctx_get_yanglib_id(const struct ly_ctx *ctx);
+uint32_t ly_ctx_get_yanglib_id(const struct ly_ctx *ctx);
 
 /**
  * @brief Get data of the internal ietf-yang-library module with information about all the loaded modules.

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1360,7 +1360,6 @@ lys_create_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_
     /* add into context */
     ret = ly_set_add(&ctx->list, mod, 1, NULL);
     LY_CHECK_GOTO(ret, cleanup);
-    ctx->module_set_id++;
 
     /* resolve includes and all imports */
     LY_CHECK_GOTO(ret = lys_resolve_import_include(pctx, mod->parsed), cleanup);


### PR DESCRIPTION
So that it is always different for a different
set of modules, not just relatively for single
context changes.
Refs sysrepo/sysrepo#2378