### PR TITLE
data tree REFACTOR remove lys_value_validate

### DIFF
--- a/doc/transition.dox
+++ b/doc/transition.dox
@@ -180,7 +180,6 @@
  * -                            | ::lys_find_child()              | Helpers wrapper around ::lys_getnext().
  * -                            | ::lys_getnext_ext()             | Alternative to ::lys_getnext() allowing processing schema trees inside extension instances.
  * -                            | ::lys_nodetype2str()            | New functionality.
- * -                            | ::lys_value_validate()          | Supplement functionality to ::lyd_value_validate().
  * lys_is_key()                 | ::lysc_is_key()                 | Renamed to connect with the compiled schema tree.
  * -                            | ::lysc_is_userordered()         | Added functionality to simplify the examination of generic compiled schema nodes.
  * -                            | ::lysc_is_np_cont()             | ^

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -355,7 +355,7 @@ lydjson_check_list(struct lyjson_ctx *jsonctx, const struct lysc_node *list)
                         goto cleanup;
                     }
 
-                    ret = _lys_value_validate(NULL, snode, jsonctx->value, jsonctx->value_len, LY_PREF_JSON, NULL);
+                    ret = lys_value_validate(NULL, snode, jsonctx->value, jsonctx->value_len, LY_PREF_JSON, NULL);
                     LY_CHECK_GOTO(ret, cleanup);
 
                     /* key with a valid value, remove from the set */
@@ -468,7 +468,7 @@ lydjson_data_check_opaq(struct lyd_json_ctx *lydctx, const struct lysc_node *sno
                 break;
             }
 
-            if (_lys_value_validate(NULL, snode, jsonctx->value, jsonctx->value_len, LY_PREF_JSON, NULL)) {
+            if (lys_value_validate(NULL, snode, jsonctx->value, jsonctx->value_len, LY_PREF_JSON, NULL)) {
                 ret = LY_ENOT;
             }
             break;

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -248,7 +248,7 @@ lydxml_check_list(struct lyxml_ctx *xmlctx, const struct lysc_node *list)
         assert(xmlctx->status == LYXML_ELEM_CONTENT);
         if (i < key_set.count) {
             /* validate the value */
-            r = _lys_value_validate(NULL, snode, xmlctx->value, xmlctx->value_len, LY_PREF_XML, &xmlctx->ns);
+            r = lys_value_validate(NULL, snode, xmlctx->value, xmlctx->value_len, LY_PREF_XML, &xmlctx->ns);
             if (!r) {
                 /* key with a valid value, remove from the set */
                 ly_set_rm_index(&key_set, i, NULL);
@@ -346,7 +346,7 @@ lydxml_data_check_opaq(struct lyd_xml_ctx *lydctx, const struct lysc_node **snod
 
         if ((*snode)->nodetype & LYD_NODE_TERM) {
             /* value may not be valid in which case we parse it as an opaque node */
-            if (_lys_value_validate(NULL, *snode, xmlctx->value, xmlctx->value_len, LY_PREF_XML, &xmlctx->ns)) {
+            if (lys_value_validate(NULL, *snode, xmlctx->value, xmlctx->value_len, LY_PREF_XML, &xmlctx->ns)) {
                 *snode = NULL;
             }
         } else {

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -1529,23 +1529,21 @@ void lyd_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr);
  *
  * The given node is not modified in any way - it is just checked if the @p value can be set to the node.
  *
- * If there is no data node instance and you are fine with checking just the type's restrictions without the
- * data tree context (e.g. for the case of require-instance restriction), use ::lys_value_validate().
- *
  * @param[in] ctx libyang context for logging (function does not log errors when @p ctx is NULL)
- * @param[in] node Data node for the @p value.
+ * @param[in] schema Schema node of the @p value.
  * @param[in] value String value to be checked, it is expected to be in JSON format.
  * @param[in] value_len Length of the given @p value (mandatory).
- * @param[in] tree Data tree (e.g. when validating RPC/Notification) where the required data instance (leafref target,
- *            instance-identifier) can be placed. NULL in case the data tree is not yet complete,
- *            then LY_EINCOMPLETE can be returned.
- * @param[out] realtype Optional real type of the value.
+ * @param[in] ctx_node Optional data tree context node for the value (leafref target, instance-identifier).
+ * If not set and is required for the validation to complete, ::LY_EINCOMPLETE is be returned.
+ * @param[out] realtype Optional real type of @p value.
+ * @param[out] canonical Optional canonical value of @p value (in the dictionary).
  * @return LY_SUCCESS on success
- * @return LY_EINCOMPLETE in case the @p trees is not provided and it was needed to finish the validation (e.g. due to require-instance).
+ * @return LY_EINCOMPLETE in case the @p ctx_node is not provided and it was needed to finish the validation
+ * (e.g. due to require-instance).
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_value_validate(const struct ly_ctx *ctx, const struct lyd_node_term *node, const char *value, size_t value_len,
-        const struct lyd_node *tree, const struct lysc_type **realtype);
+LY_ERR lyd_value_validate(const struct ly_ctx *ctx, const struct lysc_node *schema, const char *value, size_t value_len,
+        const struct lyd_node *ctx_node, const struct lysc_type **realtype, const char **canonical);
 
 /**
  * @brief Compare the node's value with the given string value. The string value is first validated according to

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -331,8 +331,23 @@ LY_ERR lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const st
 LY_ERR lyd_value_validate_incomplete(const struct ly_ctx *ctx, const struct lysc_type *type, struct lyd_value *val,
         const struct lyd_node *ctx_node, const struct lyd_node *tree);
 
-/* generic function lys_value_validate */
-LY_ERR _lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, const char *value, size_t value_len,
+/**
+ * @brief Check type restrictions applicable to the particular leaf/leaf-list with the given string @p value coming
+ * from a schema.
+ *
+ * This function check just the type's restriction, if you want to check also the data tree context (e.g. in case of
+ * require-instance restriction), use ::lyd_value_validate().
+ *
+ * @param[in] ctx libyang context for logging (function does not log errors when @p ctx is NULL)
+ * @param[in] node Schema node for the @p value.
+ * @param[in] value String value to be checked, expected to be in JSON format.
+ * @param[in] value_len Length of the given @p value (mandatory).
+ * @param[in] format Value prefix format.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
+ * @return LY_SUCCESS on success
+ * @return LY_ERR value if an error occurred.
+ */
+LY_ERR lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, const char *value, size_t value_len,
         LY_PREFIX_FORMAT format, void *prefix_data);
 
 /**

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -101,7 +101,6 @@ struct lyxp_expr;
  * - ::lys_getnext()
  * - ::lys_nodetype2str()
  * - ::lys_set_implemented()
- * - ::lys_value_validate()
  *
  * - ::lysc_has_when()
  *
@@ -2430,21 +2429,6 @@ const struct lysc_node *lys_find_child(const struct lysc_node *parent, const str
  * @return LY_ERR on other errors during module compilation.
  */
 LY_ERR lys_set_implemented(struct lys_module *mod, const char **features);
-
-/**
- * @brief Check type restrictions applicable to the particular leaf/leaf-list with the given string @p value.
- *
- * This function check just the type's restriction, if you want to check also the data tree context (e.g. in case of
- * require-instance restriction), use ::lyd_value_validate().
- *
- * @param[in] ctx libyang context for logging (function does not log errors when @p ctx is NULL)
- * @param[in] node Schema node for the @p value.
- * @param[in] value String value to be checked, expected to be in JSON format.
- * @param[in] value_len Length of the given @p value (mandatory).
- * @return LY_SUCCESS on success
- * @return LY_ERR value if an error occurred.
- */
-LY_ERR lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, const char *value, size_t value_len);
 
 /**
  * @brief Stringify schema nodetype.

--- a/tests/utests/data/test_types.c
+++ b/tests/utests/data/test_types.c
@@ -814,18 +814,18 @@ test_instanceid(void **state)
     CHECK_PARSE_LYD(data, tree);
     /* key-predicate */
     data = "/types:list2[id='a'][value='b']/id";
-    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, (const struct lyd_node_term *)tree->prev, data, strlen(data),
-            tree, NULL));
+    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, tree->prev->schema, data, strlen(data), tree->prev,
+            NULL, NULL));
     CHECK_LOG_CTX("Invalid instance-identifier \"/types:list2[id='a'][value='b']/id\" value - required instance not found.", "Data location /types:inst.");
     /* leaf-list-predicate */
     data = "/types:leaflisttarget[.='c']";
-    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, (const struct lyd_node_term *)tree->prev, data, strlen(data),
-            tree, NULL));
+    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, tree->prev->schema, data, strlen(data), tree->prev,
+            NULL, NULL));
     CHECK_LOG_CTX("Invalid instance-identifier \"/types:leaflisttarget[.='c']\" value - required instance not found.", "Data location /types:inst.");
     /* position predicate */
     data = "/types:list_keyless[4]";
-    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, (const struct lyd_node_term *)tree->prev, data, strlen(data),
-            tree, NULL));
+    assert_int_equal(LY_ENOTFOUND, lyd_value_validate(UTEST_LYCTX, tree->prev->schema, data, strlen(data), tree->prev,
+            NULL, NULL));
     CHECK_LOG_CTX("Invalid instance-identifier \"/types:list_keyless[4]\" value - required instance not found.", "Data location /types:inst.");
 
     lyd_free_all(tree);

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -269,7 +269,7 @@ main(int argc, char *argv[])
     }
 
     /* check the value */
-    match = lys_value_validate(ctx, mod->compiled->data, str, strlen(str));
+    match = lyd_value_validate(ctx, mod->compiled->data, str, strlen(str), NULL, NULL, NULL);
 
     if (verbose) {
         for (i = 0; i < patterns_count; i++) {


### PR DESCRIPTION
Its functionality was added into lyd_value_validate.