### PR TITLE
data tree BUGFIX temp workaround for keyless list insertions

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3921,6 +3921,13 @@ lyd_find_sibling_schema(const struct lyd_node *siblings, const struct lysc_node 
         /* find by hash */
         if (!lyht_find(parent->children_ht, &schema, hash, (void **)&match_p)) {
             siblings = *match_p;
+            if (siblings->prev != siblings) {
+                const struct lyd_node *first;
+                for (first = parent->child;
+                     siblings != first && siblings->prev->schema == schema;
+                     siblings = siblings->prev)
+                    ;
+            }
         } else {
             /* not found */
             siblings = NULL;


### PR DESCRIPTION
This is a temporary fix for Issue #1483 see that comment thread in
https://github.com/CESNET/libyang/issues/1483 for discussion on
eventually permanent solution.

Signed-off-by: Christian Hopps <chopps@labn.net>