### PR TITLE
context FEATURE added LY_CTX_SET_PRIV_PARSED

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -185,6 +185,12 @@ struct ly_ctx;
                                         directory, which is by default searched automatically (despite not
                                         recursively). */
 #define LY_CTX_PREFER_SEARCHDIRS 0x20 /**< When searching for schema, prefer searchdirs instead of user callback. */
+#define LY_CTX_SET_PRIV_PARSED 0x40 /**< For all compiled nodes, their private objects (::lysc_node.priv) are used
+                                        by libyang as a reference to the corresponding parsed node (::lysp_node).
+                                        So if this option is set, the user must not change private objects.
+                                        Setting this option by ::ly_ctx_set_options() may result in context recompilation.
+                                        Resetting this option by ::ly_ctx_unset_options() cause that private
+                                        objects will be set to NULL. */
 
 /** @} contextoptions */
 
@@ -314,6 +320,8 @@ uint16_t ly_ctx_get_options(const struct ly_ctx *ctx);
  * @brief Set some of the context's options, see @ref contextoptions.
  * @param[in] ctx Context to be modified.
  * @param[in] option Combination of the context's options to be set, see @ref contextoptions.
+ * If there is to be a change to ::LY_CTX_SET_PRIV_PARSED, the context will be recompiled
+ * and all ::lysc_node.priv in the modules will be overwritten, see ::LY_CTX_SET_PRIV_PARSED.
  * @return LY_ERR value.
  */
 LY_ERR ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option);

--- a/src/context.h
+++ b/src/context.h
@@ -161,8 +161,6 @@ struct ly_ctx;
  *
  * Options to change context behavior.
  *
- * Note that the flags 0xFF00 are reserved for internal use.
- *
  * @{
  */
 

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2395,6 +2395,7 @@ lys_compile_node_(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc_nod
     node->module = ctx->cur_mod;
     node->parent = parent;
     node->prev = node;
+    node->priv = ctx->ctx->flags & LY_CTX_SET_PRIV_PARSED ? pnode : NULL;
 
     /* compile any deviations for this node */
     LY_CHECK_GOTO(ret = lys_compile_node_deviations_refines(ctx, pnode, parent, &dev_pnode, &not_supported), error);

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -72,7 +72,8 @@ struct lyxp_expr;
  * the default nodes are not added into any data tree and mandatory nodes are not checked in the data trees.
  *
  * The compiled schema tree nodes are able to hold private objects (::lysc_node.priv as a pointer to a structure,
- * function, variable, ...) used by a caller application.
+ * function, variable, ...) used by a caller application unless ::LY_CTX_SET_PRIV_PARSED is set, in that case
+ * the ::lysc_node.priv pointers are used by libyang.
  * Note that the object is not freed by libyang when the context is being destroyed. So the caller is responsible
  * for freeing the provided structure after the context is destroyed or the private pointer is set to NULL in
  * appropriate schema nodes where the object was previously set. This can be automated via destructor function
@@ -1653,7 +1654,7 @@ struct lysc_node {
     const char *dsc;                 /**< description */
     const char *ref;                 /**< reference */
     struct lysc_ext_instance *exts;  /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-    void *priv;                      /**< private arbitrary user data, not used by libyang */
+    void *priv;                      /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
 };
 
 struct lysc_node_action_inout {
@@ -1671,7 +1672,7 @@ struct lysc_node_action_inout {
             const char *dsc;         /**< ALWAYS NULL, compatibility member with ::lysc_node */
             const char *ref;         /**< ALWAYS NULL, compatibility member with ::lysc_node */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /** private arbitrary user data, not used by libyang */
+            void *priv;              /** private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1697,7 +1698,7 @@ struct lysc_node_action {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /** private arbitrary user data, not used by libyang */
+            void *priv;              /** private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1727,7 +1728,7 @@ struct lysc_node_notif {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /** private arbitrary user data, not used by libyang */
+            void *priv;              /** private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1756,7 +1757,7 @@ struct lysc_node_container {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1785,7 +1786,7 @@ struct lysc_node_case {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1812,7 +1813,7 @@ struct lysc_node_choice {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1841,7 +1842,7 @@ struct lysc_node_leaf {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1871,7 +1872,7 @@ struct lysc_node_leaflist {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1905,7 +1906,7 @@ struct lysc_node_list {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 
@@ -1938,7 +1939,7 @@ struct lysc_node_anydata {
             const char *dsc;         /**< description */
             const char *ref;         /**< reference */
             struct lysc_ext_instance *exts; /**< list of the extension instances ([sized array](@ref sizedarrays)) */
-            void *priv;              /**< private arbitrary user data, not used by libyang */
+            void *priv;              /**< private arbitrary user data, not used by libyang unless ::LY_CTX_SET_PRIV_PARSED is set */
         };
     };
 

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -956,6 +956,10 @@ lysc_module_free(struct lysc_module *module, void (*private_destructor)(const st
     /* TODO use the destructor, this just suppress warning about unused parameter */
     (void) private_destructor;
 
+    /* TODO if (module->mod->ctx->flags & LY_CTX_SET_PRIV_PARSED) is true, then
+     * don't use the destructor because private pointers are used by libyang.
+     */
+
     if (module) {
         lysc_module_free_(module);
     }


### PR DESCRIPTION
With this option, libyang sets ::lysc_node.priv pointers as a reference to the corresponding ::lysp_node.
This was introduced due to the printer tree module (RFC 8340), which needs both a compiled and a parsed tree to print.