### PR TITLE
remove private_destructor parameter from ly_ctx_destroy()

### DIFF
--- a/doc/transition.dox
+++ b/doc/transition.dox
@@ -103,6 +103,15 @@
  * introduce some kind of context lock to completely abandon any change of the YANG modules after starting work with the
  * instantiated data.
  *
+ * Another change to note is the removed destructor of private data (::lysc_node.priv) in ::ly_ctx_destroy(). The mechanism
+ * was not reliable with the context recompilation and the splitted parsed and compiled schema trees or the complexity of
+ * YANG extensions. It is better to let the caller maintain the allocated data directly via some memory pool or using
+ * ::lysc_tree_dfs_full() since he is the best to know where the additional data were added.
+ * 
+ * The meaining of the ::lysc_node.priv pointer can be now also changed by ::LY_CTX_SET_PRIV_PARSED context option, which
+ * makes libyang to connect the original parsed schema node structure (::lysp_node) into the compiled nodes via their 'priv'
+ * pointer. 
+ *
  * Other significant changes connected with the context are depicted in the following table.
  *
  * libyang 1.x               | libyang 2.0                          | Notes
@@ -126,6 +135,7 @@
  * ly_ctx_unset_searchdirs() | ::ly_ctx_unset_searchdir()           | Simplify API and instead of index numbers, work with the values themselves.
  * ly_ctx_set*()             | ::ly_ctx_set_options()               | API simplification.
  * ly_ctx_unset*()           | ::ly_ctx_unset_options()             | ^
+ * ly_ctx_destroy()          | ::ly_ctx_destroy()                   | The destructor callback parameter was removed, see the notes above.
  *
  *
  * @section transitionSchemas YANG Modules (Schema)

--- a/src/context.c
+++ b/src/context.c
@@ -287,7 +287,7 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
 error:
     ly_in_free(in, 0);
     lys_compile_unres_glob_erase(ctx, &unres);
-    ly_ctx_destroy(ctx, NULL);
+    ly_ctx_destroy(ctx);
     return rc;
 }
 
@@ -438,11 +438,11 @@ cleanup:
     ly_set_free(set, NULL);
     ly_set_erase(&features, NULL);
     if (ctx_yl != ctx_new) {
-        ly_ctx_destroy(ctx_yl, NULL);
+        ly_ctx_destroy(ctx_yl);
     }
     *ctx = ctx_new;
     if (ret) {
-        ly_ctx_destroy(*ctx, NULL);
+        ly_ctx_destroy(*ctx);
         *ctx = NULL;
     }
 
@@ -1098,7 +1098,7 @@ error:
 }
 
 API void
-ly_ctx_destroy(struct ly_ctx *ctx, void (*private_destructor)(const struct lysc_node *node, void *priv))
+ly_ctx_destroy(struct ly_ctx *ctx)
 {
     if (!ctx) {
         return;
@@ -1107,7 +1107,7 @@ ly_ctx_destroy(struct ly_ctx *ctx, void (*private_destructor)(const struct lysc_
     /* models list */
     for ( ; ctx->list.count; ctx->list.count--) {
         /* remove the module */
-        lys_module_free(ctx->list.objs[ctx->list.count - 1], private_destructor);
+        lys_module_free(ctx->list.objs[ctx->list.count - 1]);
     }
     free(ctx->list.objs);
 

--- a/src/context.h
+++ b/src/context.h
@@ -593,11 +593,12 @@ LY_ERR ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root,
  * All instance data are supposed to be freed before destroying the context.
  * Data models are destroyed automatically as part of ::ly_ctx_destroy() call.
  *
+ * Note that the data stored by user into the ::lysc_node.priv pointer are kept
+ * untouched and the caller is responsible for freeing this private data.
+ *
  * @param[in] ctx libyang context to destroy
- * @param[in] private_destructor Optional destructor function for private objects assigned
- * to the schema nodes' priv pointer. If NULL, the private objects are not freed by libyang.
  */
-void ly_ctx_destroy(struct ly_ctx *ctx, void (*private_destructor)(const struct lysc_node *node, void *priv));
+void ly_ctx_destroy(struct ly_ctx *ctx);
 
 /** @} context */
 

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -1361,7 +1361,7 @@ lys_compile_unres_glob_revert(struct ly_ctx *ctx, struct lys_glob_unres *unres)
 
         /* remove the module from the context and free it */
         ly_set_rm(&ctx->list, m, NULL);
-        lys_module_free(m, NULL);
+        lys_module_free(m);
     }
 
     if (unres->implementing.count) {
@@ -1545,7 +1545,7 @@ lys_recompile(struct ly_ctx *ctx, ly_bool log)
         mod = ctx->list.objs[idx];
         if (mod->compiled) {
             /* free the module */
-            lysc_module_free(mod->compiled, NULL);
+            lysc_module_free(mod->compiled);
             mod->compiled = NULL;
         }
 
@@ -1721,7 +1721,7 @@ error:
     LOG_LOCBACK(0, 0, 1, 0);
     lys_precompile_augments_deviations_revert(ctx.ctx, mod);
     lys_compile_unres_mod_erase(&ctx, 1);
-    lysc_module_free(mod_c, NULL);
+    lysc_module_free(mod_c);
     mod->compiled = NULL;
 
     return ret;

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1392,7 +1392,7 @@ lys_create_module(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format, ly_
     goto cleanup;
 
 free_mod_cleanup:
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     if (ret) {
         mod = NULL;
     } else {

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -76,8 +76,8 @@ struct lyxp_expr;
  * the ::lysc_node.priv pointers are used by libyang.
  * Note that the object is not freed by libyang when the context is being destroyed. So the caller is responsible
  * for freeing the provided structure after the context is destroyed or the private pointer is set to NULL in
- * appropriate schema nodes where the object was previously set. This can be automated via destructor function
- * to free these private objects. The destructor is passed to the ::ly_ctx_destroy() function.
+ * appropriate schema nodes where the object was previously set. Also ::lysc_tree_dfs_full() can be useful to manage
+ * the private data.
  *
  * Despite all the schema structures and their members are available as part of the libyang API and callers can use
  * it to navigate through the schema tree structure or to obtain various information, we recommend to use the following

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -927,13 +927,16 @@ lysc_node_free(struct ly_ctx *ctx, struct lysc_node *node, ly_bool unlink)
     lysc_node_free_(ctx, node);
 }
 
-static void
-lysc_module_free_(struct lysc_module *module)
+void
+lysc_module_free(struct lysc_module *module)
 {
     struct ly_ctx *ctx;
     struct lysc_node *node, *node_next;
 
-    LY_CHECK_ARG_RET(NULL, module, );
+    if (!module) {
+        return;
+    }
+
     ctx = module->mod->ctx;
 
     LY_LIST_FOR_SAFE(module->data, node_next, node) {
@@ -951,28 +954,13 @@ lysc_module_free_(struct lysc_module *module)
 }
 
 void
-lysc_module_free(struct lysc_module *module, void (*private_destructor)(const struct lysc_node *node, void *priv))
-{
-    /* TODO use the destructor, this just suppress warning about unused parameter */
-    (void) private_destructor;
-
-    /* TODO if (module->mod->ctx->flags & LY_CTX_SET_PRIV_PARSED) is true, then
-     * don't use the destructor because private pointers are used by libyang.
-     */
-
-    if (module) {
-        lysc_module_free_(module);
-    }
-}
-
-void
-lys_module_free(struct lys_module *module, void (*private_destructor)(const struct lysc_node *node, void *priv))
+lys_module_free(struct lys_module *module)
 {
     if (!module) {
         return;
     }
 
-    lysc_module_free(module->compiled, private_destructor);
+    lysc_module_free(module->compiled);
     FREE_ARRAY(module->ctx, module->identities, lysc_ident_free);
     lysp_module_free(module->parsed);
 

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -753,16 +753,14 @@ void lysc_node_container_free(struct ly_ctx *ctx, struct lysc_node_container *no
 /**
  * @brief Free the compiled schema structure.
  * @param[in,out] module Compiled schema module structure to free.
- * @param[in] private_destructor Function to remove private data from the compiled schema tree.
  */
-void lysc_module_free(struct lysc_module *module, void (*private_destructor)(const struct lysc_node *node, void *priv));
+void lysc_module_free(struct lysc_module *module);
 
 /**
  * @brief Free the schema structure. It just frees, it does not remove the schema from its context.
  * @param[in,out] module Schema module structure to free.
- * @param[in] private_destructor Function to remove private data from the compiled schema tree.
  */
-void lys_module_free(struct lys_module *module, void (*private_destructor)(const struct lysc_node *node, void *priv));
+void lys_module_free(struct lys_module *module);
 
 /**
  * @brief match yang keyword

--- a/tests/fuzz/buf_add_char.c
+++ b/tests/fuzz/buf_add_char.c
@@ -46,7 +46,7 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 
 	free(old_data);
 	free(dest);
-	ly_ctx_destroy(ctx, NULL);
+	ly_ctx_destroy(ctx);
 
 	return 0;
 }

--- a/tests/fuzz/lyd_parse_mem_json.c
+++ b/tests/fuzz/lyd_parse_mem_json.c
@@ -75,7 +75,7 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 	data[len] = 0;
 
 	lyd_parse_data_mem(ctx, data, LYD_JSON, 0, LYD_VALIDATE_PRESENT, &tree);
-	ly_ctx_destroy(ctx, NULL);
+	ly_ctx_destroy(ctx);
 
 	free(data);
 

--- a/tests/fuzz/lyd_parse_mem_xml.c
+++ b/tests/fuzz/lyd_parse_mem_xml.c
@@ -75,7 +75,7 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 	data[len] = 0;
 
 	lyd_parse_data_mem(ctx, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree);
-	ly_ctx_destroy(ctx, NULL);
+	ly_ctx_destroy(ctx);
 
 	free(data);
 

--- a/tests/fuzz/lys_parse_mem.c
+++ b/tests/fuzz/lys_parse_mem.c
@@ -31,7 +31,7 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 	data[len] = 0;
 
 	lys_parse_mem(ctx, data, LYS_IN_YANG, NULL);
-	ly_ctx_destroy(ctx, NULL);
+	ly_ctx_destroy(ctx);
 	free(data);
 	return 0;
 }

--- a/tests/fuzz/yang_parse_module.c
+++ b/tests/fuzz/yang_parse_module.c
@@ -46,6 +46,6 @@ int LLVMFuzzerTestOneInput(uint8_t const *buf, size_t len)
 
 	free(data);
 	free(mod);
-	ly_ctx_destroy(ctx, NULL);
+	ly_ctx_destroy(ctx);
 	return 0;
 }

--- a/tests/utests/basic/test_context.c
+++ b/tests/utests/basic/test_context.c
@@ -99,7 +99,7 @@ test_searchdirs(void **state)
     assert_int_equal(LY_SUCCESS, ly_ctx_unset_searchdir(UTEST_LYCTX, NULL));
 
     /* cleanup */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
 
     /* test searchdir list in ly_ctx_new() */
     assert_int_equal(LY_EINVAL, ly_ctx_new("/nonexistingfile", 0, &UTEST_LYCTX));
@@ -114,7 +114,7 @@ static void
 test_options(void **state)
 {
     /* use own context with extra flags */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
 
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0xffff, &UTEST_LYCTX));
 
@@ -205,7 +205,7 @@ test_models(void **state)
     struct lys_glob_unres unres = {0};
 
     /* use own context with extra flags */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
 
     /* invalid arguments */
     assert_int_equal(0, ly_ctx_get_change_count(NULL));
@@ -309,7 +309,7 @@ test_imports(void **state)
     const struct lys_module *mod1, *mod2, *import;
 
     /* use own context with extra flags */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
 
     /* import callback provides newer revision of module 'a' than present in context, so when importing 'a', the newer revision
      * from the callback should be loaded into the context and used as an import */
@@ -328,7 +328,7 @@ test_imports(void **state)
     assert_string_equal("2019-09-17", import->revision);
     assert_int_equal(0, import->implemented);
     assert_non_null(ly_ctx_get_module(UTEST_LYCTX, "a", "2019-09-16"));
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
 
     /* import callback provides older revision of module 'a' than present in context, so when importing a, the newer revision
      * already present in the context should be selected and the callback's revision should not be loaded into the context */
@@ -660,7 +660,7 @@ test_ylmem(void **state)
     assert_int_equal(LY_SUCCESS, ly_ctx_new_ylmem(TESTS_SRC "/modules/yang/", yanglibrary_only, LYD_XML, 0, &ctx_test));
     assert_ptr_not_equal(NULL, ly_ctx_get_module(ctx_test, "ietf-yang-library", "2019-01-04"));
     assert_null(ly_ctx_get_module(ctx_test, "ietf-netconf", "2011-06-01"));
-    ly_ctx_destroy(ctx_test, NULL);
+    ly_ctx_destroy(ctx_test);
 
     /* test loading module, should also import other module */
     assert_int_equal(LY_SUCCESS, ly_ctx_new_ylmem(TESTS_SRC "/modules/yang/", with_netconf, LYD_XML, 0, &ctx_test));
@@ -669,14 +669,14 @@ test_ylmem(void **state)
     assert_int_not_equal(NULL, ly_ctx_get_module(ctx_test, "ietf-netconf-acm", "2018-02-14"));
     assert_int_equal(0, ly_ctx_get_module(ctx_test, "ietf-netconf-acm", "2018-02-14")->implemented);
     assert_int_equal(LY_ENOT, lys_feature_value(ly_ctx_get_module(ctx_test, "ietf-netconf", "2011-06-01"), "url"));
-    ly_ctx_destroy(ctx_test, NULL);
+    ly_ctx_destroy(ctx_test);
 
     /* test loading module with feature if they are present */
     assert_int_equal(LY_SUCCESS, ly_ctx_new_ylmem(TESTS_SRC "/modules/yang/", with_netconf_features, LYD_XML, 0, &ctx_test));
     assert_ptr_not_equal(NULL, ly_ctx_get_module(ctx_test, "ietf-netconf", "2011-06-01"));
     assert_ptr_not_equal(NULL, ly_ctx_get_module(ctx_test, "ietf-netconf-acm", "2018-02-14"));
     assert_int_equal(LY_SUCCESS, lys_feature_value(ly_ctx_get_module(ctx_test, "ietf-netconf", "2011-06-01"), "url"));
-    ly_ctx_destroy(ctx_test, NULL);
+    ly_ctx_destroy(ctx_test);
 
     /* test with not matching revision */
     assert_int_equal(LY_EINVAL, ly_ctx_new_ylmem(TESTS_SRC "/modules/yang/", garbage_revision, LYD_XML, 0, &ctx_test));
@@ -687,7 +687,7 @@ test_ylmem(void **state)
     /* test creating without ietf-yang-library */
     assert_int_equal(LY_SUCCESS, ly_ctx_new_ylmem(TESTS_SRC "/modules/yang/", no_yanglibrary, LYD_XML, LY_CTX_NO_YANGLIBRARY, &ctx_test));
     assert_int_equal(NULL, ly_ctx_get_module(ctx_test, "ietf-yang-library", "2019-01-04"));
-    ly_ctx_destroy(ctx_test, NULL);
+    ly_ctx_destroy(ctx_test);
 }
 
 static LY_ERR
@@ -815,7 +815,7 @@ test_set_priv_parsed(void **state)
             "}\n";
 
     /* use own context with extra flags */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
     const char *feats[] = {"f1", NULL};
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_SET_PRIV_PARSED, &UTEST_LYCTX));
     UTEST_ADD_MODULE(schema_a, LYS_IN_YANG, feats, NULL);

--- a/tests/utests/basic/test_hash_table.c
+++ b/tests/utests/basic/test_hash_table.c
@@ -55,7 +55,7 @@ test_dict_hit(void **state)
     lydict_remove(UTEST_LYCTX, "test2");
 
     /* destroy dictionary - should raise warning about data presence */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
     UTEST_LYCTX = NULL;
     CHECK_LOG("String \"test1\" not freed from the dictionary, refcount 1", NULL);
 

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -57,7 +57,7 @@ setup(void **state)
     assert_non_null(OUT_NODE);
 
 #define RECREATE_CTX_WITH_MODULE(CTX, MODULE) \
-    ly_ctx_destroy(CTX, NULL); \
+    ly_ctx_destroy(CTX); \
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, 0, &CTX)); \
     assert_int_equal(LY_SUCCESS, ly_in_new_memory(MODULE, &_UC->in)); \
     assert_int_equal(LY_SUCCESS, lys_parse(CTX, _UC->in, LYS_IN_YANG, NULL, NULL)); \
@@ -258,7 +258,7 @@ test_compare_diff_ctx(void **state)
     lyd_free_all(tree2);
 
     /* clean up */
-    ly_ctx_destroy(ctx2, NULL);
+    ly_ctx_destroy(ctx2);
     _UC->in = NULL;
 }
 

--- a/tests/utests/schema/test_parser_yang.c
+++ b/tests/utests/schema/test_parser_yang.c
@@ -100,7 +100,7 @@ setup(void **state)
 static int
 teardown(void **state)
 {
-    lys_module_free(YCTX->parsed_mod->mod, NULL);
+    lys_module_free(YCTX->parsed_mod->mod);
     LOG_LOCBACK(0, 0, 0, 1);
 
     free(YCTX);
@@ -546,7 +546,7 @@ mod_renew(struct lys_yang_parser_ctx *ctx)
 {
     struct ly_ctx *ly_ctx = ctx->parsed_mod->mod->ctx;
 
-    lys_module_free(ctx->parsed_mod->mod, NULL);
+    lys_module_free(ctx->parsed_mod->mod);
     ctx->parsed_mod = calloc(1, sizeof *ctx->parsed_mod);
     ctx->parsed_mod->mod = calloc(1, sizeof *ctx->parsed_mod->mod);
     ctx->parsed_mod->mod->parsed = ctx->parsed_mod;
@@ -562,7 +562,7 @@ submod_renew(struct lys_yang_parser_ctx *ctx)
 {
     struct ly_ctx *ly_ctx = ctx->parsed_mod->mod->ctx;
 
-    lys_module_free(ctx->parsed_mod->mod, NULL);
+    lys_module_free(ctx->parsed_mod->mod);
     ctx->parsed_mod = calloc(1, sizeof(struct lysp_submodule));
     ctx->parsed_mod->mod = calloc(1, sizeof *ctx->parsed_mod->mod);
     lydict_insert(ly_ctx, "name", 0, &ctx->parsed_mod->mod->name);
@@ -764,7 +764,7 @@ test_module(void **state)
     assert_int_equal(LY_EVALID, yang_parse_module(&ctx_p, &in, m, &unres));
     CHECK_LOG_CTX("Trailing garbage \"module q {names...\" after module, expected end-of-input.", "Line number 1.");
     yang_parser_ctx_free(ctx_p);
-    lys_module_free(m, NULL);
+    lys_module_free(m);
 
     in.current = "prefix " SCHEMA_BEGINNING "}";
     m = calloc(1, sizeof *m);
@@ -772,7 +772,7 @@ test_module(void **state)
     assert_int_equal(LY_EVALID, yang_parse_module(&ctx_p, &in, m, &unres));
     CHECK_LOG_CTX("Invalid keyword \"prefix\", expected \"module\" or \"submodule\".", "Line number 1.");
     yang_parser_ctx_free(ctx_p);
-    lys_module_free(m, NULL);
+    lys_module_free(m);
 
     in.current = "module " SCHEMA_BEGINNING "leaf enum {type enumeration {enum seven { position 7;}}}}";
     m = calloc(1, sizeof *m);
@@ -780,7 +780,7 @@ test_module(void **state)
     assert_int_equal(LY_EVALID, yang_parse_module(&ctx_p, &in, m, &unres));
     CHECK_LOG_CTX("Invalid keyword \"position\" as a child of \"enum\".", "Line number 1.");
     yang_parser_ctx_free(ctx_p);
-    lys_module_free(m, NULL);
+    lys_module_free(m);
 
     /* extensions */
     TEST_GENERIC("prefix:test;}", mod->exts,

--- a/tests/utests/schema/test_parser_yin.c
+++ b/tests/utests/schema/test_parser_yin.c
@@ -158,7 +158,7 @@ static int
 teardown_ctx(void **UNUSED(state))
 {
     lyxml_ctx_free(YCTX->xmlctx);
-    lys_module_free(YCTX->parsed_mod->mod, NULL);
+    lys_module_free(YCTX->parsed_mod->mod);
     free(YCTX);
     YCTX = NULL;
 
@@ -3422,7 +3422,7 @@ mod_renew(struct lys_yin_parser_ctx *ctx)
 {
     struct ly_ctx *ly_ctx = ctx->parsed_mod->mod->ctx;
 
-    lys_module_free(ctx->parsed_mod->mod, NULL);
+    lys_module_free(ctx->parsed_mod->mod);
     ctx->parsed_mod = calloc(1, sizeof *ctx->parsed_mod);
     ctx->parsed_mod->mod = calloc(1, sizeof *ctx->parsed_mod->mod);
     ctx->parsed_mod->mod->parsed = ctx->parsed_mod;
@@ -3550,7 +3550,7 @@ submod_renew(struct lys_yin_parser_ctx *ctx, const char *belongs_to)
 {
     struct ly_ctx *ly_ctx = ctx->parsed_mod->mod->ctx;
 
-    lys_module_free(ctx->parsed_mod->mod, NULL);
+    lys_module_free(ctx->parsed_mod->mod);
     ctx->parsed_mod = calloc(1, sizeof(struct lysp_submodule));
     ctx->parsed_mod->mod = calloc(1, sizeof *ctx->parsed_mod->mod);
     lydict_insert(ly_ctx, belongs_to, 0, &ctx->parsed_mod->mod->name);
@@ -3710,7 +3710,7 @@ test_yin_parse_module(void **state)
     assert_null(mod->parsed->exts->child->next->child);
     assert_string_equal(mod->parsed->exts->child->next->arg, "test");
     lys_compile_unres_glob_erase(UTEST_LYCTX, &unres);
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     yin_parser_ctx_free(yin_ctx);
     ly_in_free(in, 0);
     mod = NULL;
@@ -3749,7 +3749,7 @@ test_yin_parse_module(void **state)
     assert_int_equal(ly_in_new_memory(data, &in), LY_SUCCESS);
     assert_int_equal(yin_parse_module(&yin_ctx, in, mod, &unres), LY_SUCCESS);
     lys_compile_unres_glob_erase(UTEST_LYCTX, &unres);
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     yin_parser_ctx_free(yin_ctx);
     ly_in_free(in, 0);
     mod = NULL;
@@ -3765,7 +3765,7 @@ test_yin_parse_module(void **state)
     assert_int_equal(ly_in_new_memory(data, &in), LY_SUCCESS);
     assert_int_equal(yin_parse_module(&yin_ctx, in, mod, &unres), LY_SUCCESS);
     lys_compile_unres_glob_erase(UTEST_LYCTX, &unres);
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     yin_parser_ctx_free(yin_ctx);
     ly_in_free(in, 0);
     mod = NULL;
@@ -3778,7 +3778,7 @@ test_yin_parse_module(void **state)
     assert_int_equal(ly_in_new_memory(data, &in), LY_SUCCESS);
     assert_int_equal(yin_parse_module(&yin_ctx, in, mod, &unres), LY_EINVAL);
     CHECK_LOG_CTX("Input data contains submodule which cannot be parsed directly without its main module.", NULL);
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     yin_parser_ctx_free(yin_ctx);
     ly_in_free(in, 0);
 
@@ -3793,7 +3793,7 @@ test_yin_parse_module(void **state)
     assert_int_equal(ly_in_new_memory(data, &in), LY_SUCCESS);
     assert_int_equal(yin_parse_module(&yin_ctx, in, mod, &unres), LY_EVALID);
     CHECK_LOG_CTX("Trailing garbage \"<module>\" after module, expected end-of-input.", "Line number 6.");
-    lys_module_free(mod, NULL);
+    lys_module_free(mod);
     yin_parser_ctx_free(yin_ctx);
     ly_in_free(in, 0);
     mod = NULL;

--- a/tests/utests/schema/test_schema_extensions.c
+++ b/tests/utests/schema/test_schema_extensions.c
@@ -89,7 +89,7 @@ test_extension_argument(void **state)
     free(printed);
 
     /* context reset */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
     ly_ctx_new(NULL, 0, &UTEST_LYCTX);
 
     /* from YIN */
@@ -191,7 +191,7 @@ test_extension_argument_element(void **state)
     free(printed);
 
     /* context reset */
-    ly_ctx_destroy(UTEST_LYCTX, NULL);
+    ly_ctx_destroy(UTEST_LYCTX);
     ly_ctx_new(NULL, 0, &UTEST_LYCTX);
 
     /* from YIN */

--- a/tests/utests/utests.h
+++ b/tests/utests/utests.h
@@ -1296,7 +1296,7 @@ utest_teardown(void **state)
     *state = NULL;
 
     /* libyang context */
-    ly_ctx_destroy(current_utest_context->ctx, NULL);
+    ly_ctx_destroy(current_utest_context->ctx);
 
     /* utest context */
     ly_in_free(current_utest_context->in, 0);

--- a/tools/lint/cmd_clear.c
+++ b/tools/lint/cmd_clear.c
@@ -78,7 +78,7 @@ cmd_clear(struct ly_ctx **ctx, const char *cmdline)
         goto cleanup;
     }
 
-    ly_ctx_destroy(*ctx, NULL);
+    ly_ctx_destroy(*ctx);
     *ctx = ctx_new;
 
 cleanup:

--- a/tools/lint/main.c
+++ b/tools/lint/main.c
@@ -96,7 +96,7 @@ main(int argc, char *argv[])
     }
 
     store_config();
-    ly_ctx_destroy(ctx, NULL);
+    ly_ctx_destroy(ctx);
 
     return 0;
 }

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -100,7 +100,7 @@ erase_context(struct context *c)
     ly_set_erase(&c->searchpaths, NULL);
 
     ly_out_free(c->out, NULL,  0);
-    ly_ctx_destroy(c->ctx, NULL);
+    ly_ctx_destroy(c->ctx);
 }
 
 static void

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -294,7 +294,7 @@ main(int argc, char *argv[])
     }
 
 cleanup:
-    ly_ctx_destroy(ctx, NULL);
+    ly_ctx_destroy(ctx);
     for (i = 0; i < patterns_count; i++) {
         free(patterns[i]);
     }


### PR DESCRIPTION
The mechanism was not reliable and not used often. libyang provides a function to traverse the schema and free the set data manually or the caller can maintain some information to free the set data directly.

The difference of the API in contrast to 1.x (and so far to 2.0) shouldn't be a big issue since the parameter was used rarely.