### PR TITLE
build BUGFIX fix for OpenBSD and exposing realpath()

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -15,8 +15,9 @@
 #define _POSIX_C_SOURCE 200809L /* strdup */
 
 #if defined (__NetBSD__) || defined (__OpenBSD__)
-#define _XOPEN_SOURCE
-#define _XOPEN_SOURCE_EXTENDED /* realpath */
+/* realpath */
+#define _XOPEN_SOURCE 1
+#define _XOPEN_SOURCE_EXTENDED 1
 #endif
 
 #include "context.h"

--- a/src/in.c
+++ b/src/in.c
@@ -21,8 +21,8 @@
 
 #if defined (__NetBSD__) || defined (__OpenBSD__)
 /* realpath */
-#define _XOPEN_SOURCE
-#define _XOPEN_SOURCE_EXTENDED /* realpath */
+#define _XOPEN_SOURCE 1
+#define _XOPEN_SOURCE_EXTENDED 1
 #endif
 
 #include "in.h"


### PR DESCRIPTION
The openbsd sys/cdefs.h is doing arithmetic with the defines, so set to 1 rather than just defined.