### PR TITLE
tree data BUGFIX move defn of named union out of struct defn

### DIFF
--- a/src/path.h
+++ b/src/path.h
@@ -37,22 +37,29 @@ enum ly_path_pred_type {
 };
 
 /**
- * @brief Structure for holding one segment of resolved path on schema including simple predicates.
- * Is used as a [sized array](@ref sizedarrays).
+ * @brief Structure for simple path predicate.
+ */
+struct ly_path_predicate {
+    union {
+        uint64_t position; /**< position value for the position-predicate */
+        struct {
+            const struct lysc_node *key; /**< key node of the predicate, NULL in
+                                            case of a leaf-list predicate */
+            struct lyd_value value; /**< value representation according to the
+                                       key's type, its realtype is allocated */
+        };
+    };
+};
+
+/**
+ * @brief Structure for holding one segment of resolved path on schema including
+ * simple predicates. Is used as a [sized array](@ref sizedarrays).
  */
 struct ly_path {
     const struct lysc_node *node; /**< Schema node representing the path segment, first node has special meaning:
                                        - is a top-level node - path is absolute,
                                        - is inner node - path is relative */
-    struct ly_path_predicate {
-        union {
-            uint64_t position;    /**< position value for the position-predicate */
-            struct {
-                const struct lysc_node *key;    /**< key node of the predicate, NULL in case of a leaf-list predicate */
-                struct lyd_value value; /**< value representation according to the key's type, its realtype is allocated */
-            };
-        };
-    } *predicates;            /**< [Sized array](@ref sizedarrays) of the path segment's predicates */
+    struct ly_path_predicate *predicates;  /**< [Sized array](@ref sizedarrays) of the path segment's predicates */
     enum ly_path_pred_type pred_type;   /**< Predicate type (see YANG ABNF) */
 };
 

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -718,7 +718,19 @@ struct lyd_node_term {
 };
 
 /**
- * @brief Data node structure for the anydata data tree nodes - anydata or anyxml.
+ * @brief union for anydata/anyxml value representation.
+ */
+union lyd_any_value {
+    struct lyd_node *tree; /**< data tree */
+    const char *str;       /**< Generic string data */
+    const char *xml;       /**< Serialized XML data */
+    const char *json;      /**< I-JSON encoded string */
+    char *mem;             /**< LYD_ANYDATA_LYB memory chunk */
+};
+
+/**
+ * @brief Data node structure for the anydata data tree nodes - anydata or
+ * anyxml.
  */
 struct lyd_node_any {
     union {
@@ -742,13 +754,7 @@ struct lyd_node_any {
         };
     };                                      /**< common part corresponding to ::lyd_node */
 
-    union lyd_any_value {
-        struct lyd_node *tree;          /**< data tree */
-        const char *str;                /**< Generic string data */
-        const char *xml;                /**< Serialized XML data */
-        const char *json;               /**< I-JSON encoded string */
-        char *mem;                      /**< LYD_ANYDATA_LYB memory chunk */
-    } value;                            /**< pointer to the stored value representation of the anydata/anyxml node */
+    union lyd_any_value value;          /**< pointer to the stored value representation of the anydata/anyxml node */
     LYD_ANYDATA_VALUETYPE value_type;   /**< type of the data stored as ::lyd_node_any.value */
 };
 


### PR DESCRIPTION
Defining a union inside a struct does not define that union globally in
C++. Thus one can't use "union lyd_any_value *foo" in C++.