### PR TITLE
format test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: libyang CI
-on: 
+on:
   push:
     branches:
       - libyang2
@@ -72,6 +72,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Uncrustify
+        shell: bash
+        working-directory: ${{ github.workspace }}
+        run: |
+          git clone --branch uncrustify-0.71.0 https://github.com/uncrustify/uncrustify
+          cd uncrustify
+          mkdir build
+          cd build
+          CC=${{ matrix.config.cc }} cmake ..
+          make
+          sudo make install
+        if: ${{ matrix.config.name == 'Debug, Ubuntu 18.04, gcc' }}
 
       - name: Dependencies
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,10 @@ set(headers
 # source files to be covered by the 'format' target
 set(format_sources
     compat/*
-    src/*)
+    src/*.c
+    src/*.h
+    src/plugins_exts/*
+    src/plugins_types/*)
 #
 # options
 #
@@ -305,6 +308,11 @@ if(ENABLE_BUILD_TESTS)
     find_package(CMocka 1.0.0)
 endif(ENABLE_BUILD_TESTS)
 
+if ("${BUILD_TYPE_UPPER}" STREQUAL "DEBUG")
+    # enable before adding tests to let them detect that format checking is available - one of the tests is format checking
+    source_format_enable()
+endif()
+
 # tests
 if(ENABLE_VALGRIND_TESTS)
     set(ENABLE_BUILD_TESTS ON)
@@ -341,10 +349,9 @@ if ("${BUILD_TYPE_UPPER}" STREQUAL "ABICHECK")
     libyang_abicheck()
 endif()
 
-# source code format
-if ("${BUILD_TYPE_UPPER}" STREQUAL "DEBUG")
-	source_format(${format_sources})
-endif()
+# source code format target for Makefile
+# - add it after tests which may also update list of sources to format
+source_format(${format_sources})
 
 # clean cmake cache
 add_custom_target(cclean

--- a/CMakeModules/SourceFormat.cmake
+++ b/CMakeModules/SourceFormat.cmake
@@ -1,12 +1,22 @@
 # format source files with uncrustify
+
+# check that format checking is available - always use before SOURCE_FORMAT
+macro(SOURCE_FORMAT_ENABLE)
+    find_package(Uncrustify 0.71)
+    if(UNCRUSTIFY_FOUND)
+        set(SOURCE_FORMAT_ENABLED TRUE)
+    else()
+        set(SOURCE_FORMAT_ENABLED FALSE)
+    endif()
+endmacro()
+
 # files are expected to be a list and relative paths are resolved wtih respect to CMAKE_SOURCE DIR
 macro(SOURCE_FORMAT)
     if(NOT ${ARGC})
         message(FATAL_ERROR "source_format() needs a list of files to format!")
     endif()
 
-    find_package(Uncrustify 0.71)
-    if(UNCRUSTIFY_FOUND)
+    if(SOURCE_FORMAT_ENABLED)
         add_custom_target(format
                 COMMAND ${UNCRUSTIFY} -c ${CMAKE_SOURCE_DIR}/uncrustify.cfg --no-backup --replace ${ARGN}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
@@ -16,5 +26,7 @@ macro(SOURCE_FORMAT)
                 COMMAND ${UNCRUSTIFY} -c ${CMAKE_SOURCE_DIR}/uncrustify.cfg --check ${ARGN}
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                 COMMENT "Checking format of the sources with ${UNCRUSTIFY} ...")
+
+        set(SOURCE_FORMAT_ENABLED TRUE)
     endif()
 endmacro()

--- a/src/context.c
+++ b/src/context.c
@@ -475,6 +475,7 @@ API LY_ERR
 ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option)
 {
     LY_ERR lyrc;
+
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
     LY_CHECK_ERR_RET(option & LY_CTX_NO_YANGLIBRARY, LOGARG(ctx, option), LY_EINVAL);
     lyrc = LY_SUCCESS;

--- a/tests/style/CMakeLists.txt
+++ b/tests/style/CMakeLists.txt
@@ -1,2 +1,6 @@
 add_test(NAME headers
 	COMMAND ${CMAKE_SOURCE_DIR}/tests/style/check_includes.sh ${CMAKE_SOURCE_DIR}/src/ ${CMAKE_SOURCE_DIR}/tools/lint/ ${CMAKE_SOURCE_DIR}/tools/re/)
+
+if (${SOURCE_FORMAT_ENABLED})
+	add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND make format-check)
+endif()

--- a/tests/utests/basic/test_context.c
+++ b/tests/utests/basic/test_context.c
@@ -817,6 +817,7 @@ test_set_priv_parsed(void **state)
     /* use own context with extra flags */
     ly_ctx_destroy(UTEST_LYCTX);
     const char *feats[] = {"f1", NULL};
+
     assert_int_equal(LY_SUCCESS, ly_ctx_new(NULL, LY_CTX_SET_PRIV_PARSED, &UTEST_LYCTX));
     UTEST_ADD_MODULE(schema_a, LYS_IN_YANG, feats, NULL);
 


### PR DESCRIPTION
Make the format checking part of the test suit.

GitHub Action runners do not contain an environment with a sufficient `uncrustify` version (ubuntu 20.10 should work) and I'm not sure that compiling it from source is worth it, so for now the test is not running in Actions.