### PR TITLE
c++ compatibility of public headers

### DIFF
--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -489,7 +489,7 @@ lyplg_type_validate_patterns(struct lysc_pattern **patterns, const char *str, si
                 return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, eapptag, patterns[u]->emsg);
             } else {
                 const char *inverted = patterns[u]->inverted ? "inverted " : "";
-                return ly_err_new(err, LY_EVALID, 0, NULL, eapptag,
+                return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, eapptag,
                         LY_ERRMSG_NOPATTERN, (int)str_len, str, inverted, patterns[u]->expr);
             }
         }

--- a/src/tree.h
+++ b/src/tree.h
@@ -125,7 +125,7 @@ extern "C" {
 #define LY_ARRAY_FOR_ITER(ARRAY, TYPE, ITER) \
     for (ITER = ARRAY; \
          (ARRAY) && ((void*)ITER - (void*)ARRAY)/(sizeof(TYPE)) < (*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
-         ITER = (void*)((TYPE*)ITER + 1))
+         ITER = (TYPE*)ITER + 1)
 
 /**
  * @brief Helper macro to go through sized-arrays with a numeric iterator.

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -48,7 +48,42 @@ void *ly_realloc(void *ptr, size_t size);
  * @{
  */
 
-/** @} trees_edit */
+/**
+ * @brief (Re-)Allocation of a ([sized array](@ref sizedarrays)).
+ *
+ * Increases the size information.
+ *
+ * This is a generic macro for ::LY_ARRAY_NEW_RET and ::LY_ARRAY_NEW_GOTO.
+ *
+ * @param[in] CTX libyang context for logging.
+ * @param[in,out] ARRAY Pointer to the array to allocate/resize. The size of the allocated
+ * space is counted from the type of the ARRAY, so do not provide placeholder void pointers.
+ * @param[out] NEW_ITEM Returning pointer to the newly allocated record in the ARRAY.
+ * @param[in] EACTION Action to perform in case of error (memory allocation failure).
+ */
+#define LY_ARRAY_NEW(CTX, ARRAY, EACTION) \
+    { \
+        void *p__; \
+        if (ARRAY) { \
+            ++(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
+            p__ = realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), \
+                    sizeof(LY_ARRAY_COUNT_TYPE) + (*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) * sizeof *(ARRAY))); \
+            if (!p__) { \
+                --(*((LY_ARRAY_COUNT_TYPE*)(p__) - 1)); \
+                LOGMEM(CTX); \
+                EACTION; \
+            } \
+        } else { \
+            p__ = malloc(sizeof(LY_ARRAY_COUNT_TYPE) + sizeof *(ARRAY)); \
+            if (!p__) { \
+                LOGMEM(CTX); \
+                EACTION; \
+            } \
+            *((LY_ARRAY_COUNT_TYPE*)(p__)) = 1; \
+        } \
+        p__ = (void*)((LY_ARRAY_COUNT_TYPE*)(p__) + 1); \
+        memcpy(&(ARRAY), &p__, sizeof p__); \
+    }
 
 /**
  * @brief (Re-)Allocation of a ([sized array](@ref sizedarrays)).
@@ -62,20 +97,9 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] RETVAL Return value for the case of error (memory allocation failure).
  */
 #define LY_ARRAY_NEW_RET(CTX, ARRAY, NEW_ITEM, RETVAL) \
-        if (!(ARRAY)) { \
-            ARRAY = malloc(sizeof(LY_ARRAY_COUNT_TYPE) + sizeof *(ARRAY)); \
-            *((LY_ARRAY_COUNT_TYPE*)(ARRAY)) = 1; \
-        } else { \
-            ++(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
-            ARRAY = ly_realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), sizeof(LY_ARRAY_COUNT_TYPE) + (*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) * sizeof *(ARRAY))); \
-            if (!(ARRAY)) { \
-                LOGMEM(CTX); \
-                return RETVAL; \
-            } \
-        } \
-        ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-        (NEW_ITEM) = &(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) - 1]; \
-        memset(NEW_ITEM, 0, sizeof *(NEW_ITEM))
+    LY_ARRAY_NEW(CTX, ARRAY, return RETVAL); \
+    (NEW_ITEM) = &(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) - 1]; \
+    memset(NEW_ITEM, 0, sizeof *(NEW_ITEM))
 
 /**
  * @brief (Re-)Allocation of a ([sized array](@ref sizedarrays)).
@@ -90,21 +114,48 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] GOTO Label to go in case of error (memory allocation failure).
  */
 #define LY_ARRAY_NEW_GOTO(CTX, ARRAY, NEW_ITEM, RET, GOTO) \
-        if (!(ARRAY)) { \
-            ARRAY = malloc(sizeof(LY_ARRAY_COUNT_TYPE) + sizeof *(ARRAY)); \
-            *((LY_ARRAY_COUNT_TYPE*)(ARRAY)) = 1; \
-        } else { \
-            ++(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
-            ARRAY = ly_realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), sizeof(LY_ARRAY_COUNT_TYPE) + (*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) * sizeof *(ARRAY))); \
-            if (!(ARRAY)) { \
-                RET = LY_EMEM; \
+    LY_ARRAY_NEW(CTX, ARRAY, RET = LY_EMEM; goto GOTO); \
+    (NEW_ITEM) = &(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) - 1]; \
+    memset(NEW_ITEM, 0, sizeof *(NEW_ITEM))
+
+/**
+ * @brief Allocate a ([sized array](@ref sizedarrays)) for the specified number of items.
+ * If the ARRAY already exists, it is resized (space for SIZE items is added and zeroed).
+ *
+ * Does not set the size information, it is supposed to be incremented via ::LY_ARRAY_INCREMENT
+ * when the items are filled.
+ *
+ * This is a generic macro for ::LY_ARRAY_CREATE_RET and ::LY_ARRAY_CREATE_GOTO.
+ *
+ * @param[in] CTX libyang context for logging.
+ * @param[in,out] ARRAY Pointer to the array to create.
+ * @param[in] SIZE Number of the new items the array is supposed to hold. The size of the allocated
+ * space is then counted from the type of the ARRAY, so do not provide placeholder void pointers.
+ * @param[in] EACTION Action to perform in case of error (memory allocation failure).
+ */
+#define LY_ARRAY_CREATE(CTX, ARRAY, SIZE, EACTION) \
+    { \
+        void *p__; \
+        if (ARRAY) { \
+            p__ = realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), \
+                    sizeof(LY_ARRAY_COUNT_TYPE) + ((*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) + (SIZE)) * sizeof *(ARRAY))); \
+            if (!p__) { \
                 LOGMEM(CTX); \
-                goto GOTO; \
+                EACTION; \
+            } \
+        } else { \
+            p__ = calloc(1, sizeof(LY_ARRAY_COUNT_TYPE) + (SIZE) * sizeof *(ARRAY)); \
+            if (!p__) { \
+                LOGMEM(CTX); \
+                EACTION; \
             } \
         } \
-        ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-        (NEW_ITEM) = &(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) - 1]; \
-        memset(NEW_ITEM, 0, sizeof *(NEW_ITEM))
+        p__ = (void*)((LY_ARRAY_COUNT_TYPE*)(p__) + 1); \
+        memcpy(&(ARRAY), &p__, sizeof p__); \
+        if (ARRAY) { \
+            memset(&(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(p__) - 1)], 0, (SIZE) * sizeof *(ARRAY)); \
+        } \
+    }
 
 /**
  * @brief Allocate a ([sized array](@ref sizedarrays)) for the specified number of items.
@@ -120,22 +171,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] RETVAL Return value for the case of error (memory allocation failure).
  */
 #define LY_ARRAY_CREATE_RET(CTX, ARRAY, SIZE, RETVAL) \
-        if (ARRAY) { \
-            ARRAY = ly_realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), sizeof(LY_ARRAY_COUNT_TYPE) + ((*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1) + (SIZE)) * sizeof *(ARRAY))); \
-            if (!(ARRAY)) { \
-                LOGMEM(CTX); \
-                return RETVAL; \
-            } \
-            ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-            memset(&(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)], 0, (SIZE) * sizeof *(ARRAY)); \
-        } else { \
-            ARRAY = calloc(1, sizeof(LY_ARRAY_COUNT_TYPE) + (SIZE) * sizeof *(ARRAY)); \
-            if (!(ARRAY)) { \
-                LOGMEM(CTX); \
-                return RETVAL; \
-            } \
-            ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-        }
+    LY_ARRAY_CREATE(CTX, ARRAY, SIZE, return RETVAL)
 
 /**
  * @brief Allocate a ([sized array](@ref sizedarrays)) for the specified number of items.
@@ -152,24 +188,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] GOTO Label to go in case of error (memory allocation failure).
  */
 #define LY_ARRAY_CREATE_GOTO(CTX, ARRAY, SIZE, RET, GOTO) \
-        if (ARRAY) { \
-            ARRAY = ly_realloc(((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1), sizeof(LY_ARRAY_COUNT_TYPE) + ((LY_ARRAY_COUNT(ARRAY) + (SIZE)) * sizeof *(ARRAY))); \
-            if (!(ARRAY)) { \
-                RET = LY_EMEM; \
-                LOGMEM(CTX); \
-                goto GOTO; \
-            } \
-            ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-            memset(&(ARRAY)[*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)], 0, (SIZE) * sizeof *(ARRAY)); \
-        } else { \
-            ARRAY = calloc(1, sizeof(LY_ARRAY_COUNT_TYPE) + (SIZE) * sizeof *(ARRAY)); \
-            if (!(ARRAY)) { \
-                RET = LY_EMEM; \
-                LOGMEM(CTX); \
-                goto GOTO; \
-            } \
-            ARRAY = (void*)((LY_ARRAY_COUNT_TYPE*)(ARRAY) + 1); \
-        }
+    LY_ARRAY_CREATE(CTX, ARRAY, SIZE, RET = LY_EMEM; goto GOTO)
 
 /**
  * @brief Increment the items counter in a ([sized array](@ref sizedarrays)).
@@ -238,6 +257,28 @@ void *ly_realloc(void *ptr, size_t size);
 /**
  * @brief Allocate and insert new item into linked list, return in case of error.
  *
+ * This is a generic macro for ::LY_LIST_NEW_RET and ::LY_LIST_NEW_GOTO.
+ *
+ * @param[in] CTX used for logging.
+ * @param[in,out] LIST Linked list to add to.
+ * @param[out] NEW_ITEM New item that is appended to the list.
+ * @param[in] LINKER name of structure member that is used to connect items together.
+ * @param[in] EACTION Action to perform in case of error (memory allocation failure).
+ */
+#define LY_LIST_NEW(CTX, LIST, NEW_ITEM, LINKER, EACTION) \
+    { \
+        void *p__ = calloc(1, sizeof *NEW_ITEM); \
+        if (!p__) { \
+            LOGMEM(CTX); \
+            EACTION; \
+        } \
+        memcpy(&(NEW_ITEM), &p__, sizeof p__); \
+        LY_LIST_INSERT(LIST, NEW_ITEM, LINKER); \
+    }
+
+/**
+ * @brief Allocate and insert new item into linked list, return in case of error.
+ *
  * @param[in] CTX used for logging.
  * @param[in,out] LIST Linked list to add to.
  * @param[out] NEW_ITEM New item that is appended to the list.
@@ -245,12 +286,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] RETVAL Return value for the case of error (memory allocation failure).
  */
 #define LY_LIST_NEW_RET(CTX, LIST, NEW_ITEM, LINKER, RETVAL) \
-    NEW_ITEM = calloc(1, sizeof *NEW_ITEM); \
-    if (!(NEW_ITEM)) { \
-        LOGMEM(CTX); \
-        return RETVAL; \
-    } \
-    LY_LIST_INSERT(LIST, NEW_ITEM, LINKER)
+    LY_LIST_NEW(CTX, LIST, NEW_ITEM, LINKER, return RETVAL)
 
 /**
  * @brief Allocate and insert new item into linked list, goto specified label in case of error.
@@ -263,13 +299,9 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] LABEL label to goto in case of error.
  */
 #define LY_LIST_NEW_GOTO(CTX, LIST, NEW_ITEM, LINKER, RET, LABEL) \
-    NEW_ITEM = calloc(1, sizeof *NEW_ITEM); \
-    if (!(NEW_ITEM)) { \
-        RET = LY_EMEM; \
-        LOGMEM(CTX); \
-        goto LABEL; \
-    } \
-    LY_LIST_INSERT(LIST, NEW_ITEM, LINKER)
+    LY_LIST_NEW(CTX, LIST, NEW_ITEM, LINKER, RET = LY_EMEM; goto LABEL)
+
+/** @} trees_edit */
 
 #ifdef __cplusplus
 }

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -225,13 +225,14 @@ void *ly_realloc(void *ptr, size_t size);
  */
 #define LY_LIST_INSERT(LIST, NEW_ITEM, LINKER)\
     if (!(*LIST)) { \
-        *LIST = (__typeof__(*(LIST)))NEW_ITEM; \
+        memcpy(LIST, &(NEW_ITEM), sizeof NEW_ITEM); \
     } else { \
-        do { \
-            __typeof__(*(LIST)) iterator; \
-            for (iterator = *(LIST); iterator->LINKER; iterator = iterator->LINKER) {} \
-            iterator->LINKER = (__typeof__(*(LIST)))NEW_ITEM; \
-        } while (0); \
+        size_t offset__ = (void*)&(*LIST)->LINKER - (void*)(*LIST); \
+        void **iter__ = (void **)((size_t)(*LIST) + offset__); \
+        while (*iter__) { \
+            iter__ = (void **)((size_t)(*iter__) + offset__); \
+        } \
+        memcpy(iter__, &(NEW_ITEM), sizeof NEW_ITEM); \
     }
 
 /**

--- a/src/validation.c
+++ b/src/validation.c
@@ -256,7 +256,7 @@ node_ext_tovalidate_add(struct ly_set *node_exts, struct lysc_ext_instance *exts
     struct lysc_ext_instance *ext;
     struct node_ext *rec;
 
-    LY_ARRAY_FOR(exts, const struct lysc_ext_instance, ext) {
+    LY_ARRAY_FOR(exts, struct lysc_ext_instance, ext) {
         if (ext->def->plugin && ext->def->plugin->validate) {
             rec = malloc(sizeof *rec);
             LY_CHECK_ERR_RET(!rec, LOGMEM(LYD_CTX(node)), LY_EMEM);

--- a/tests/style/CMakeLists.txt
+++ b/tests/style/CMakeLists.txt
@@ -1,6 +1,12 @@
 add_test(NAME headers
-	COMMAND ${CMAKE_SOURCE_DIR}/tests/style/check_includes.sh ${CMAKE_SOURCE_DIR}/src/ ${CMAKE_SOURCE_DIR}/tools/lint/ ${CMAKE_SOURCE_DIR}/tools/re/)
+    COMMAND ${CMAKE_SOURCE_DIR}/tests/style/check_includes.sh ${CMAKE_SOURCE_DIR}/src/ ${CMAKE_SOURCE_DIR}/tools/lint/ ${CMAKE_SOURCE_DIR}/tools/re/)
 
 if (${SOURCE_FORMAT_ENABLED})
-	add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND make format-check)
+    add_test(NAME format WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND make format-check)
 endif()
+
+# just compile
+add_executable(cpp_compat cpp_compat.c $<TARGET_OBJECTS:yangobj> $<TARGET_OBJECTS:compat>)
+target_include_directories(cpp_compat BEFORE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(cpp_compat ${CMAKE_THREAD_LIBS_INIT} ${PCRE2_LIBRARIES} ${CMAKE_DL_LIBS} m)
+target_compile_options(cpp_compat PUBLIC "-Werror=c++-compat")

--- a/tests/style/cpp_compat.c
+++ b/tests/style/cpp_compat.c
@@ -1,0 +1,97 @@
+/**
+ * @file cpp_compat.c
+ * @author Michal Vasko <mvasko@cesnet.cz>
+ * @brief test for C++ compatibility of public headers (macros)
+ *
+ * Copyright (c) 2021 CESNET, z.s.p.o.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* LOCAL INCLUDE HEADERS */
+#include "libyang.h"
+#include "plugins_exts.h"
+#include "plugins_types.h"
+
+int
+main(void)
+{
+    struct ly_ctx *ctx = NULL;
+    const struct lys_module *mod;
+    int *sa = NULL, *item;
+    struct test_list {
+        int val;
+        struct test_list *next;
+    } *tl = NULL, *tl_item = NULL, *tl_next;
+    LY_ARRAY_COUNT_TYPE u;
+    const struct lysc_node *scnode;
+    struct lyd_node *data = NULL, *next, *elem, *opaq = NULL;
+    LY_ERR ret = LY_SUCCESS;
+
+    if ((ret = ly_ctx_new(NULL, 0, &ctx))) {
+        goto cleanup;
+    }
+    if (!(mod = ly_ctx_get_module_latest(ctx, "ietf-yang-library"))) {
+        ret = LY_EINT;
+        goto cleanup;
+    }
+    if ((ret = ly_ctx_get_yanglib_data(ctx, &data, "%u", ly_ctx_get_change_count(ctx)))) {
+        goto cleanup;
+    }
+    if ((ret = lyd_new_opaq(NULL, ctx, "name", "val", NULL, "module", &opaq))) {
+        goto cleanup;
+    }
+
+    /* tree_edit.h / tree.h */
+    LY_ARRAY_NEW_GOTO(ctx, sa, item, ret, cleanup);
+    LY_ARRAY_NEW_GOTO(ctx, sa, item, ret, cleanup);
+    LY_ARRAY_FOR(sa, int, item) {}
+    LY_ARRAY_FREE(sa);
+    sa = NULL;
+
+    LY_ARRAY_CREATE_GOTO(ctx, sa, 2, ret, cleanup);
+    LY_ARRAY_INCREMENT(sa);
+    LY_ARRAY_INCREMENT(sa);
+    LY_ARRAY_FOR(sa, u) {}
+    LY_ARRAY_DECREMENT_FREE(sa);
+    LY_ARRAY_DECREMENT_FREE(sa);
+
+    LY_LIST_NEW_GOTO(ctx, &tl, tl_item, next, ret, cleanup);
+    LY_LIST_NEW_GOTO(ctx, &tl, tl_item, next, ret, cleanup);
+    LY_LIST_FOR(tl, tl_item) {}
+    LY_LIST_FOR_SAFE(tl, tl_next, tl_item) {}
+    tl_item = tl->next;
+
+    /* tree_data.h */
+    LYD_TREE_DFS_BEGIN(data, elem) {
+        LYD_TREE_DFS_END(data, elem);
+    }
+    LYD_LIST_FOR_INST(data, data->schema, elem) {}
+    LYD_LIST_FOR_INST_SAFE(data, data->schema, next, elem) {}
+    (void)LYD_CTX(data);
+    (void)LYD_CANON_VALUE(lyd_child(data));
+    (void)LYD_NAME(data);
+    (void)LYD_OPAQ_VALUE(opaq);
+
+    /* tree_schema.h */
+    LYSC_TREE_DFS_BEGIN(mod->compiled->data, scnode) {
+        LYSC_TREE_DFS_END(mod->compiled->data, scnode);
+    }
+    (void)LYSP_MODULE_NAME(mod->parsed);
+    (void)lysc_is_userordered(data->schema);
+    (void)lysc_is_key(data->schema);
+    (void)lysc_is_np_cont(data->schema);
+    (void)lysc_is_dup_inst_list(data->schema);
+
+cleanup:
+    free(tl_item);
+    free(tl);
+    lyd_free_tree(opaq);
+    lyd_free_all(data);
+    ly_ctx_destroy(ctx);
+    return ret;
+}


### PR DESCRIPTION
Rewrite macros to not use implicit casts - mentioned in #1504.

@choppsv1 - could you please check, that the changes help? I don't want to add `-Wc++-compat` directly to our build since the issues reported are fine from the C point of view and this is C code. I agree that the public headers are promising usability even for C++, so I tried to solve the issues there. Unfortunately, I'm not sure if there is a way to simply check only the (macros in) public headers.