### PR TITLE
printer tree FEATURE tree diagram printed from lysc tree

### DIFF
--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -114,7 +114,11 @@ LY_ERR yin_print_parsed_module(struct ly_out *out, const struct lysp_module *mod
 LY_ERR yin_print_parsed_submodule(struct ly_out *out, const struct lysp_submodule *submodp, uint32_t options);
 
 /**
- * @brief YANG Tree Diagram printer of the parsed submodule. Full YANG Tree printer.
+ * @brief Full YANG Tree Diagram printer.
+ *
+ * The module should be compiled and the @ref contextoptions must be set to LY_CTX_SET_PRIV_PARSED.
+ * If not, the printer will use parsed (unresolved) YANG schema tree, which means,
+ * for example, that `grouping` sections will be on the output.
  *
  * @param[in] out Output specification.
  * @param[in] module Main module.
@@ -122,7 +126,7 @@ LY_ERR yin_print_parsed_submodule(struct ly_out *out, const struct lysp_submodul
  * @param[in] line_length Maximum characters to be printed on a line, 0 for unlimited. Only for ::LYS_OUT_TREE printer.
  * @return LY_ERR value, number of the printed bytes is updated in ::ly_out.printed.
  */
-LY_ERR tree_print_parsed_module(struct ly_out *out, const struct lys_module *module, uint32_t options,
+LY_ERR tree_print_module(struct ly_out *out, const struct lys_module *module, uint32_t options,
         size_t line_length);
 
 /**

--- a/src/printer_schema.c
+++ b/src/printer_schema.c
@@ -68,7 +68,7 @@ lys_print_module(struct ly_out *out, const struct lys_module *module, LYS_OUTFOR
             ret = LY_EINVAL;
             break;
         }
-        ret = tree_print_parsed_module(out, module, options, line_length);
+        ret = tree_print_module(out, module, options, line_length);
         break;
     /* TODO not yet implemented
     case LYS_OUT_INFO:

--- a/tests/utests/schema/test_printer_tree.c
+++ b/tests/utests/schema/test_printer_tree.c
@@ -22,21 +22,16 @@
 
 #define TEST_LOCAL_SETUP \
     char *printed; \
-    struct ly_out *out; \
     const struct lys_module *mod; \
     const char *orig; \
-    const char *expect;
+    const char *expect; \
+    assert_int_equal(LY_SUCCESS, ly_out_new_memory(&printed, 0, &UTEST_OUT));
 
-#define TEST_LOCAL_CALL_PRINT(LINE_LENGTH) \
-    assert_int_equal(LY_SUCCESS, lys_print_module(out, mod, LYS_OUT_TREE, LINE_LENGTH, 0));
-
-#define TEST_LOCAL_PRECHECK(LINE_LENGTH) \
-    assert_int_equal(LY_SUCCESS, ly_out_new_memory(&printed, 0, &out)); \
-    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod); \
-    TEST_LOCAL_CALL_PRINT(LINE_LENGTH)
+#define TEST_LOCAL_PRINT(MOD, LINE_LENGTH) \
+    assert_int_equal(LY_SUCCESS, lys_print_module(UTEST_OUT, MOD, LYS_OUT_TREE, LINE_LENGTH, 0));
 
 #define TEST_LOCAL_TEARDOWN \
-    ly_out_free(out, NULL, 1);
+    ly_out_free(UTEST_OUT, NULL, 1);
 
 static void
 base_sections(void **state)
@@ -77,8 +72,9 @@ base_sections(void **state)
             "    +---n n1\n"
             "    +---n n2\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -110,8 +106,9 @@ node_status(void **state)
             "  x--rw m\n"
             "  o--rw n\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -139,8 +136,9 @@ node_config_flags(void **state)
             "  +--rw l\n"
             "  +--ro m\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -174,8 +172,9 @@ node_rpcs_flags(void **state)
             "        +---w input\n"
             "           +---w in?   string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -206,9 +205,9 @@ node_grouping_flags(void **state)
             "\n"
             "  grouping g:\n"
             "    +--rw c\n";
-
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -233,8 +232,9 @@ notif_inside_container(void **state)
             "  +--rw c\n"
             "     +---n notif\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -256,8 +256,9 @@ node_choice(void **state)
             "module: a07\n"
             "  +--rw (my_choice)?\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -282,8 +283,9 @@ node_case(void **state)
             "  +--rw (my_choice)?\n"
             "     +--:(my_case)\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -338,8 +340,9 @@ optional_opts(void **state)
             "  +--rw x1      anyxml\n"
             "  +--rw x2?     anyxml\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -365,8 +368,9 @@ presence_container(void **state)
             "  +--rw c\n"
             "  +--rw d!\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -410,8 +414,9 @@ node_keys(void **state)
             "  |  +--rw b    string\n"
             "  +--rw ll*   string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -441,8 +446,9 @@ node_type_target(void **state)
             "  +--rw a?   -> /x:b\n"
             "  +--rw b?   string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -474,8 +480,9 @@ node_type_leafref(void **state)
             "  +--rw a?\n"
             "          leafref\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -503,8 +510,11 @@ node_iffeatures(void **state)
             "module: a14\n"
             "  +--rw c {foo or bar}?\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    const char *feats[] = {"foo", NULL};
+
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -551,8 +561,9 @@ indent_wrapper(void **state)
             "     +--rw j\n"
             "     +--rw k\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -598,11 +609,14 @@ line_length_twiddling(void **state)
             "     +--rw nod-leaf?   some-long-type {f}?\n"
             "     +--rw nos-leaf?   int32 {f}?\n";
 
-    TEST_LOCAL_PRECHECK(42);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    const char *feats[] = {"f", NULL};
+
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 42);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* break_before_iffeature */
 
     /* pyang --tree-line-length 41 */
@@ -614,11 +628,12 @@ line_length_twiddling(void **state)
             "     |       {f}?\n"
             "     +--rw nos-leaf?   int32 {f}?\n";
 
-    TEST_LOCAL_CALL_PRINT(41);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 41);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* break_before_type */
 
     /* pyang --tree-line-length 29 */
@@ -632,11 +647,12 @@ line_length_twiddling(void **state)
             "     +--rw nos-leaf?   int32\n"
             "             {f}?\n";
 
-    TEST_LOCAL_CALL_PRINT(29);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 29);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* break_before_keys */
 
     /* pyang --tree-line-length 23 */
@@ -652,11 +668,12 @@ line_length_twiddling(void **state)
             "     +--rw nos-leaf?\n"
             "             int32 {f}?\n";
 
-    TEST_LOCAL_CALL_PRINT(23);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 23);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* every_node_name_is_too_long */
 
     /* pyang --tree-line-length 14 */
@@ -673,8 +690,9 @@ line_length_twiddling(void **state)
             "             int32\n"
             "             {f}?\n";
 
-    TEST_LOCAL_CALL_PRINT(14);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 14);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
     TEST_LOCAL_TEARDOWN;
@@ -707,8 +725,9 @@ break_before_leafref(void **state)
             "  +--rw abcd?\n"
             "          -> /x:e\n";
 
-    TEST_LOCAL_PRECHECK(14);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 14);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -744,8 +763,11 @@ break_before_leafref_and_iffeature(void **state)
             "          leafref\n"
             "          {f}?\n";
 
-    TEST_LOCAL_PRECHECK(20);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    const char *feats[] = {"f", NULL};
+
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, feats, &mod);
+    TEST_LOCAL_PRINT(mod, 20);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -795,8 +817,9 @@ basic_unified_indent_before_type(void **state)
             "     +--rw E        longType\n"
             "     +--rw G?       int8\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -848,11 +871,12 @@ twiddling_unified_indent_before_type(void **state)
             "     +--rw E                longType\n"
             "     +--rw G?               int8\n";
 
-    TEST_LOCAL_PRECHECK(36);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 36);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* unified_indent_before_type_long_node_name */
 
     /* pyang --tree-line-length 32 */
@@ -866,11 +890,12 @@ twiddling_unified_indent_before_type(void **state)
             "     |       longType\n"
             "     +--rw G?               int8\n";
 
-    TEST_LOCAL_CALL_PRINT(32);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 32);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
-    ly_out_reset(out);
+    ly_out_reset(UTEST_OUT);
     /* unified_indent_before_type_long_node_type */
 
     /* pyang --tree-line-length 31 */
@@ -888,8 +913,9 @@ twiddling_unified_indent_before_type(void **state)
             "     +--rw G?\n"
             "             int8\n";
 
-    TEST_LOCAL_CALL_PRINT(31);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 31);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
 
     TEST_LOCAL_TEARDOWN;
@@ -918,8 +944,9 @@ inheritance_of_config_flag(void **state)
             "  +--ro a\n"
             "     +--ro b?   string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -972,8 +999,9 @@ inheritance_of_status_flag(void **state)
             "     o--rw h\n"
             "        o--rw e?   string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -1013,8 +1041,9 @@ key_leaf_is_always_mandatory_true(void **state)
             "     |  +--rw k2    string\n"
             "     +--rw k1    string\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }
@@ -1071,8 +1100,9 @@ transition_between_rpc_and_notif(void **state)
             "     +---n n1\n"
             "     +---n n2\n";
 
-    TEST_LOCAL_PRECHECK(72);
-    assert_int_equal(strlen(expect), ly_out_printed(out));
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
     TEST_LOCAL_TEARDOWN;
 }

--- a/tests/utests/schema/test_printer_tree.c
+++ b/tests/utests/schema/test_printer_tree.c
@@ -102,6 +102,34 @@ base_sections(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+
+    /* from pyang */
+    expect =
+            "module: a01\n"
+            "  +--rw g\n"
+            "\n"
+            "  augment /xx:c:\n"
+            "    +--rw e\n"
+            "  augment /xx:d:\n"
+            "    +--rw f\n"
+            "\n"
+            "  rpcs:\n"
+            "    +---x rpc1\n"
+            "    +---x rpc2\n"
+            "\n"
+            "  notifications:\n"
+            "    +---n n1\n"
+            "    +---n n2\n";
+
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -136,6 +164,15 @@ node_status(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -166,6 +203,15 @@ node_config_flags(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -186,6 +232,12 @@ node_rpcs_flags(void **state)
             "          type string;\n"
             "        }\n"
             "      }\n"
+            "\n"
+            "      output {\n"
+            "        leaf out {\n"
+            "          type string;\n"
+            "        }\n"
+            "      }\n"
             "    }\n"
             "  }\n"
             "}\n";
@@ -196,12 +248,23 @@ node_rpcs_flags(void **state)
             "  +--rw cont\n"
             "     +---x rpc1\n"
             "        +---w input\n"
-            "           +---w in?   string\n";
+            "        |  +---w in?   string\n"
+            "        +--ro output\n"
+            "           +--ro out?   string\n";
 
     UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -263,6 +326,27 @@ node_grouping_flags(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    /* from pyang */
+    expect =
+            "module: a05\n"
+            "  +--rw d\n"
+            "     +--rw a?   string\n"
+            "     +--ro b?   string\n"
+            "     +--rw c?   string\n"
+            "     +--ro d\n"
+            "     |  +--ro e?   string\n"
+            "     +--rw f\n"
+            "        +--rw g?   string\n";
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -290,6 +374,15 @@ notif_inside_container(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -314,6 +407,15 @@ node_choice(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -341,6 +443,15 @@ node_case(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -398,6 +509,15 @@ optional_opts(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -426,6 +546,15 @@ presence_container(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -472,6 +601,15 @@ node_keys(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -504,6 +642,15 @@ node_type_target(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -538,6 +685,15 @@ node_type_leafref(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -570,6 +726,15 @@ node_iffeatures(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -619,6 +784,15 @@ indent_wrapper(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -671,6 +845,14 @@ line_length_twiddling(void **state)
     assert_string_equal(printed, expect);
 
     ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 42);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
+    ly_out_reset(UTEST_OUT);
     /* break_before_iffeature */
 
     /* pyang --tree-line-length 41 */
@@ -686,6 +868,14 @@ line_length_twiddling(void **state)
     TEST_LOCAL_PRINT(mod, 41);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 41);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
     ly_out_reset(UTEST_OUT);
     /* break_before_type */
@@ -705,6 +895,14 @@ line_length_twiddling(void **state)
     TEST_LOCAL_PRINT(mod, 29);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 29);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
     ly_out_reset(UTEST_OUT);
     /* break_before_keys */
@@ -728,6 +926,14 @@ line_length_twiddling(void **state)
     assert_string_equal(printed, expect);
 
     ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 23);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
+    ly_out_reset(UTEST_OUT);
     /* every_node_name_is_too_long */
 
     /* pyang --tree-line-length 14 */
@@ -748,6 +954,14 @@ line_length_twiddling(void **state)
     TEST_LOCAL_PRINT(mod, 14);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 14);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
     TEST_LOCAL_TEARDOWN;
 }
@@ -783,6 +997,15 @@ break_before_leafref(void **state)
     TEST_LOCAL_PRINT(mod, 14);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 14);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -823,6 +1046,15 @@ break_before_leafref_and_iffeature(void **state)
     TEST_LOCAL_PRINT(mod, 20);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 20);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -875,6 +1107,15 @@ basic_unified_indent_before_type(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -931,6 +1172,14 @@ twiddling_unified_indent_before_type(void **state)
     assert_string_equal(printed, expect);
 
     ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 36);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
+    ly_out_reset(UTEST_OUT);
     /* unified_indent_before_type_long_node_name */
 
     /* pyang --tree-line-length 32 */
@@ -948,6 +1197,14 @@ twiddling_unified_indent_before_type(void **state)
     TEST_LOCAL_PRINT(mod, 32);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 32);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
     ly_out_reset(UTEST_OUT);
     /* unified_indent_before_type_long_node_type */
@@ -971,6 +1228,14 @@ twiddling_unified_indent_before_type(void **state)
     TEST_LOCAL_PRINT(mod, 31);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 31);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
     TEST_LOCAL_TEARDOWN;
 }
@@ -1002,6 +1267,15 @@ inheritance_of_config_flag(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -1057,6 +1331,15 @@ inheritance_of_status_flag(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -1099,6 +1382,25 @@ key_leaf_is_always_mandatory_true(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+
+    /* from pyang but with some swapped lines */
+    expect =
+            "module: a23\n"
+            "  +--rw a* [k1]\n"
+            "     +--rw k1    string\n"
+            "     +--rw b* [k2]\n"
+            "        +--rw k2    string\n"
+            "        +--rw k1?   string\n";
+
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -1112,6 +1414,9 @@ transition_between_rpc_and_notif(void **state)
             "  namespace \"x:y\";\n"
             "  prefix x;\n"
             "  container top {\n"
+            "    leaf g {\n"
+            "      type string;\n"
+            "    }\n"
             "    action rpc1 {\n"
             "\n"
             "      input {\n"
@@ -1143,6 +1448,7 @@ transition_between_rpc_and_notif(void **state)
     expect =
             "module: a24\n"
             "  +--rw top\n"
+            "     +--rw g?      string\n"
             "     +---x rpc1\n"
             "     |  +---w input\n"
             "     |     +---w in?   string\n"
@@ -1158,6 +1464,49 @@ transition_between_rpc_and_notif(void **state)
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
+
+    ly_out_reset(UTEST_OUT);
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
+    TEST_LOCAL_TEARDOWN;
+}
+
+static void
+local_augment(void **state)
+{
+    TEST_LOCAL_SETUP;
+
+    orig =
+            "module a25 {\n"
+            "  yang-version 1.1;\n"
+            "  namespace \"x:y\";\n"
+            "  prefix x;\n"
+            "  container g;\n"
+            "  augment \"/x:g\" {\n"
+            "    container e;\n"
+            "  }\n"
+            "}\n";
+
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+
+    /* from pyang */
+    expect =
+            "module: a25\n"
+            "  +--rw g\n"
+            "     +--rw e\n";
+
+    /* using lysc tree */
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -1189,6 +1538,7 @@ main(void)
         UTEST(inheritance_of_status_flag),
         UTEST(key_leaf_is_always_mandatory_true),
         UTEST(transition_between_rpc_and_notif),
+        UTEST(local_augment),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tools/lint/cmd_print.c
+++ b/tools/lint/cmd_print.c
@@ -137,6 +137,11 @@ cmd_print(struct ly_ctx **ctx, const char *cmdline)
         out_stdout = 1;
     }
 
+    if (format == LYS_OUT_TREE) {
+        /* print tree from lysc_nodes */
+        ly_ctx_set_options(*ctx, LY_CTX_SET_PRIV_PARSED);
+    }
+
     if (node_path) {
         const struct lysc_node *node;
         node = lys_find_path(*ctx, NULL, node_path, 0);

--- a/tools/lint/main_ni.c
+++ b/tools/lint/main_ni.c
@@ -664,6 +664,11 @@ fill_context(int argc, char *argv[], struct context *c)
         return ret;
     }
 
+    if (c->schema_out_format == LYS_OUT_TREE) {
+        /* print tree from lysc_nodes */
+        ly_ctx_set_options(c->ctx, LY_CTX_SET_PRIV_PARSED);
+    }
+
     /* the second batch of checks */
     if (c->schema_print_options && !c->schema_out_format) {
         YLMSG_W("Schema printer options specified, but the schema output format is missing.\n");


### PR DESCRIPTION
The tree printer module uses lysc nodes to print the diagram.