### PR TITLE
LYB data DOC specific description of data stored in LYB format

### DIFF
--- a/src/plugins_types/ipv6_address.c
+++ b/src/plugins_types/ipv6_address.c
@@ -30,7 +30,8 @@
 #include "compat.h"
 
 /**
- * @page lybformat_ipv6_address ietf-inet-types LYB ipv6-address(-no-zone)
+ * @page howtoDataLYB LYB Binary Format
+ * @subsection howtoDataLYBTypesIPv6Address ietf-inet-types LYB ipv6-address(-no-zone)
  *
  * | Size (B) | Mandatory | Meaning |
  * | :------  | :-------: | :-----: |

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -370,7 +370,7 @@ struct lyd_node_term;
  * support out-of-the-box (meaning that have a special type plugin). Any derived types inherit the format of its
  * closest type with explicit support (up to a built-in type).
  *
- * @subpage lybformat_ipv6_address
+ * @section howtoDataLYBTypes Specific storing of particular data type values
  */
 
 /**


### PR DESCRIPTION
Change the doxygen of LYB to directly include type-specific details of storing values.