### PR TITLE
xml parser BUGFIX namespace not found

### DIFF
--- a/tests/fuzz/corpus/lyd_parse_mem_xml/pull1529
+++ b/tests/fuzz/corpus/lyd_parse_mem_xml/pull1529
@@ -1,0 +1,1 @@
+<enums w=''B:s=''xmlns='urn:tests:types'

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -973,15 +973,15 @@ test_type_length(void **state)
 #endif
 
     /* invalid values */
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;leaf l {type binary {length -10;}}}", LYS_IN_YANG, NULL));
+    assert_int_equal(LY_EDENIED, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;leaf l {type binary {length -10;}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - value \"-10\" does not fit the type limitations.", "/aa:l");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb;leaf l {type binary {length 18446744073709551616;}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - invalid value \"18446744073709551616\".", "/bb:l");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {namespace urn:cc;prefix cc;leaf l {type binary {length \"max .. 10\";}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - unexpected data after max keyword (.. 10).", "/cc:l");
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module dd {namespace urn:dd;prefix dd;leaf l {type binary {length 50..10;}}}", LYS_IN_YANG, NULL));
+    assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module dd {namespace urn:dd;prefix dd;leaf l {type binary {length 50..10;}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (10).", "/dd:l");
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;leaf l {type binary {length \"50 | 10\";}}}", LYS_IN_YANG, NULL));
+    assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;leaf l {type binary {length \"50 | 10\";}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (10).", "/ee:l");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ff {namespace urn:ff;prefix ff;leaf l {type binary {length \"x\";}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - unexpected data (x).", "/ff:l");
@@ -995,7 +995,7 @@ test_type_length(void **state)
     CHECK_LOG_CTX("Invalid length restriction - unexpected \"..\" without a lower bound.", "/jj:l");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module kk {namespace urn:kk;prefix kk;leaf l {type binary {length \"10 |\";}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - unexpected end of the expression (10 |).", "/kk:l");
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module kl {namespace urn:kl;prefix kl;leaf l {type binary {length \"10..20 | 15..30\";}}}", LYS_IN_YANG, NULL));
+    assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module kl {namespace urn:kl;prefix kl;leaf l {type binary {length \"10..20 | 15..30\";}}}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (15).", "/kl:l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ll {namespace urn:ll;prefix ll;typedef mytype {type binary {length 10;}}"
@@ -1361,11 +1361,11 @@ test_type_dec64(void **state)
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ab {namespace urn:ab;prefix ab; typedef mytype {type decimal64;}leaf l {type mytype;}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Missing fraction-digits substatement for decimal64 type mytype.", "/ab:l");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb; leaf l {type decimal64 {fraction-digits 2;"
+    assert_int_equal(LY_EINVAL, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb; leaf l {type decimal64 {fraction-digits 2;"
             "range '3.142';}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Range boundary \"3.142\" of decimal64 type exceeds defined number (2) of fraction digits.", "/bb:l");
 
-    assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {namespace urn:cc;prefix cc; leaf l {type decimal64 {fraction-digits 2;"
+    assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module cc {namespace urn:cc;prefix cc; leaf l {type decimal64 {fraction-digits 2;"
             "range '4 | 3.14';}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (3.14).", "/cc:l");
 

--- a/tests/utests/types/int8.c
+++ b/tests/utests/types/int8.c
@@ -223,25 +223,25 @@ test_schema_yang(void **state)
 
     /* TEST ERROR -60 .. 0 | 0 .. 127 */
     schema = MODULE_CREATE_YANG("ERR0", "leaf port {type int8 {range \"-60 .. 0 | 0 .. 127\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EEXIST);
     CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).",
             "/ERR0:port");
 
     /* TEST ERROR 0 .. 128 */
     schema = MODULE_CREATE_YANG("ERR1", "leaf port {type int8 {range \"0 .. 128\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.",
             "/ERR1:port");
 
     /* TEST ERROR -129 .. 126 */
     schema = MODULE_CREATE_YANG("ERR2", "leaf port {type int8 {range \"-129 .. 0\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
             "/ERR2:port");
 
     /* TEST ERROR 0 */
     schema = MODULE_CREATE_YANG("ERR3", "leaf port {type int8 {range \"-129\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
             "/ERR3:port");
 
@@ -392,7 +392,7 @@ test_schema_yang(void **state)
     schema = MODULE_CREATE_YANG("TS_ERR4",
             "typedef my_int_type { type int8 {range \"-128 .. -60 | -1 .. 1 |  60 .. 127\";}}"
             "leaf my_leaf {type my_int_type {range \"-100 .. -90 | 100 .. 128\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.",
             "/TS_ERR4:my_leaf");
 
@@ -732,7 +732,7 @@ test_schema_yin(void **state)
             "<leaf name=\"port\"> "
             "   <type name=\"int8\"> <range value = \"min .. 0 | 0 .. 12\"/>  </type>"
             "</leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EEXIST);
     CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).",
             "/TE0:port");
 
@@ -741,7 +741,7 @@ test_schema_yin(void **state)
             "<leaf name=\"port\">"
             "   <type name=\"int8\"> <range value = \"0 .. 128\"/>  </type>"
             "</leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.",
             "/TE1:port");
 
@@ -750,7 +750,7 @@ test_schema_yin(void **state)
             "<leaf name=\"port\"> "
             "   <type name=\"int8\"> <range value =\"-129 .. 126\"/>  </type>"
             "</leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
             "/TE2:port");
 

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -183,7 +183,7 @@ test_schema_yang(void **state)
 
     /* ERROR TESTS NEGATIVE VALUE */
     schema = MODULE_CREATE_YANG("ERR0", "leaf port {type string {length \"-1 .. 20\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
             "/ERR0:port");
 
@@ -193,7 +193,7 @@ test_schema_yang(void **state)
             "/ERR1:port");
 
     schema = MODULE_CREATE_YANG("ERR2", "leaf port {type string {length \"10 .. 20 | 20 .. 30\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EEXIST);
     CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).",
             "/ERR2:port");
 
@@ -202,7 +202,7 @@ test_schema_yang(void **state)
             "    type string;"
             "}"
             "leaf port {type my_type {length \"-1 .. 15\";}}");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
             "/ERR3:port");
 
@@ -436,7 +436,7 @@ test_schema_yin(void **state)
     /* ERROR TESTS NEGATIVE VALUE */
     schema = MODULE_CREATE_YIN("ERR0", "<leaf name=\"port\"> <type name=\"string\">"
             "<length value =\"-1 .. 20\"/> </type></leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
             "/ERR0:port");
 
@@ -450,7 +450,7 @@ test_schema_yin(void **state)
     schema = MODULE_CREATE_YIN("ERR2", "<leaf name=\"port\">"
             "<type name=\"string\"> <length value=\"10 .. 20 | 20 .. 30\"/>"
             "</type> </leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EEXIST);
     CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).",
             "/ERR2:port");
 
@@ -458,7 +458,7 @@ test_schema_yin(void **state)
             "<typedef name=\"my_type\"> <type name=\"string\"/> </typedef>"
             "<leaf name=\"port\"> <type name=\"my_type\"> <length value=\"-1 .. 15\"/>"
             "</type> </leaf>");
-    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
+    UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
     CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
             "/ERR3:port");
 


### PR DESCRIPTION
This PR fixes oss-fuzz issue 3147. Function `lydxml_metadata` now returns an error if the namespace of an attribute is not found.
A similar error with a return code was discovered and fixed in other files.