### PR TITLE
context FEATURE callback for every compiled module

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -300,8 +300,12 @@ struct ly_ctx {
     struct dict_table dict;           /**< dictionary to effectively store strings used in the context related structures */
     struct ly_set search_paths;       /**< set of directories where to search for schema's imports/includes */
     struct ly_set list;               /**< set of loaded YANG schemas */
+
     ly_module_imp_clb imp_clb;        /**< Optional callback for retrieving missing included or imported models in a custom way. */
     void *imp_clb_data;               /**< Optional private data for ::ly_ctx.imp_clb */
+    ly_module_compiled_clb compiled_clb; /**< Optional callback called for every compiled module. */
+    void *compiled_clb_data;          /**< Optional private data for ::ly_ctx.compiled_clb */
+
     uint16_t change_count;            /**< Count of changes of the context, on some changes it could be incremented more times */
     uint16_t flags;                   /**< context settings, see @ref contextoptions. */
     pthread_key_t errlist_key;        /**< key for the thread-specific list of errors related to the context */

--- a/src/context.c
+++ b/src/context.c
@@ -627,6 +627,26 @@ ly_ctx_get_module_imp_clb(const struct ly_ctx *ctx, void **user_data)
     return ctx->imp_clb;
 }
 
+API ly_module_compiled_clb
+ly_ctx_get_module_compiled_clb(const struct ly_ctx *ctx, void **user_data)
+{
+    LY_CHECK_ARG_RET(ctx, ctx, NULL);
+
+    if (user_data) {
+        *user_data = ctx->compiled_clb_data;
+    }
+    return ctx->compiled_clb;
+}
+
+API void
+ly_ctx_set_module_compiled_clb(struct ly_ctx *ctx, ly_module_compiled_clb clb, void *user_data)
+{
+    LY_CHECK_ARG_RET(ctx, ctx, );
+
+    ctx->compiled_clb = clb;
+    ctx->compiled_clb_data = user_data;
+}
+
 API const struct lys_module *
 ly_ctx_get_module_iter(const struct ly_ctx *ctx, uint32_t *index)
 {

--- a/src/context.h
+++ b/src/context.h
@@ -408,6 +408,33 @@ ly_module_imp_clb ly_ctx_get_module_imp_clb(const struct ly_ctx *ctx, void **use
 void ly_ctx_set_module_imp_clb(struct ly_ctx *ctx, ly_module_imp_clb clb, void *user_data);
 
 /**
+ * @brief Callback called for each (re)compiled module in a context.
+ *
+ * @param[in] mod Implemented and compiled module.
+ * @param[in] user_data Arbitrary user data.
+ */
+typedef void (*ly_module_compiled_clb)(const struct lys_module *mod, void *user_data);
+
+/**
+ * @brief Get callback for compiled or recompiled modules in a context.
+ *
+ * @param[in] ctx Context to read from.
+ * @param[out] user_data Optional pointer for the set user data.
+ * @return Callback or NULL if not set.
+ */
+ly_module_compiled_clb ly_ctx_get_module_compiled_clb(const struct ly_ctx *ctx, void **user_data);
+
+/**
+ * @brief Set callback called for each compiled or recompiled module in a context. It can be used
+ * when ::lysc_node.priv pointers are being used and need to be set for every compiled module.
+ *
+ * @param[in] ctx Context that will use the callback.
+ * @param[in] clb Callback for the compiled modules.
+ * @param[in] user data Arbitrary user data passed to @p clb.
+ */
+void ly_ctx_set_module_compiled_clb(struct ly_ctx *ctx, ly_module_compiled_clb clb, void *user_data);
+
+/**
  * @brief Get YANG module of the given name and revision.
  *
  * @param[in] ctx Context to work in.

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -1735,6 +1735,11 @@ lys_compile(struct lys_module *mod, uint32_t options, struct lys_glob_unres *unr
     /* finish compilation for all unresolved module items in the context */
     LY_CHECK_GOTO(ret = lys_compile_unres_mod(&ctx), cleanup);
 
+    /* call the callback for new compiled module */
+    if (mod->ctx->compiled_clb) {
+        mod->ctx->compiled_clb(mod, mod->ctx->compiled_clb_data);
+    }
+
 cleanup:
     LOG_LOCBACK(0, 0, 1, 0);
     lys_compile_unres_mod_erase(&ctx, ret);


### PR DESCRIPTION
Note that even when a single context change is being performed (new module compiled, feature changed), the callback may be called several times for the same module.

@choppsv1
Refs #1528