### PR TITLE
build BUGFIX fix BSD builds, again, and cleanup

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -11,14 +11,13 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _GNU_SOURCE /* asprintf */
-#define _POSIX_C_SOURCE 200809L /* strdup */
-
+#define _GNU_SOURCE /* asprintf, strdup */
 #if defined (__NetBSD__) || defined (__OpenBSD__)
 /* realpath */
 #define _XOPEN_SOURCE 1
 #define _XOPEN_SOURCE_EXTENDED 1
 #endif
+#include <sys/cdefs.h>
 
 #include "context.h"
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -11,8 +11,8 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _POSIX_C_SOURCE 200809L /* strdup */
-#define _GNU_SOURCE /* asprintf */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "diff.h"
 

--- a/src/log.c
+++ b/src/log.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "log.h"
 

--- a/src/out.c
+++ b/src/out.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup, vdprintf */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "out.h"
 #include "out_internal.h"

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ip_prefix.c
+++ b/src/plugins_types/ip_prefix.c
@@ -12,11 +12,16 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "plugins_types.h"
 
 #include <arpa/inet.h>
+#if defined (__FreeBSD__) || defined (__NetBSD__) || defined (__OpenBSD__)
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
 #include <assert.h>
 #include <errno.h>
 #include <stdint.h>

--- a/src/plugins_types/ipv6_address.c
+++ b/src/plugins_types/ipv6_address.c
@@ -12,11 +12,16 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "plugins_types.h"
 
 #include <arpa/inet.h>
+#if defined (__FreeBSD__) || defined (__NetBSD__) || defined (__OpenBSD__)
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup, strndup */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "schema_compile_node.h"
 

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "tree_schema.h"
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -11,8 +11,8 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _POSIX_C_SOURCE 200809L /* strdup */
-#define _GNU_SOURCE /* asprintf */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "validation.h"
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -11,11 +11,8 @@
  *
  *     https://opensource.org/licenses/BSD-3-Clause
  */
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup, strndup */
-
-/* needed by libmath functions isfinite(), isinf(), isnan(), signbit(), ... */
-#define _ISOC99_SOURCE
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include "xpath.h"
 

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -12,8 +12,8 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 
-#define _GNU_SOURCE
-#define _POSIX_C_SOURCE 200809L /* strdup, getline */
+#define _GNU_SOURCE /* asprintf, strdup */
+#include <sys/cdefs.h>
 
 #include <errno.h>
 #include <getopt.h>


### PR DESCRIPTION
- just define _GNU_SOURCE and include sys/cdefs.h this gets everything
set the right way (no need to define _POSIX_C_SOURCE, etc).
- BSD requires more includes to get to sockaddr and AF_*