### PR TITLE
libyang BUGFIX change LOGVAL to LOGVAL_ERRITEM

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -105,10 +105,10 @@ void ly_log_location(const struct lysc_node *scnode, const struct lyd_node *dnod
 /**
  * @brief Revert the specific logger's location data by number of changes made by ::ly_log_location().
  *
- * @param[in] scnode_steps Number of items in ::log_location.scnodes to forget.
- * @param[in] dnode_steps Number of items in ::log_location.dnodes to forget.
- * @param[in] path_steps Number of path strings in ::log_location.paths to forget.
- * @param[in] in_steps Number of input handlers ::log_location.inputs to forget.
+ * @param[in] scnode_steps Number of items in ::ly_log_location_s.scnodes to forget.
+ * @param[in] dnode_steps Number of items in ::ly_log_location_s.dnodes to forget.
+ * @param[in] path_steps Number of path strings in ::ly_log_location_s.paths to forget.
+ * @param[in] in_steps Number of input handlers ::ly_log_location_s.inputs to forget.
  */
 void ly_log_location_revert(uint32_t scnode_steps, uint32_t dnode_steps, uint32_t path_steps, uint32_t in_steps);
 
@@ -340,7 +340,9 @@ struct lys_module *ly_ctx_get_module_implemented2(const struct ly_ctx *ctx, cons
  * @param[in] CTX libyang context.
  * @param[in] STRING string to store.
  * @param[in] LEN length of the string in WORD to store.
- * @param[in,out] DYNAMIC Set to 1 if STR is dynamically allocated, 0 otherwise. If set to 1, zerocopy version of lydict_insert is used.
+ * @param[in,out] DYNAMIC Set to 1 if @p STRING is dynamically allocated, 0 otherwise.
+ * If set to 1, zerocopy version of lydict_insert is used.
+ * @param[out] TARGET pointer is set to @p STRING value stored in the dictionary.
  */
 #define INSERT_STRING_RET(CTX, STRING, LEN, DYNAMIC, TARGET) \
     if (DYNAMIC) { \
@@ -372,10 +374,10 @@ void *ly_realloc(void *ptr, size_t size);
 char *ly_strnchr(const char *s, int c, size_t len);
 
 /**
- * @brief Compare NULL-terminated @p refstr with @str_len bytes from @p str.
+ * @brief Compare NULL-terminated @p refstr with @p str_len bytes from @p str.
  *
- * @param[in] refstr NULL-terminated string which must match @str_len bytes from @str followed by NULL-byte.
- * @param[in] str String to compare
+ * @param[in] refstr NULL-terminated string which must match @p str_len bytes from @p str followed by NULL-byte.
+ * @param[in] str String to compare.
  * @param[in] str_len Number of bytes to take into comparison from @p str.
  * @return An integer less than, equal to, or greater than zero if @p refstr matches,
  * respectively, to be less than, to match, or be greater than @p str.
@@ -536,7 +538,7 @@ LY_ERR ly_parse_uint(const char *val_str, size_t val_len, uint64_t max, int base
  * @param[out] prefix Node's prefix, NULL if there is not any.
  * @param[out] prefix_len Length of the node's prefix, 0 if there is not any.
  * @param[out] name Node's name.
- * @param[out] nam_len Length of the node's name.
+ * @param[out] name_len Length of the node's name.
  * @return LY_ERR value: LY_SUCCESS or LY_EINVAL in case of invalid character in the id.
  */
 LY_ERR ly_parse_nodeid(const char **id, const char **prefix, size_t *prefix_len, const char **name, size_t *name_len);

--- a/src/common.h
+++ b/src/common.h
@@ -174,6 +174,17 @@ void ly_log_dbg(uint32_t group, const char *format, ...);
     ly_log_location(NULL, NULL, NULL, NULL, LINE, 0); \
     ly_vlog(CTX, CODE, ##__VA_ARGS__)
 
+/**
+ * @brief Print Validation error from struct ly_err_item.
+ *
+ * String ::ly_err_item.msg cannot be used directly because it may contain the % character,
+ * which is incorrectly interpreted in this situation as a conversion specification.
+ *
+ * @param[in] CTX libyang context to store the error record. If not provided, the error is just printed.
+ * @param[in] ERRITEM pointer to ly_err_item that contains an error message.
+ */
+#define LOGVAL_ERRITEM(CTX, ERRITEM) ly_vlog(CTX, ERRITEM->vecode, "%s", ERRITEM->msg)
+
 #define LOGMEM_RET(CTX) LOGMEM(CTX); return LY_EMEM
 #define LOGINT_RET(CTX) LOGINT(CTX); return LY_EINT
 #define LOGARG_RET(CTX) LOGARG(CTX); return LY_EINVAL

--- a/src/plugins_types/xpath1.0.c
+++ b/src/plugins_types/xpath1.0.c
@@ -263,7 +263,7 @@ lyplg_type_print_xpath10(const struct ly_ctx *UNUSED(ctx), const struct lyd_valu
 
     if (xpath10_print_value(value->ptr, format, prefix_data, &str_value, &err)) {
         if (err) {
-            LOGVAL(NULL, err->vecode, err->msg);
+            LOGVAL_ERRITEM(NULL, err);
             ly_err_free(err);
         }
         *dynamic = 0;

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -81,7 +81,7 @@ lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct ly
         }
     } else if (ret) {
         if (err) {
-            LOGVAL(ctx, err->vecode, err->msg);
+            LOGVAL_ERRITEM(ctx, err);
             ly_err_free(err);
         } else {
             LOGVAL(ctx, LYVE_OTHER, "Storing value \"%.*s\" failed.", (int)value_len, value);
@@ -104,7 +104,7 @@ lyd_value_validate_incomplete(const struct ly_ctx *ctx, const struct lysc_type *
     ret = type->plugin->validate(ctx, type, ctx_node, tree, val, &err);
     if (ret) {
         if (err) {
-            LOGVAL(ctx, err->vecode, err->msg);
+            LOGVAL_ERRITEM(ctx, err);
             ly_err_free(err);
         } else {
             LOGVAL(ctx, LYVE_OTHER, "Resolving value \"%s\" failed.", type->plugin->print(ctx, val, LY_VALUE_CANON,
@@ -143,7 +143,7 @@ lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node, const
         if (ctx) {
             /* log only in case the ctx was provided as input parameter */
             LOG_LOCSET(NULL, NULL, err->path, NULL);
-            LOGVAL(ctx, err->vecode, err->msg);
+            LOGVAL_ERRITEM(ctx, err);
             LOG_LOCBACK(0, 0, 1, 0);
         }
         ly_err_free(err);
@@ -195,7 +195,7 @@ lyd_value_validate(const struct ly_ctx *ctx, const struct lysc_node *schema, con
             } else {
                 LOG_LOCSET(schema, NULL, NULL, NULL);
             }
-            LOGVAL(ctx, err->vecode, err->msg);
+            LOGVAL_ERRITEM(ctx, err);
             if (err->path) {
                 LOG_LOCBACK(0, 0, 1, 0);
             } else if (ctx_node) {


### PR DESCRIPTION
Segfault occurs if the LOGVAR macro is called with the ly_err_item.msg parameter, which contains a conversion specification (character %). Commit should solve issues with numbers 31536, 31778, 32183 on oss-fuzz.

The warnings thrown by doxygen have also been fixed in the common.h file.