### PR TITLE
data tree FEATURE add sorting compare callback

### DIFF
--- a/src/plugins_types/binary.c
+++ b/src/plugins_types/binary.c
@@ -292,6 +292,37 @@ lyplg_type_compare_binary(const struct lyd_value *val1, const struct lyd_value *
     return LY_SUCCESS;
 }
 
+static int
+lyplg_type_sort_binary(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_binary *v1;
+    const struct lyd_value_binary *v2;
+    size_t minsize;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    /* just do something deterministic -- should not happen */
+    if (val1->realtype != val2->realtype) {
+        return val1->realtype < val2->realtype ? -1 : 1;
+    }
+
+    minsize = v1->size < v2->size ? v1->size : v2->size;
+    if ((result = memcmp(v1->data, v2->data, minsize))) {
+        return result;
+    } else if (v1->size == v2->size) {
+        return 0;
+    } else if (minsize == v1->size) {
+        return -1;
+    }
+    return 1;
+}
+
 API const void *
 lyplg_type_print_binary(const struct ly_ctx *ctx, const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *UNUSED(prefix_data), ly_bool *dynamic, size_t *value_len)
@@ -393,6 +424,7 @@ const struct lyplg_type_record plugins_binary[] = {
         .plugin.store = lyplg_type_store_binary,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_binary,
+        .plugin.sort = lyplg_type_sort_binary,
         .plugin.print = lyplg_type_print_binary,
         .plugin.duplicate = lyplg_type_dup_binary,
         .plugin.free = lyplg_type_free_binary,

--- a/src/plugins_types/boolean.c
+++ b/src/plugins_types/boolean.c
@@ -118,6 +118,22 @@ lyplg_type_compare_boolean(const struct lyd_value *val1, const struct lyd_value 
     return LY_SUCCESS;
 }
 
+static int
+lyplg_type_sort_boolean(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    if (val1->boolean == val2->boolean) {
+        return 0;
+    }
+
+    return val1->boolean ? 1 : -1;
+}
+
 API const void *
 lyplg_type_print_boolean(const struct ly_ctx *UNUSED(ctx), const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *UNUSED(prefix_data), ly_bool *dynamic, size_t *value_len)
@@ -157,6 +173,7 @@ const struct lyplg_type_record plugins_boolean[] = {
         .plugin.store = lyplg_type_store_boolean,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_boolean,
+        .plugin.sort = lyplg_type_sort_boolean,
         .plugin.print = lyplg_type_print_boolean,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple

--- a/src/plugins_types/empty.c
+++ b/src/plugins_types/empty.c
@@ -57,14 +57,8 @@ lyplg_type_store_empty(const struct ly_ctx *ctx, const struct lysc_type *type, c
     }
 
     /* store canonical value */
-    if (options & LYPLG_TYPE_STORE_DYNAMIC) {
-        ret = lydict_insert_zc(ctx, (char *)value, &storage->_canonical);
-        options &= ~LYPLG_TYPE_STORE_DYNAMIC;
-        LY_CHECK_GOTO(ret, cleanup);
-    } else {
-        ret = lydict_insert(ctx, "", value_len, &storage->_canonical);
-        LY_CHECK_GOTO(ret, cleanup);
-    }
+    ret = lydict_insert(ctx, "", value_len, &storage->_canonical);
+    LY_CHECK_GOTO(ret, cleanup);
 
 cleanup:
     if (options & LYPLG_TYPE_STORE_DYNAMIC) {

--- a/src/plugins_types/enumeration.c
+++ b/src/plugins_types/enumeration.c
@@ -116,6 +116,35 @@ cleanup:
     return ret;
 }
 
+static LY_ERR
+lyplg_type_compare_enum(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    if (val1->realtype != val2->realtype) {
+        return LY_ENOT;
+    }
+    if (val1->enum_item->value != val2->enum_item->value) {
+        return LY_ENOT;
+    }
+    return LY_SUCCESS;
+}
+
+static int
+lyplg_type_sort_enum(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    if (val1->enum_item->value < val2->enum_item->value) {
+        return -1;
+    } else if (val1->enum_item->value > val2->enum_item->value) {
+        return 1;
+    }
+    return 0;
+}
+
 API const void *
 lyplg_type_print_enum(const struct ly_ctx *UNUSED(ctx), const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *UNUSED(prefix_data), ly_bool *dynamic, size_t *value_len)
@@ -154,7 +183,8 @@ const struct lyplg_type_record plugins_enumeration[] = {
         .plugin.id = "libyang 2 - enumeration, version 1",
         .plugin.store = lyplg_type_store_enum,
         .plugin.validate = NULL,
-        .plugin.compare = lyplg_type_compare_simple,
+        .plugin.compare = lyplg_type_compare_enum,
+        .plugin.sort = lyplg_type_sort_enum,
         .plugin.print = lyplg_type_print_enum,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple

--- a/src/plugins_types/identityref.c
+++ b/src/plugins_types/identityref.c
@@ -310,6 +310,7 @@ const struct lyplg_type_record plugins_identityref[] = {
         .plugin.store = lyplg_type_store_identityref,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_identityref,
+        .plugin.sort = lyplg_type_sort_simple,
         .plugin.print = lyplg_type_print_identityref,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple

--- a/src/plugins_types/instanceid.c
+++ b/src/plugins_types/instanceid.c
@@ -360,6 +360,7 @@ const struct lyplg_type_record plugins_instanceid[] = {
         .plugin.store = lyplg_type_store_instanceid,
         .plugin.validate = lyplg_type_validate_instanceid,
         .plugin.compare = lyplg_type_compare_instanceid,
+        .plugin.sort = lyplg_type_sort_simple,
         .plugin.print = lyplg_type_print_instanceid,
         .plugin.duplicate = lyplg_type_dup_instanceid,
         .plugin.free = lyplg_type_free_instanceid

--- a/src/plugins_types/integer.c
+++ b/src/plugins_types/integer.c
@@ -397,6 +397,89 @@ lyplg_type_compare_uint(const struct lyd_value *val1, const struct lyd_value *va
     return LY_SUCCESS;
 }
 
+static inline uint64_t
+lyplg_type_get_value(const struct lyd_value *val, int *is_signed)
+{
+    switch (val->realtype->basetype) {
+    case LY_TYPE_UINT8:
+        *is_signed = 0;
+        return val->uint8;
+    case LY_TYPE_UINT16:
+        *is_signed = 0;
+        return val->uint16;
+    case LY_TYPE_UINT32:
+        *is_signed = 0;
+        return val->uint32;
+    case LY_TYPE_UINT64:
+        *is_signed = 0;
+        return val->uint64;
+    case LY_TYPE_INT8:
+        *is_signed = 1;
+        return val->int8;
+    case LY_TYPE_INT16:
+        *is_signed = 1;
+        return val->int16;
+    case LY_TYPE_INT32:
+        *is_signed = 1;
+        return val->int32;
+    case LY_TYPE_INT64:
+        *is_signed = 1;
+        return val->int64;
+    default:
+        ly_log(NULL, LY_LLERR, LY_EINVAL, "%s: non-integer type", __func__);
+        return 0;
+    }
+}
+
+static int
+lyplg_type_sort_integers(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    int64_t inum;
+    int is_signed1, is_signed2;
+
+    uint64_t num1 = lyplg_type_get_value(val1, &is_signed1);
+    uint64_t num2 = lyplg_type_get_value(val2, &is_signed2);
+
+    if (is_signed1 != is_signed2) {
+        if (is_signed1) {
+            inum = (int64_t)num1;
+            if (inum < 0) {
+                return -1;
+            }
+            if (num2 > 0x7fffffffffffffffUL) {
+                return -1;
+            }
+            if (inum < (int64_t)num2) {
+                return -1;
+            }
+            if (inum > (int64_t)num2) {
+                return 1;
+            }
+            return 0;
+        }
+        inum = (int64_t)num2;
+        if (inum < 0) {
+            return 1;
+        }
+        if (num1 > 0x7fffffffffffffffUL) {
+            return 1;
+        }
+        if ((int64_t)num1 < inum) {
+            return -1;
+        } else if ((int64_t)num1 > inum) {
+            return 1;
+        }
+        return 0;
+    }
+    if (num1 < num2) {
+        return -1;
+    }
+    if (num1 > num2) {
+        return 1;
+    }
+    return 0;
+}
+
 API const void *
 lyplg_type_print_uint(const struct ly_ctx *UNUSED(ctx), const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *UNUSED(prefix_data), ly_bool *dynamic, size_t *value_len)
@@ -448,6 +531,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_uint,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_uint,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_uint,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -460,6 +544,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_uint,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_uint,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_uint,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -472,6 +557,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_uint,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_uint,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_uint,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -484,6 +570,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_uint,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_uint,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_uint,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -496,6 +583,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_int,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_int,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_int,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -508,6 +596,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_int,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_int,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_int,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -520,6 +609,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_int,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_int,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_int,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple
@@ -532,6 +622,7 @@ const struct lyplg_type_record plugins_integer[] = {
         .plugin.store = lyplg_type_store_int,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_int,
+        .plugin.sort = lyplg_type_sort_integers,
         .plugin.print = lyplg_type_print_int,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple

--- a/src/plugins_types/ipv4_address.c
+++ b/src/plugins_types/ipv4_address.c
@@ -234,6 +234,35 @@ lyplg_type_compare_ipv4_address(const struct lyd_value *val1, const struct lyd_v
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv4-address ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv4_address(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_ipv4_address *v1;
+    const struct lyd_value_ipv4_address *v2;
+    const char *z1, *z2;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    if ((result = memcmp(&v1->addr, &v2->addr, sizeof v1->addr))) {
+        return result;
+    }
+    z1 = v1->zone ? v1->zone : "";
+    z2 = v2->zone ? v2->zone : "";
+    if (v1->zone == v2->zone) {
+        return 0;
+    }
+    return strcmp(z1, z2);
+}
+
+/**
  * @brief Implementation of ::lyplg_type_print_clb for the ipv4-address ietf-inet-types type.
  */
 static const void *
@@ -371,6 +400,7 @@ const struct lyplg_type_record plugins_ipv4_address[] = {
         .plugin.store = lyplg_type_store_ipv4_address,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv4_address,
+        .plugin.sort = lyplg_type_sort_ipv4_address,
         .plugin.print = lyplg_type_print_ipv4_address,
         .plugin.duplicate = lyplg_type_dup_ipv4_address,
         .plugin.free = lyplg_type_free_ipv4_address

--- a/src/plugins_types/ipv4_address_no_zone.c
+++ b/src/plugins_types/ipv4_address_no_zone.c
@@ -151,6 +151,26 @@ lyplg_type_compare_ipv4_address_no_zone(const struct lyd_value *val1, const stru
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv4-address-no-zone ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv4_address_no_zone(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    if (val1->uint32 < val2->uint32) {
+        return -1;
+    } else if (val1->uint32 > val2->uint32) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
  * @brief Implementation of ::lyplg_type_print_clb for the ipv4-address-no-zone ietf-inet-types type.
  */
 static const void *
@@ -216,6 +236,7 @@ const struct lyplg_type_record plugins_ipv4_address_no_zone[] = {
         .plugin.store = lyplg_type_store_ipv4_address_no_zone,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv4_address_no_zone,
+        .plugin.sort = lyplg_type_sort_ipv4_address_no_zone,
         .plugin.print = lyplg_type_print_ipv4_address_no_zone,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple

--- a/src/plugins_types/ipv4_prefix.c
+++ b/src/plugins_types/ipv4_prefix.c
@@ -221,6 +221,35 @@ lyplg_type_compare_ipv4_prefix(const struct lyd_value *val1, const struct lyd_va
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv6-prefix ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv4_prefix(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_ipv4_prefix *v1;
+    const struct lyd_value_ipv4_prefix *v2;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    /* count on host bits being set to zero */
+    if ((result = memcmp(&v1->addr, &v2->addr, sizeof v1->addr))) {
+        return result;
+    }
+    if (v1->prefix < v2->prefix) {
+        return -1;
+    } else if (v1->prefix > v2->prefix) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
  * @brief Implementation of ::lyplg_type_compare_clb for the ietf-inet-types ipv4-prefix type.
  */
 static const void *
@@ -327,6 +356,7 @@ const struct lyplg_type_record plugins_ipv4_prefix[] = {
         .plugin.store = lyplg_type_store_ipv4_prefix,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv4_prefix,
+        .plugin.sort = lyplg_type_sort_ipv4_prefix,
         .plugin.print = lyplg_type_print_ipv4_prefix,
         .plugin.duplicate = lyplg_type_dup_ipv4_prefix,
         .plugin.free = lyplg_type_free_ipv4_prefix

--- a/src/plugins_types/ipv6_address.c
+++ b/src/plugins_types/ipv6_address.c
@@ -236,6 +236,35 @@ lyplg_type_compare_ipv6_address(const struct lyd_value *val1, const struct lyd_v
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv6-address ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv6_address(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_ipv6_address *v1;
+    const struct lyd_value_ipv6_address *v2;
+    const char *z1, *z2;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    if ((result = memcmp(&v1->addr, &v2->addr, sizeof v1->addr))) {
+        return result;
+    }
+    z1 = v1->zone ? v1->zone : "";
+    z2 = v2->zone ? v2->zone : "";
+    if (v1->zone == v2->zone) {
+        return 0;
+    }
+    return strcmp(z1, z2);
+}
+
+/**
  * @brief Implementation of ::lyplg_type_print_clb for the ipv6-address ietf-inet-types type.
  */
 static const void *
@@ -373,6 +402,7 @@ const struct lyplg_type_record plugins_ipv6_address[] = {
         .plugin.store = lyplg_type_store_ipv6_address,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv6_address,
+        .plugin.sort = lyplg_type_sort_ipv6_address,
         .plugin.print = lyplg_type_print_ipv6_address,
         .plugin.duplicate = lyplg_type_dup_ipv6_address,
         .plugin.free = lyplg_type_free_ipv6_address

--- a/src/plugins_types/ipv6_address_no_zone.c
+++ b/src/plugins_types/ipv6_address_no_zone.c
@@ -199,6 +199,26 @@ lyplg_type_compare_ipv6_address_no_zone(const struct lyd_value *val1, const stru
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv6-address-no-zone ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv6_address_no_zone(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_ipv6_address_no_zone *v1;
+    const struct lyd_value_ipv6_address_no_zone *v2;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    return memcmp(&v1->addr, &v2->addr, sizeof v1->addr);
+}
+
+/**
  * @brief Implementation of ::lyplg_type_print_clb for the ipv6-address-no-zone ietf-inet-types type.
  */
 static const void *
@@ -303,6 +323,7 @@ const struct lyplg_type_record plugins_ipv6_address_no_zone[] = {
         .plugin.store = lyplg_type_store_ipv6_address_no_zone,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv6_address_no_zone,
+        .plugin.sort = lyplg_type_sort_ipv6_address_no_zone,
         .plugin.print = lyplg_type_print_ipv6_address_no_zone,
         .plugin.duplicate = lyplg_type_dup_ipv6_address_no_zone,
         .plugin.free = lyplg_type_free_ipv6_address_no_zone

--- a/src/plugins_types/ipv6_prefix.c
+++ b/src/plugins_types/ipv6_prefix.c
@@ -233,6 +233,35 @@ lyplg_type_compare_ipv6_prefix(const struct lyd_value *val1, const struct lyd_va
 }
 
 /**
+ * @brief Implementation of ::lyplg_type_sort_clb for the ipv6-prefix ietf-inet-types type.
+ */
+static int
+lyplg_type_sort_ipv6_prefix(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    const struct lyd_value_ipv6_prefix *v1;
+    const struct lyd_value_ipv6_prefix *v2;
+    int result;
+
+    if (lyplg_type_initial_sort(&val1, &val2, &result) == LY_SUCCESS) {
+        return result;
+    }
+
+    LYD_VALUE_GET(val1, v1);
+    LYD_VALUE_GET(val2, v2);
+
+    /* count on host bits being set to zero */
+    if ((result = memcmp(&v1->addr, &v2->addr, sizeof v1->addr))) {
+        return result;
+    }
+    if (v1->prefix < v2->prefix) {
+        return -1;
+    } else if (v1->prefix > v2->prefix) {
+        return 1;
+    }
+    return 0;
+}
+
+/**
  * @brief Implementation of ::lyplg_type_compare_clb for the ietf-inet-types ipv6-prefix type.
  */
 static const void *
@@ -339,6 +368,7 @@ const struct lyplg_type_record plugins_ipv6_prefix[] = {
         .plugin.store = lyplg_type_store_ipv6_prefix,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_ipv6_prefix,
+        .plugin.sort = lyplg_type_sort_ipv6_prefix,
         .plugin.print = lyplg_type_print_ipv6_prefix,
         .plugin.duplicate = lyplg_type_dup_ipv6_prefix,
         .plugin.free = lyplg_type_free_ipv6_prefix

--- a/src/plugins_types/leafref.c
+++ b/src/plugins_types/leafref.c
@@ -93,6 +93,12 @@ lyplg_type_compare_leafref(const struct lyd_value *val1, const struct lyd_value 
     return val1->realtype->plugin->compare(val1, val2);
 }
 
+API int
+lyplg_type_sort_leafref(const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    return val1->realtype->plugin->sort(val1, val2);
+}
+
 API const void *
 lyplg_type_print_leafref(const struct ly_ctx *ctx, const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *prefix_data, ly_bool *dynamic, size_t *value_len)
@@ -129,6 +135,7 @@ const struct lyplg_type_record plugins_leafref[] = {
         .plugin.store = lyplg_type_store_leafref,
         .plugin.validate = lyplg_type_validate_leafref,
         .plugin.compare = lyplg_type_compare_leafref,
+        .plugin.sort = lyplg_type_sort_leafref,
         .plugin.print = lyplg_type_print_leafref,
         .plugin.duplicate = lyplg_type_dup_leafref,
         .plugin.free = lyplg_type_free_leafref

--- a/src/plugins_types/string.c
+++ b/src/plugins_types/string.c
@@ -100,6 +100,7 @@ const struct lyplg_type_record plugins_string[] = {
         .plugin.store = lyplg_type_store_string,
         .plugin.validate = NULL,
         .plugin.compare = lyplg_type_compare_simple,
+        .plugin.sort = lyplg_type_sort_simple,
         .plugin.print = lyplg_type_print_simple,
         .plugin.duplicate = lyplg_type_dup_simple,
         .plugin.free = lyplg_type_free_simple


### PR DESCRIPTION
Add a traditional cmp compare (i.e., sorting) to plugin interface. Eventually libyang may wish to sort (e.g., leaf-lists or keyless lists); however, more importantly, users may wish to know *how* a value is not equal (is it less or more)..