### PR TITLE
plugins types REFACTOR front-ends allow for more functionality

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -1435,7 +1435,7 @@ lyd_diff_merge_create(struct lyd_node *diff_match, enum lyd_diff_op cur_op, cons
                 sleaf = (struct lysc_node_leaf *)diff_match->schema;
             }
 
-            if (sleaf && sleaf->dflt && !sleaf->dflt->realtype->plugin->compare(sleaf->dflt,
+            if (sleaf && sleaf->dflt && !lyplg_type_compare(sleaf->dflt->realtype, sleaf->dflt,
                     &((struct lyd_node_term *)src_diff)->value)) {
                 /* we deleted it, so a default value was in-use, and it matches the created value -> operation NONE */
                 LY_CHECK_RET(lyd_diff_change_op(diff_match, LYD_DIFF_OP_NONE));

--- a/src/path.c
+++ b/src/path.c
@@ -1067,7 +1067,7 @@ ly_path_dup(const struct ly_ctx *ctx, const struct ly_path *path, struct ly_path
                 case LY_PATH_PREDTYPE_LEAFLIST:
                     /* key-predicate or leaf-list-predicate */
                     (*dup)[u].predicates[v].key = pred->key;
-                    pred->value.realtype->plugin->duplicate(ctx, &pred->value, &(*dup)[u].predicates[v].value);
+                    lyplg_type_duplicate(pred->value.realtype, ctx, &pred->value, &(*dup)[u].predicates[v].value);
                     ++((struct lysc_type *)pred->value.realtype)->refcount;
                     break;
                 case LY_PATH_PREDTYPE_NONE:
@@ -1098,7 +1098,7 @@ ly_path_predicates_free(const struct ly_ctx *ctx, enum ly_path_pred_type pred_ty
         case LY_PATH_PREDTYPE_LIST:
         case LY_PATH_PREDTYPE_LEAFLIST:
             if (predicates[u].value.realtype) {
-                predicates[u].value.realtype->plugin->free(ctx, &predicates[u].value);
+                lyplg_type_free(predicates[u].value.realtype, ctx, &predicates[u].value);
                 lysc_type_free((struct ly_ctx *)ctx, (struct lysc_type *)predicates[u].value.realtype);
             }
             break;

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -791,7 +791,7 @@ lyplg_type_resolve_leafref(const struct lysc_type_leafref *lref, const struct ly
             &set, 0);
     if (ret) {
         ret = LY_ENOTFOUND;
-        val_str = lref->plugin->print(lref->cur_mod->ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
+        val_str = lyplg_type_print((const struct lysc_type *)lref, lref->cur_mod->ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
         if (asprintf(errmsg, "Invalid leafref value \"%s\" - XPath evaluation error.", val_str) == -1) {
             *errmsg = NULL;
             ret = LY_EMEM;
@@ -805,13 +805,13 @@ lyplg_type_resolve_leafref(const struct lysc_type_leafref *lref, const struct ly
             continue;
         }
 
-        if (!lref->plugin->compare(&((struct lyd_node_term *)set.val.nodes[i].node)->value, value)) {
+        if (!lyplg_type_compare((const struct lysc_type *)lref, &((struct lyd_node_term *)set.val.nodes[i].node)->value, value)) {
             break;
         }
     }
     if (i == set.used) {
         ret = LY_ENOTFOUND;
-        val_str = lref->plugin->print(lref->cur_mod->ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
+        val_str = lyplg_type_print((const struct lysc_type *)lref, lref->cur_mod->ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
         if (set.used) {
             rc = asprintf(errmsg, LY_ERRMSG_NOLREF_VAL, val_str, lref->path->expr);
         } else {

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -23,6 +23,7 @@
 #include "tree.h"
 
 #include "tree_edit.h"
+#include "tree_schema.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -515,6 +516,69 @@ struct lyplg_type_record {
     /* runtime data */
     struct lyplg_type plugin; /**< data to utilize plugin implementation */
 };
+
+/**
+ * @defgroup pluginsTypesFunctionality Plugins: Front-end access to plugin callbacks
+ * @ingroup pluginsTypes
+ * @{
+ *
+ * Use these functions to get at the plugin functionality, do not call the plugin callbacks directly.
+ */
+
+static inline LY_ERR
+lyplg_type_store(const struct lysc_type *rt, const struct ly_ctx *ctx, const struct lysc_type *type, const void *value,
+        size_t value_len, uint32_t options, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints,
+        const struct lysc_node *ctx_node, struct lyd_value *storage, struct lys_glob_unres *unres, struct ly_err_item **err)
+{
+    return rt->plugin->store(ctx, type, value, value_len, options, format, prefix_data, hints, ctx_node, storage, unres, err);
+}
+
+static inline LY_ERR
+lyplg_type_validate(const struct lysc_type *rt, const struct ly_ctx *ctx, const struct lysc_type *type,
+        const struct lyd_node *ctx_node, const struct lyd_node *tree, struct lyd_value *storage, struct ly_err_item **err)
+{
+    return rt->plugin->validate(ctx, type, ctx_node, tree, storage, err);
+}
+
+static inline LY_ERR
+lyplg_type_compare(const struct lysc_type *rt, const struct lyd_value *val1, const struct lyd_value *val2)
+{
+    return rt->plugin->compare(val1, val2);
+}
+
+static inline const void *
+lyplg_type_print(const struct lysc_type *rt, const struct ly_ctx *ctx, const struct lyd_value *value,
+        LY_VALUE_FORMAT format, void *prefix_data, ly_bool *dynamic, size_t *value_len)
+{
+    return rt->plugin->print(ctx, value, format, prefix_data, dynamic, value_len);
+}
+
+static inline const void *
+lyplg_type_hash(const struct lysc_type *rt, const struct lyd_value *value, ly_bool *dynamic, size_t *key_len)
+{
+#if 0
+    if (rt->plugin->hash) {
+        return rt->plugin->hash(value, dynamic, key_len);
+    }
+#endif
+    return rt->plugin->print(NULL, value, LY_VALUE_LYB, NULL, dynamic, key_len);
+}
+
+static inline LY_ERR
+lyplg_type_duplicate(const struct lysc_type *rt, const struct ly_ctx *ctx, const struct lyd_value *original, struct lyd_value *dup)
+{
+    return rt->plugin->duplicate(ctx, original, dup);
+}
+
+static inline void
+lyplg_type_free(const struct lysc_type *rt, const struct ly_ctx *ctx, struct lyd_value *value)
+{
+    if (rt->plugin->free) {
+        return rt->plugin->free(ctx, value);
+    }
+}
+
+/** @} pluginsTypesFunctionality */
 
 /**
  * @defgroup pluginsTypesSimple Plugins: Simple Types Callbacks

--- a/src/plugins_types/instanceid.c
+++ b/src/plugins_types/instanceid.c
@@ -95,7 +95,7 @@ instanceid_path2str(const struct ly_path *path, LY_VALUE_FORMAT format, void *pr
                 break;
             case LY_PATH_PREDTYPE_LIST:
                 /* key-predicate */
-                strval = pred->value.realtype->plugin->print(path[u].node->module->ctx, &pred->value, format, prefix_data,
+                strval = lyplg_type_print(pred->value.realtype, path[u].node->module->ctx, &pred->value, format, prefix_data,
                         &d, NULL);
 
                 /* default quote */
@@ -116,7 +116,7 @@ instanceid_path2str(const struct ly_path *path, LY_VALUE_FORMAT format, void *pr
                 break;
             case LY_PATH_PREDTYPE_LEAFLIST:
                 /* leaf-list-predicate */
-                strval = pred->value.realtype->plugin->print(path[u].node->module->ctx, &pred->value, format, prefix_data,
+                strval = lyplg_type_print(pred->value.realtype, path[u].node->module->ctx, &pred->value, format, prefix_data,
                         &d, NULL);
 
                 /* default quote */
@@ -270,13 +270,13 @@ lyplg_type_compare_instanceid(const struct lyd_value *val1, const struct lyd_val
                 case LY_PATH_PREDTYPE_LIST:
                     /* key-predicate */
                     if ((pred1->key != pred2->key) ||
-                            ((struct lysc_node_leaf *)pred1->key)->type->plugin->compare(&pred1->value, &pred2->value)) {
+                            lyplg_type_compare(((struct lysc_node_leaf *)pred1->key)->type, &pred1->value, &pred2->value)) {
                         return LY_ENOT;
                     }
                     break;
                 case LY_PATH_PREDTYPE_LEAFLIST:
                     /* leaf-list predicate */
-                    if (((struct lysc_node_leaflist *)s1->node)->type->plugin->compare(&pred1->value, &pred2->value)) {
+                    if (lyplg_type_compare(((struct lysc_node_leaflist *)s1->node)->type, &pred1->value, &pred2->value)) {
                         return LY_ENOT;
                     }
                 }

--- a/src/plugins_types/leafref.c
+++ b/src/plugins_types/leafref.c
@@ -46,7 +46,7 @@ lyplg_type_store_leafref(const struct ly_ctx *ctx, const struct lysc_type *type,
     assert(type_lr->realtype);
 
     /* store the value as the real type of the leafref target */
-    ret = type_lr->realtype->plugin->store(ctx, type_lr->realtype, value, value_len, options, format, prefix_data,
+    ret = lyplg_type_store(type_lr->realtype, ctx, type_lr->realtype, value, value_len, options, format, prefix_data,
             hints, ctx_node, storage, unres, err);
     if (ret == LY_EINCOMPLETE) {
         /* it is irrelevant whether the target type needs some resolving */
@@ -90,26 +90,26 @@ lyplg_type_validate_leafref(const struct ly_ctx *UNUSED(ctx), const struct lysc_
 API LY_ERR
 lyplg_type_compare_leafref(const struct lyd_value *val1, const struct lyd_value *val2)
 {
-    return val1->realtype->plugin->compare(val1, val2);
+    return lyplg_type_compare(val1->realtype, val1, val2);
 }
 
 API const void *
 lyplg_type_print_leafref(const struct ly_ctx *ctx, const struct lyd_value *value, LY_VALUE_FORMAT format,
         void *prefix_data, ly_bool *dynamic, size_t *value_len)
 {
-    return value->realtype->plugin->print(ctx, value, format, prefix_data, dynamic, value_len);
+    return lyplg_type_print(value->realtype, ctx, value, format, prefix_data, dynamic, value_len);
 }
 
 API LY_ERR
 lyplg_type_dup_leafref(const struct ly_ctx *ctx, const struct lyd_value *original, struct lyd_value *dup)
 {
-    return original->realtype->plugin->duplicate(ctx, original, dup);
+    return lyplg_type_duplicate(original->realtype, ctx, original, dup);
 }
 
 API void
 lyplg_type_free_leafref(const struct ly_ctx *ctx, struct lyd_value *value)
 {
-    value->realtype->plugin->free(ctx, value);
+    lyplg_type_free(value->realtype, ctx, value);
 }
 
 /**

--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -333,7 +333,7 @@ static LY_ERR
 json_print_value(struct jsonpr_ctx *ctx, const struct lyd_value *val)
 {
     ly_bool dynamic = 0;
-    const char *value = val->realtype->plugin->print(ctx->ctx, val, LY_VALUE_JSON, NULL, &dynamic, NULL);
+    const char *value = lyplg_type_print(val->realtype, ctx->ctx, val, LY_VALUE_JSON, NULL, &dynamic, NULL);
 
     /* leafref is not supported */
     switch (val->realtype->basetype) {

--- a/src/printer_xml.c
+++ b/src/printer_xml.c
@@ -196,7 +196,7 @@ xml_print_meta(struct xmlpr_ctx *ctx, const struct lyd_node *node)
     }
 #endif
     for (meta = node->meta; meta; meta = meta->next) {
-        const char *value = meta->value.realtype->plugin->print(LYD_CTX(node), &meta->value, LY_VALUE_XML, &ns_list,
+        const char *value = lyplg_type_print(meta->value.realtype, LYD_CTX(node), &meta->value, LY_VALUE_XML, &ns_list,
                 &dynamic, NULL);
 
         /* print namespaces connected with the value's prefixes */
@@ -324,7 +324,7 @@ xml_print_term(struct xmlpr_ctx *ctx, const struct lyd_node_term *node)
     const char *value;
 
     xml_print_node_open(ctx, &node->node);
-    value = ((struct lysc_node_leaf *)node->schema)->type->plugin->print(LYD_CTX(node), &node->value, LY_VALUE_XML,
+    value = lyplg_type_print(((struct lysc_node_leaf *)node->schema)->type, LYD_CTX(node), &node->value, LY_VALUE_XML,
             &ns_list, &dynamic, NULL);
 
     /* print namespaces connected with the values's prefixes */

--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -830,7 +830,7 @@ yprc_dflt_value(struct lys_ypr_ctx *ctx, const struct ly_ctx *ly_ctx, const stru
     ly_bool dynamic;
     const char *str;
 
-    str = value->realtype->plugin->print(ly_ctx, value, LY_VALUE_JSON, NULL, &dynamic, NULL);
+    str = lyplg_type_print(value->realtype, ly_ctx, value, LY_VALUE_JSON, NULL, &dynamic, NULL);
     ypr_substmt(ctx, LY_STMT_DEFAULT, 0, str, exts);
     if (dynamic) {
         free((void *)str);

--- a/src/schema_compile.c
+++ b/src/schema_compile.c
@@ -1075,7 +1075,7 @@ lys_compile_unres_dflt(struct lysc_ctx *ctx, struct lysc_node *node, struct lysc
     struct ly_err_item *err = NULL;
 
     options = (ctx->ctx->flags & LY_CTX_REF_IMPLEMENTED) ? LYPLG_TYPE_STORE_IMPLEMENT : 0;
-    ret = type->plugin->store(ctx->ctx, type, dflt, strlen(dflt), options, LY_VALUE_SCHEMA, (void *)dflt_pmod,
+    ret = lyplg_type_store(type, ctx->ctx, type, dflt, strlen(dflt), options, LY_VALUE_SCHEMA, (void *)dflt_pmod,
             LYD_HINT_SCHEMA, node, storage, unres, &err);
     if (ret == LY_ERECOMPILE) {
         /* fine, but we need to recompile */
@@ -1184,10 +1184,10 @@ lys_compile_unres_llist_dflts(struct lysc_ctx *ctx, struct lysc_node_leaflist *l
         /* configuration data values must be unique - so check the default values */
         for (u = orig_count; u < LY_ARRAY_COUNT(llist->dflts); ++u) {
             for (v = 0; v < u; ++v) {
-                if (!llist->dflts[u]->realtype->plugin->compare(llist->dflts[u], llist->dflts[v])) {
+                if (!lyplg_type_compare(llist->dflts[u]->realtype, llist->dflts[u], llist->dflts[v])) {
                     lysc_update_path(ctx, llist->parent ? llist->parent->module : NULL, llist->name);
                     LOGVAL(ctx->ctx, LYVE_SEMANTICS, "Configuration leaf-list has multiple defaults of the same value \"%s\".",
-                            llist->dflts[u]->realtype->plugin->print(ctx->ctx, llist->dflts[u], LY_VALUE_CANON, NULL, NULL, NULL));
+                            lyplg_type_print(llist->dflts[u]->realtype, ctx->ctx, llist->dflts[u], LY_VALUE_CANON, NULL, NULL, NULL));
                     lysc_update_path(ctx, NULL, NULL);
                     return LY_EVALID;
                 }

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -3143,7 +3143,7 @@ lys_compile_node_list(struct lysc_ctx *ctx, struct lysp_node *pnode, struct lysc
 
         /* ignore default values of the key */
         if (key->dflt) {
-            key->dflt->realtype->plugin->free(ctx->ctx, key->dflt);
+            lyplg_type_free(key->dflt->realtype, ctx->ctx, key->dflt);
             lysc_type_free(ctx->ctx, (struct lysc_type *)key->dflt->realtype);
             free(key->dflt);
             key->dflt = NULL;

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -62,7 +62,7 @@ lyd_free_meta(struct lyd_meta *meta, ly_bool siblings)
         iter = iter->next;
 
         lydict_remove(meta->annotation->module->ctx, meta->name);
-        meta->value.realtype->plugin->free(meta->annotation->module->ctx, &meta->value);
+        lyplg_type_free(meta->value.realtype, meta->annotation->module->ctx, &meta->value);
         free(meta);
     }
 }
@@ -176,7 +176,7 @@ lyd_free_subtree(struct lyd_node *node, ly_bool top)
         /* only frees the value this way */
         lyd_any_copy_value(node, NULL, 0);
     } else if (node->schema->nodetype & LYD_NODE_TERM) {
-        ((struct lysc_node_leaf *)node->schema)->type->plugin->free(LYD_CTX(node), &((struct lyd_node_term *)node)->value);
+        lyplg_type_free(((struct lysc_node_leaf *)node->schema)->type, LYD_CTX(node), &((struct lyd_node_term *)node)->value);
     }
 
     if (!node->schema) {

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -53,7 +53,7 @@ lyd_hash(struct lyd_node *node)
             for (iter = list->child; iter && (iter->schema->flags & LYS_KEY); iter = iter->next) {
                 struct lyd_node_term *key = (struct lyd_node_term *)iter;
 
-                hash_key = key->value.realtype->plugin->print(NULL, &key->value, LY_VALUE_LYB, NULL, &dyn, &key_len);
+                hash_key = lyplg_type_hash(key->value.realtype, &key->value, &dyn, &key_len);
                 node->hash = dict_hash_multi(node->hash, hash_key, key_len);
                 if (dyn) {
                     free((void *)hash_key);
@@ -64,7 +64,7 @@ lyd_hash(struct lyd_node *node)
         /* leaf-list adds its hash key */
         struct lyd_node_term *llist = (struct lyd_node_term *)node;
 
-        hash_key = llist->value.realtype->plugin->print(NULL, &llist->value, LY_VALUE_LYB, NULL, &dyn, &key_len);
+        hash_key = lyplg_type_hash(llist->value.realtype, &llist->value, &dyn, &key_len);
         node->hash = dict_hash_multi(node->hash, hash_key, key_len);
         if (dyn) {
             free((void *)hash_key);

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -262,7 +262,7 @@ lyd_value_get_canonical(const struct ly_ctx *ctx, const struct lyd_value *value)
     LY_CHECK_ARG_RET(ctx, ctx, value, NULL);
 
     return value->_canonical ? value->_canonical :
-           (const char *)value->realtype->plugin->print(ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
+           (const char *)lyplg_type_print(value->realtype, ctx, value, LY_VALUE_CANON, NULL, NULL, NULL);
 }
 
 API LY_ERR

--- a/src/tree_schema_free.c
+++ b/src/tree_schema_free.c
@@ -731,7 +731,7 @@ lysc_node_leaf_free(struct ly_ctx *ctx, struct lysc_node_leaf *node)
     }
     lydict_remove(ctx, node->units);
     if (node->dflt) {
-        node->dflt->realtype->plugin->free(ctx, node->dflt);
+        lyplg_type_free(node->dflt->realtype, ctx, node->dflt);
         lysc_type_free(ctx, (struct lysc_type *)node->dflt->realtype);
         free(node->dflt);
     }
@@ -749,7 +749,7 @@ lysc_node_leaflist_free(struct ly_ctx *ctx, struct lysc_node_leaflist *node)
     }
     lydict_remove(ctx, node->units);
     LY_ARRAY_FOR(node->dflts, u) {
-        node->dflts[u]->realtype->plugin->free(ctx, node->dflts[u]);
+        lyplg_type_free(node->dflts[u]->realtype, ctx, node->dflts[u]);
         lysc_type_free(ctx, (struct lysc_type *)node->dflts[u]->realtype);
         free(node->dflts[u]);
     }

--- a/src/validation.c
+++ b/src/validation.c
@@ -972,7 +972,7 @@ uniquecheck:
                 val2 = slist->uniques[u][v]->dflt;
             }
 
-            if (!val1 || !val2 || val1->realtype->plugin->compare(val1, val2)) {
+            if (!val1 || !val2 || lyplg_type_compare(val1->realtype, val1, val2)) {
                 /* values differ or either one is not set */
                 break;
             }
@@ -1106,7 +1106,7 @@ lyd_validate_unique(const struct lyd_node *first, const struct lysc_node *snode,
                     }
 
                     /* get hash key */
-                    hash_key = val->realtype->plugin->print(NULL, val, LY_VALUE_LYB, NULL, &dyn, &key_len);
+                    hash_key = lyplg_type_hash(val->realtype, val, &dyn, &key_len);
                     hash = dict_hash_multi(hash, hash_key, key_len);
                     if (dyn) {
                         free((void *)hash_key);

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -1573,7 +1573,7 @@ set_comp_canonize(struct lyxp_set *trg, const struct lyxp_set *src, const struct
     }
 
     /* ignore errors, the value may not satisfy schema constraints */
-    rc = type->plugin->store(src->ctx, type, str, strlen(str), LYPLG_TYPE_STORE_DYNAMIC, src->format, src->prefix_data,
+    rc = lyplg_type_store(type, src->ctx, type, str, strlen(str), LYPLG_TYPE_STORE_DYNAMIC, src->format, src->prefix_data,
             LYD_HINT_DATA, xp_node->node->schema, &val, NULL, &err);
     ly_err_free(err);
     if (rc) {
@@ -1586,12 +1586,12 @@ set_comp_canonize(struct lyxp_set *trg, const struct lyxp_set *src, const struct
     set_init(trg, src);
     trg->type = src->type;
     if (src->type == LYXP_SET_NUMBER) {
-        trg->val.num = strtold(type->plugin->print(src->ctx, &val, LY_VALUE_CANON, NULL, NULL, NULL), &ptr);
+        trg->val.num = strtold(lyplg_type_print(type, src->ctx, &val, LY_VALUE_CANON, NULL, NULL, NULL), &ptr);
         LY_CHECK_ERR_RET(ptr[0], LOGINT(src->ctx), LY_EINT);
     } else {
-        trg->val.str = strdup(type->plugin->print(src->ctx, &val, LY_VALUE_CANON, NULL, NULL, NULL));
+        trg->val.str = strdup(lyplg_type_print(type, src->ctx, &val, LY_VALUE_CANON, NULL, NULL, NULL));
     }
-    type->plugin->free(src->ctx, &val);
+    lyplg_type_free(type, src->ctx, &val);
     return LY_SUCCESS;
 
 fill:
@@ -3348,7 +3348,7 @@ warn_equality_value(const struct lyxp_expr *exp, struct lyxp_set *set, uint16_t 
 
         type = ((struct lysc_node_leaf *)scnode)->type;
         if (type->basetype != LY_TYPE_IDENT) {
-            rc = type->plugin->store(set->ctx, type, value, strlen(value), 0, set->format, set->prefix_data,
+            rc = lyplg_type_store(type, set->ctx, type, value, strlen(value), 0, set->format, set->prefix_data,
                     LYD_HINT_DATA, scnode, &storage, NULL, &err);
             if (rc == LY_EINCOMPLETE) {
                 rc = LY_SUCCESS;
@@ -3365,7 +3365,7 @@ warn_equality_value(const struct lyxp_expr *exp, struct lyxp_set *set, uint16_t 
                         (exp->tok_pos[last_equal_exp] - exp->tok_pos[equal_exp]) + exp->tok_len[last_equal_exp],
                         exp->expr + exp->tok_pos[equal_exp]);
             } else {
-                type->plugin->free(set->ctx, &storage);
+                lyplg_type_free(type, set->ctx, &storage);
             }
         }
         free(value);


### PR DESCRIPTION
Many advantages to using front-ends for accessing plugin callbacks,
including allowing for optional callback functionality, future expansion of
plugin types, default implementations, etc..