### PR TITLE
json BUGFIX parsing number with E0

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -412,6 +412,15 @@ invalid_character:
             return LY_EVALID;
         }
 
+        if (!e_val) {
+            /* exponent is zero, so just cut the part with the exponent */
+            num_len = exponent;
+            LY_CHECK_RET(lyjson_get_buffer_for_number(jsonctx, num_len, &num));
+            memcpy(num, in, num_len);
+            num[num_len] = '\0';
+            goto store_exp_number;
+        }
+
         dec_point = ly_strnchr(in, '.', exponent);
         if (!dec_point) {
             /* value is integer, we are just ... */
@@ -492,6 +501,7 @@ invalid_character:
         /* terminating NULL byte */
         num[i] = '\0';
 
+store_exp_number:
         /* store the modified number */
         lyjson_ctx_set_value(jsonctx, num, num_len, 1);
     } else {

--- a/tests/utests/basic/test_json.c
+++ b/tests/utests/basic/test_json.c
@@ -104,6 +104,15 @@ test_number(void **state)
     assert_int_equal(0, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 
+    str = "-0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("-0", jsonctx->value);
+    assert_int_equal(2, jsonctx->value_len);
+    assert_int_equal(0, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
     /* exp number */
     str = "1E10";
     assert_non_null(ly_in_memory(in, str));
@@ -136,6 +145,24 @@ test_number(void **state)
     assert_non_null(ly_in_memory(in, str));
     assert_int_equal(LY_EVALID, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
 
+    str = "0E0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("0", jsonctx->value);
+    assert_int_equal(1, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
+    str = "0E-0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("0", jsonctx->value);
+    assert_int_equal(1, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
     /* exp fraction number */
     str = "1.1e3";
     assert_non_null(ly_in_memory(in, str));
@@ -152,6 +179,15 @@ test_number(void **state)
     assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
     assert_string_equal("12100", jsonctx->value);
     assert_int_equal(5, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
+    str = "0.0e0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("0.0", jsonctx->value);
+    assert_int_equal(3, jsonctx->value_len);
     assert_int_equal(1, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 
@@ -183,6 +219,15 @@ test_number(void **state)
     assert_int_equal(1, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 
+    str = "0.0e-0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("0.0", jsonctx->value);
+    assert_int_equal(3, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
     /* exp negative fraction number */
     str = "-0.11e3";
     assert_non_null(ly_in_memory(in, str));
@@ -199,6 +244,15 @@ test_number(void **state)
     assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
     assert_string_equal("-44110", jsonctx->value);
     assert_int_equal(6, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
+    str = "-0.0e0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("-0.0", jsonctx->value);
+    assert_int_equal(4, jsonctx->value_len);
     assert_int_equal(1, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 
@@ -227,6 +281,15 @@ test_number(void **state)
     assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
     assert_string_equal("-0.987", jsonctx->value);
     assert_int_equal(6, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
+    str = "-0.0e-0";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("-0.0", jsonctx->value);
+    assert_int_equal(4, jsonctx->value_len);
     assert_int_equal(1, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 


### PR DESCRIPTION
This PR fixes issue 32351 from oss-fuzz.