### PR TITLE
schema helpers BUGFIX added isprint protection

### DIFF
--- a/src/tree_schema_helpers.c
+++ b/src/tree_schema_helpers.c
@@ -843,7 +843,7 @@ lysp_check_identifierchar(struct lys_parser_ctx *ctx, uint32_t c, ly_bool first,
 {
     if (first || (prefix && ((*prefix) == 1))) {
         if (!is_yangidentstartchar(c)) {
-            if (isprint(c)) {
+            if ((c < UCHAR_MAX) && isprint(c)) {
                 LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier first character '%c' (0x%04x).", (char)c, c);
             } else {
                 LOGVAL_PARSER(ctx, LYVE_SYNTAX_YANG, "Invalid identifier first character 0x%04x.", c);

--- a/tests/fuzz/corpus/lys_parse_mem/pull1568.yang
+++ b/tests/fuzz/corpus/lys_parse_mem/pull1568.yang
@@ -1,0 +1,4 @@
+module
+f{grouping
+s{list
+󠀡ym{


### PR DESCRIPTION
This PR fixes issue 32530 from oss-fuzz.