### PR TITLE
distro BUGFIX remove unnecessary build dependencies

### DIFF
--- a/distro/pkg/deb/control
+++ b/distro/pkg/deb/control
@@ -6,7 +6,6 @@ Priority: optional
 Standards-Version: 4.5.0
 Build-Depends: cmake,
                debhelper (>= 10),
-               libcmocka-dev <!nocheck>,
                libpcre2-dev,
                pkg-config
 Vcs-Browser: https://github.com/CESNET/libyang/tree/libyang2

--- a/distro/pkg/rpm/libyang2.spec
+++ b/distro/pkg/rpm/libyang2.spec
@@ -7,9 +7,7 @@ Source: libyang-%{version}.tar.gz
 License: BSD-3-Clause
 
 BuildRequires:  cmake
-BuildRequires:  doxygen
 BuildRequires:  gcc
-BuildRequires:  libcmocka-devel
 BuildRequires:  make
 BuildRequires:  pcre2-devel
 


### PR DESCRIPTION
Tests and docs are not built by default in Release build mode so doxygen
and cmocka are not needed.

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>