### PR TITLE
cmake BUGFIX do not error out on custom CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,7 @@ elseif ("${BUILD_TYPE_UPPER}" STREQUAL "ABICHECK")
   set(CMAKE_BUILD_TYPE "ABICheck" CACHE STRING "Build Type" FORCE)
 elseif ("${BUILD_TYPE_UPPER}" STREQUAL "DOCONLY")
   set(CMAKE_BUILD_TYPE "DocOnly" CACHE STRING "Build Type" FORCE)
-else ()
-  message(FATAL_ERROR "Unknown CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\".")
-endif ()
+endif()
 
 # check the supported platform
 if(NOT UNIX)


### PR DESCRIPTION
* Discovered while trying to package version 2.0.0 on Gentoo Linux, where we use `CMAKE_BUILD_TYPE=Gentoo`, so don't error out on `CMAKE_BUILD_TYPE` different than the ones specified in `CMakeLists.txt`