### PR TITLE
build CHANGE separated build type for building docs without dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 include(GNUInstallDirs)
 include(CheckSymbolExists)
 include(UseCompat)
+include(Doc)
 
 set(LIBYANG_DESCRIPTION "libyang is YANG data modelling language parser and toolkit written (and providing API) in C.")
 
@@ -37,6 +38,59 @@ set(LIBYANG_MICRO_SOVERSION 28)
 set(LIBYANG_SOVERSION_FULL ${LIBYANG_MAJOR_SOVERSION}.${LIBYANG_MINOR_SOVERSION}.${LIBYANG_MICRO_SOVERSION})
 set(LIBYANG_SOVERSION ${LIBYANG_MAJOR_SOVERSION})
 
+set(libsrc
+    src/common.c
+    src/context.c
+    src/log.c
+    src/hash_table.c
+    src/resolve.c
+    src/validation.c
+    src/xml.c
+    src/parser.c
+    src/parser_yin.c
+    src/parser_xml.c
+    src/parser_json.c
+    src/parser_lyb.c
+    src/parser_yang_bis.c
+    src/parser_yang_lex.c
+    src/parser_yang.c
+    src/tree_schema.c
+    src/tree_data.c
+    src/plugins.c
+    src/printer.c
+    src/xpath.c
+    src/printer_yang.c
+    src/printer_yin.c
+    src/printer_json_schema.c
+    src/printer_xml.c
+    src/printer_tree.c
+    src/printer_info.c
+    src/printer_json.c
+    src/printer_lyb.c
+    src/yang_types.c)
+
+set(lintsrc
+    tools/lint/main.c
+    tools/lint/main_ni.c
+    tools/lint/commands.c
+    tools/lint/completion.c
+    tools/lint/configuration.c
+    linenoise/linenoise.c)
+
+set(resrc
+    tools/re/main.c)
+
+set(yang2yinsrc
+    tools/yang2yin/main.c)
+
+set(headers
+    src/tree_schema.h
+    src/tree_data.h
+    src/extensions.h
+    src/user_types.h
+    src/xml.h
+    src/dict.h)
+
 # check the supported platform
 if(NOT UNIX)
     message(FATAL_ERROR "Only *nix like systems are supported.")
@@ -45,6 +99,11 @@ endif()
 # set default build type if not specified by user
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE debug)
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL DocOnly)
+    libyang_doc()
+    return()
 endif()
 
 set(CMAKE_C_FLAGS         "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99 -fno-strict-aliasing")
@@ -138,59 +197,6 @@ endif()
 # static build requires static libpcre library
 option(ENABLE_STATIC "Build static (.a) library" OFF)
 
-set(libsrc
-    src/common.c
-    src/context.c
-    src/log.c
-    src/hash_table.c
-    src/resolve.c
-    src/validation.c
-    src/xml.c
-    src/parser.c
-    src/parser_yin.c
-    src/parser_xml.c
-    src/parser_json.c
-    src/parser_lyb.c
-    src/parser_yang_bis.c
-    src/parser_yang_lex.c
-    src/parser_yang.c
-    src/tree_schema.c
-    src/tree_data.c
-    src/plugins.c
-    src/printer.c
-    src/xpath.c
-    src/printer_yang.c
-    src/printer_yin.c
-    src/printer_json_schema.c
-    src/printer_xml.c
-    src/printer_tree.c
-    src/printer_info.c
-    src/printer_json.c
-    src/printer_lyb.c
-    src/yang_types.c)
-
-set(lintsrc
-    tools/lint/main.c
-    tools/lint/main_ni.c
-    tools/lint/commands.c
-    tools/lint/completion.c
-    tools/lint/configuration.c
-    linenoise/linenoise.c)
-
-set(resrc
-    tools/re/main.c)
-
-set(yang2yinsrc
-    tools/yang2yin/main.c)
-
-set(headers
-    src/tree_schema.h
-    src/tree_data.h
-    src/extensions.h
-    src/user_types.h
-    src/xml.h
-    src/dict.h)
-
 # link compat
 use_compat()
 
@@ -265,20 +271,7 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 # generate doxygen documentation for libyang API
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-    find_program(DOT_PATH dot PATH_SUFFIXES graphviz2.38/bin graphviz/bin)
-    if(DOT_PATH)
-        set(HAVE_DOT "YES")
-    else()
-        set(HAVE_DOT "NO")
-        message(AUTHOR_WARNING "Doxygen: to generate UML diagrams please install graphviz")
-    endif()
-    add_custom_target(doc
-            COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-    configure_file(Doxyfile.in Doxyfile)
-endif()
+libyang_doc()
 
 # clean cmake cache
 add_custom_target(cclean

--- a/CMakeModules/Doc.cmake
+++ b/CMakeModules/Doc.cmake
@@ -1,0 +1,17 @@
+# Prepare building doxygen documentation
+macro(LIBYANG_DOC)
+    find_package(Doxygen)
+    if(DOXYGEN_FOUND)
+        find_program(DOT_PATH dot PATH_SUFFIXES graphviz2.38/bin graphviz/bin)
+        if(DOT_PATH)
+            set(HAVE_DOT "YES")
+        else()
+            set(HAVE_DOT "NO")
+            message(AUTHOR_WARNING "Doxygen: to generate UML diagrams please install graphviz")
+        endif()
+        add_custom_target(doc
+                COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/Doxyfile
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+        configure_file(Doxyfile.in Doxyfile)
+    endif()
+endmacro()


### PR DESCRIPTION
Let the user build doxygen documentation without need of other compile
dependencies.

Moves the docs build into a separated cmake functions in CMakeModules.