### PR TITLE
json BUGFIX in lyjson_number

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -428,7 +428,7 @@ invalid_character:
                 /* adding zeros at the end */
                 num_len = exponent + e_val;
                 dp_position = num_len; /* decimal point is behind the actual value */
-            } else if ((size_t)labs(e_val) < exponent) {
+            } else if ((size_t)labs(e_val) < (exponent - minus)) {
                 /* adding decimal point between the integer's digits */
                 num_len = exponent + 1;
                 dp_position = exponent + e_val;

--- a/tests/utests/basic/test_json.c
+++ b/tests/utests/basic/test_json.c
@@ -132,6 +132,24 @@ test_number(void **state)
     assert_int_equal(1, jsonctx->dynamic);
     lyjson_ctx_free(jsonctx);
 
+    str = "15E-2";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("0.15", jsonctx->value);
+    assert_int_equal(4, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
+    str = "-15E-2";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    assert_int_equal(LYJSON_NUMBER, lyjson_ctx_status(jsonctx, 0));
+    assert_string_equal("-0.15", jsonctx->value);
+    assert_int_equal(5, jsonctx->value_len);
+    assert_int_equal(1, jsonctx->dynamic);
+    lyjson_ctx_free(jsonctx);
+
     str = "15E-3";
     assert_non_null(ly_in_memory(in, str));
     assert_int_equal(LY_SUCCESS, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));


### PR DESCRIPTION
The minus sign was taken as part of the number, which is not correct
in this expression.
This PR fixes issue 34107 from oss-fuzz.