### PR TITLE
parser yang/json BUGFIX stack-oveflow protection

### DIFF
--- a/src/json.h
+++ b/src/json.h
@@ -59,6 +59,7 @@ struct lyjson_ctx {
     const char *value;      /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
     size_t value_len;       /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
     ly_bool dynamic;        /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
+    uint32_t depth;         /* current number of nested blocks, see ::LY_MAX_BLOCK_DEPTH */
 
     struct {
         enum LYJSON_PARSER_STATUS status;
@@ -66,6 +67,7 @@ struct lyjson_ctx {
         const char *value;
         size_t value_len;
         ly_bool dynamic;
+        uint32_t depth;
         const char *input;
     } backup;
 };

--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -751,7 +751,18 @@ keyword_start:
     word_start = ctx->in->current;
     *kw = lysp_match_kw(ctx->in, &ctx->indent);
 
-    if ((*kw == LY_STMT_SYNTAX_SEMICOLON) || (*kw == LY_STMT_SYNTAX_LEFT_BRACE) || (*kw == LY_STMT_SYNTAX_RIGHT_BRACE)) {
+    if (*kw == LY_STMT_SYNTAX_SEMICOLON) {
+        goto success;
+    } else if (*kw == LY_STMT_SYNTAX_LEFT_BRACE) {
+        ctx->depth++;
+        if (ctx->depth > LY_MAX_BLOCK_DEPTH) {
+            LOGERR(ctx->parsed_mod->mod->ctx, LY_EINVAL,
+                    "The maximum number of block nestings has been exceeded.");
+            return LY_EINVAL;
+        }
+        goto success;
+    } else if (*kw == LY_STMT_SYNTAX_RIGHT_BRACE) {
+        ctx->depth--;
         goto success;
     }
 

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -35,6 +35,14 @@ struct lys_glob_unres;
 #define LY_PCRE2_MSG_LIMIT 256
 
 /**
+ * @brief The maximum depth at which the last nested block is located.
+ * Designed to protect against corrupted input that causes a stack-overflow error.
+ * For yang language and json format, the block is bounded by "{ }".
+ * For the xml format, the opening and closing element tag is considered as the block.
+ */
+#define LY_MAX_BLOCK_DEPTH 500
+
+/**
  * @brief Informational structure for YANG statements
  */
 struct stmt_info_s {
@@ -153,6 +161,7 @@ struct lys_yang_parser_ctx {
     struct lys_glob_unres *unres;   /**< global unres structure */
     struct ly_in *in;               /**< input handler for the parser */
     uint64_t indent;                /**< current position on the line for YANG indentation */
+    uint32_t depth;                 /**< current number of nested blocks, see ::LY_MAX_BLOCK_DEPTH */
 };
 
 /**

--- a/src/xml.c
+++ b/src/xml.c
@@ -598,7 +598,14 @@ lyxml_open_element(struct lyxml_ctx *xmlctx, const char *prefix, size_t prefix_l
     e->prefix = prefix;
     e->name_len = name_len;
     e->prefix_len = prefix_len;
+
     LY_CHECK_RET(ly_set_add(&xmlctx->elements, e, 1, NULL));
+    if (xmlctx->elements.count > LY_MAX_BLOCK_DEPTH) {
+        LOGERR(xmlctx->ctx, LY_EINVAL,
+                "The maximum number of open elements has been exceeded.");
+        ret = LY_EINVAL;
+        goto cleanup;
+    }
 
     /* skip WS */
     ign_xmlws(xmlctx);


### PR DESCRIPTION
By tracking the right and left braces.
This PR fixes issues 31630, 31858, 31998, 32066, 32934, 33439, 32392 from oss-fuzz.