### PR TITLE
Fix <sys/cdefs.h> inclusion on non-BSD, non-glibc systems

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -16,8 +16,8 @@
 /* realpath */
 #define _XOPEN_SOURCE 1
 #define _XOPEN_SOURCE_EXTENDED 1
-#endif
 #include <sys/cdefs.h>
+#endif
 
 #include "context.h"
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -12,7 +12,9 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "diff.h"
 

--- a/src/log.c
+++ b/src/log.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "log.h"
 

--- a/src/out.c
+++ b/src/out.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "out.h"
 #include "out_internal.h"

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/bits.c
+++ b/src/plugins_types/bits.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/date_and_time.c
+++ b/src/plugins_types/date_and_time.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/identityref.c
+++ b/src/plugins_types/identityref.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/integer.c
+++ b/src/plugins_types/integer.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv4_address.c
+++ b/src/plugins_types/ipv4_address.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv4_address_no_zone.c
+++ b/src/plugins_types/ipv4_address_no_zone.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv4_prefix.c
+++ b/src/plugins_types/ipv4_prefix.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv6_address.c
+++ b/src/plugins_types/ipv6_address.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv6_address_no_zone.c
+++ b/src/plugins_types/ipv6_address_no_zone.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/ipv6_prefix.c
+++ b/src/plugins_types/ipv6_prefix.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/plugins_types/union.c
+++ b/src/plugins_types/union.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "plugins_types.h"
 

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "schema_compile_node.h"
 

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include <assert.h>
 #include <ctype.h>

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "tree_schema.h"
 

--- a/src/validation.c
+++ b/src/validation.c
@@ -12,7 +12,9 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "validation.h"
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -12,7 +12,9 @@
  *     https://opensource.org/licenses/BSD-3-Clause
  */
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include "xpath.h"
 

--- a/tools/re/main.c
+++ b/tools/re/main.c
@@ -13,7 +13,9 @@
  */
 
 #define _GNU_SOURCE /* asprintf, strdup */
+#if defined (__NetBSD__) || defined (__OpenBSD__)
 #include <sys/cdefs.h>
+#endif
 
 #include <errno.h>
 #include <getopt.h>


### PR DESCRIPTION
Fixes this build failure seen since #1534  on any non-glibc system:

```
/ly2/libyang-2.0.7/build # ldd --version
musl libc (x86_64)
Version 1.2.2
Dynamic Program Loader
Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname
/ly2/libyang-2.0.7/build # make
[  1%] Building C object CMakeFiles/yangobj.dir/src/log.c.o
/ly2/libyang-2.0.7/src/log.c:16:10: fatal error: sys/cdefs.h: No such file or directory
   16 | #include <sys/cdefs.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/yangobj.dir/build.make:95: CMakeFiles/yangobj.dir/src/log.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:211: CMakeFiles/yangobj.dir/all] Error 2
make: *** [Makefile:149: all] Error 2
```
`<sys/cdefs.h>` is a part of BSD's libc ABI and is necessary to explicitly include only in that case. This worked incidentally on glibc systems because `<sys/cdefs.h>` is an internal header and *not* part of its ABI. For non-glibc systems (like the musl-based one above) attempting to include this file caused the breakage above (see [the musl FAQ entry about this](https://wiki.musl-libc.org/faq.html#Q:-When-compiling-something-against-musl,-I-get-error-messages-about-%3Ccode%3Esys/cdefs.h%3C/code%3E))

Solution is to only include this header on the BSD systems where it is needed.

