### PR TITLE
hash table BUGFIX key_part with zero length

### DIFF
--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -102,7 +102,7 @@ dict_hash_multi(uint32_t hash, const char *key_part, size_t len)
 {
     uint32_t i;
 
-    if (key_part) {
+    if (key_part && len) {
         for (i = 0; i < len; ++i) {
             hash += key_part[i];
             hash += (hash << 10);

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -44,8 +44,10 @@ lyd_hash(struct lyd_node *node)
 
     if (node->schema->nodetype == LYS_LIST) {
         if (node->schema->flags & LYS_KEYLESS) {
-            /* key-less list simply adds its schema name again to the hash, just so that it differs from the first-instance hash */
-            node->hash = dict_hash_multi(node->hash, node->schema->name, strlen(node->schema->name));
+            /* key-less list simply calls hash function again with empty key,
+             * just so that it differs from the first-instance hash
+             */
+            node->hash = dict_hash_multi(node->hash, NULL, 0);
         } else {
             struct lyd_node_inner *list = (struct lyd_node_inner *)node;
 

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -491,6 +491,43 @@ test_find_path(void **state)
     lyd_free_all(root);
 }
 
+static void
+test_data_hash(void **state)
+{
+    struct lyd_node *tree;
+    const char *schema, *data;
+
+    schema =
+            "module test-data-hash {"
+            "  yang-version 1.1;"
+            "  namespace \"urn:tests:tdh\";"
+            "  prefix t;"
+            "  container c {"
+            "    leaf-list ll {"
+            "      type string;"
+            "    }"
+            "  }"
+            "}";
+
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+
+    /* The number of <ll/> must be greater or equal to LYD_HT_MIN_ITEMS
+     * for the correct test run. It should guarantee the creation of a hash table.
+     */
+    assert_true(LYD_HT_MIN_ITEMS <= 4);
+    data =
+            "<c xmlns='urn:tests:tdh'>"
+            "  <ll/>"
+            "  <ll/>"
+            "  <ll/>"
+            "  <ll/>"
+            "</c>";
+
+    /* The run must not crash due to the assert that checks the hash. */
+    CHECK_PARSE_LYD_PARAM(data, LYD_XML, 0, LYD_VALIDATE_PRESENT, LY_EVALID, tree);
+    lyd_free_all(tree);
+}
+
 int
 main(void)
 {
@@ -502,6 +539,7 @@ main(void)
         UTEST(test_list_pos, setup),
         UTEST(test_first_sibling, setup),
         UTEST(test_find_path, setup),
+        UTEST(test_data_hash, setup),
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This PR fixes issue 34504 from oss-fuzz.