### PR TITLE
json BUGFIX integer under/overflow checks

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -63,10 +63,6 @@ ly_strncmp(const char *refstr, const char *str, size_t str_len)
     }
 }
 
-#define LY_OVERFLOW_ADD(MAX, X, Y) ((X > MAX - Y) ? 1 : 0)
-
-#define LY_OVERFLOW_MUL(MAX, X, Y) ((X > MAX / Y) ? 1 : 0)
-
 LY_ERR
 ly_strntou8(const char *nptr, size_t len, uint8_t *ret)
 {

--- a/src/common.h
+++ b/src/common.h
@@ -462,6 +462,16 @@ LY_ERR ly_value_prefix_next(const char *str_begin, const char *str_end, uint32_t
 
 #define ly_sizeofarray(ARRAY) (sizeof ARRAY / sizeof *ARRAY)
 
+/**
+ * @brief Check for overflow during the addition of two unsigned integers.
+ */
+#define LY_OVERFLOW_ADD(MAX, X, Y) (X > MAX - Y)
+
+/**
+ * @brief Check for overflow during the multiplication of two unsigned integers.
+ */
+#define LY_OVERFLOW_MUL(MAX, X, Y) (X > MAX / Y)
+
 /*
  * Numerical bases for use in functions like strtoll() instead of magic numbers
  */

--- a/tests/utests/basic/test_json.c
+++ b/tests/utests/basic/test_json.c
@@ -505,6 +505,16 @@ test_number(void **state)
     assert_int_equal(LY_EVALID, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
     CHECK_LOG_CTX("Exponent out-of-bounds in a JSON Number value (1e9999999999999999999).", "Line number 1.");
 
+    str = "1.1e66000";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_EVALID, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    CHECK_LOG_CTX("Exponent out-of-bounds in a JSON Number value (1.1e66000).", "Line number 1.");
+
+    str = "1.1e-66000";
+    assert_non_null(ly_in_memory(in, str));
+    assert_int_equal(LY_EVALID, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));
+    CHECK_LOG_CTX("Exponent out-of-bounds in a JSON Number value (1.1e-66000).", "Line number 1.");
+
     str = "-2.1e0.";
     assert_non_null(ly_in_memory(in, str));
     assert_int_equal(LY_EVALID, lyjson_ctx_new(UTEST_LYCTX, in, &jsonctx));


### PR DESCRIPTION
... in ::lyjson_exp_number().

This PR fixes issue 35193 from oss-fuzz.