### PR TITLE
Internal docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,12 @@ set(libsrc
     ${type_plugins})
 
 set(headers
-    src/libyang.h
     src/context.h
     src/dict.h
-    src/log.h
     src/in.h
+    src/libyang.h
+    src/log.h
+    src/out.h
     src/parser_data.h
     src/parser_schema.h
     src/plugins.h
@@ -158,13 +159,12 @@ set(headers
     src/plugins_exts_compile.h
     src/plugins_exts_print.h
     src/plugins_types.h
-    src/out.h
     src/printer_data.h
     src/printer_schema.h
     src/set.h
     src/tree.h
-    src/tree_edit.h
     src/tree_data.h
+    src/tree_edit.h
     src/tree_schema.h)
 
 set(gen_headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,28 @@ set(headers
     src/tree_edit.h
     src/tree_schema.h)
 
+set(internal_headers
+    src/common.h
+    src/diff.h
+    src/hash_table.h
+    src/in_internal.h
+    src/json.h
+    src/lyb.h
+    src/out_internal.h
+    src/parser_internal.h
+    src/path.h
+    src/plugins_internal.h
+    src/printer_internal.h
+    src/schema_compile.h
+    src/schema_compile_amend.h
+    src/schema_compile_node.h
+    src/schema_features.h
+    src/tree_data_internal.h
+    src/tree_schema_internal.h
+    src/validation.h
+    src/xml.h
+    src/xpath.h)
+
 set(gen_headers
     src/version.h
     src/config.h)
@@ -198,16 +220,21 @@ set(format_sources
 if(("${BUILD_TYPE_UPPER}" STREQUAL "DEBUG") OR ("${BUILD_TYPE_UPPER}" STREQUAL "RELWITHDEBINFO"))
     option(ENABLE_TESTS "Build tests" ON)
     option(ENABLE_VALGRIND_TESTS "Build tests with valgrind" ON)
-    # TODO enable when the internal docs ready
-    set(INTERNAL_DOCS NO)
 else()
     option(ENABLE_TESTS "Build tests" OFF)
     option(ENABLE_VALGRIND_TESTS "Build tests with valgrind" OFF)
-    set(INTERNAL_DOCS NO)
 endif()
 option(ENABLE_PERF_TESTS "Build performance tests" OFF)
 option(ENABLE_COVERAGE "Build code coverage report from tests" OFF)
 option(ENABLE_FUZZ_TARGETS "Build target programs suitable for fuzzing with AFL" OFF)
+option(ENABLE_INTERNAL_DOCS "Generate doxygen documentation also from internal headers" OFF)
+
+if(ENABLE_INTERNAL_DOCS)
+    set(doxy_files ${doxy_files} ${internal_headers})
+    set(INTERNAL_DOCS YES)
+else()
+    set(INTERNAL_DOCS NO)
+endif()
 
 set(LYD_VALUE_SIZE "24" CACHE STRING "Maximum size in bytes of data node values that do not need to be allocated dynamically, minimum is 8")
 if(LYD_VALUE_SIZE LESS 8)

--- a/src/json.h
+++ b/src/json.h
@@ -54,11 +54,11 @@ struct lyjson_ctx {
     const struct ly_ctx *ctx;
     struct ly_in *in;       /* input structure */
 
-    struct ly_set status;   /* stack of LYJSON_PARSER_STATUS values corresponding to the JSON items being processed */
+    struct ly_set status;   /* stack of ::LYJSON_PARSER_STATUS values corresponding to the JSON items being processed */
 
-    const char *value;      /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
-    size_t value_len;       /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
-    ly_bool dynamic;        /* LYJSON_STRING, LYJSON_NUMBER, LYJSON_OBJECT */
+    const char *value;      /* ::LYJSON_STRING, ::LYJSON_NUMBER, ::LYJSON_OBJECT */
+    size_t value_len;       /* ::LYJSON_STRING, ::LYJSON_NUMBER, ::LYJSON_OBJECT */
+    ly_bool dynamic;        /* ::LYJSON_STRING, ::LYJSON_NUMBER, ::LYJSON_OBJECT */
     uint32_t depth;         /* current number of nested blocks, see ::LY_MAX_BLOCK_DEPTH */
 
     struct {
@@ -77,7 +77,7 @@ struct lyjson_ctx {
  *
  * @param[in] ctx libyang context.
  * @param[in] in JSON string data to parse.
- * @param[out] jsonctx New JSON context with status ::LYJSON_VALUE.
+ * @param[out] jsonctx New JSON context with status referring the parsed value.
  * @return LY_ERR value.
  */
 LY_ERR lyjson_ctx_new(const struct ly_ctx *ctx,  struct ly_in *in, struct lyjson_ctx **jsonctx);
@@ -87,7 +87,7 @@ LY_ERR lyjson_ctx_new(const struct ly_ctx *ctx,  struct ly_in *in, struct lyjson
  *
  * @param[in] jsonctx JSON context to check.
  * @param[in] index Index of the token, starting by 0 for the last token
- * @return LYJSON_ERROR in case of invalid index, other LYJSON_PARSER_STATUS corresponding to the token.
+ * @return ::LYJSON_ERROR in case of invalid index, other ::LYJSON_PARSER_STATUS corresponding to the token.
  */
 enum LYJSON_PARSER_STATUS lyjson_ctx_status(struct lyjson_ctx *jsonctx, uint32_t index);
 
@@ -100,7 +100,7 @@ enum LYJSON_PARSER_STATUS lyjson_ctx_status(struct lyjson_ctx *jsonctx, uint32_t
 const char *lyjson_token2str(enum LYJSON_PARSER_STATUS status);
 
 /**
- * @brief Move to the next JSON artefact and update parser status.
+ * @brief Move to the next JSON artifact and update parser status.
  *
  * @param[in] jsonctx XML context to move.
  * @param[out] status Optional parameter to provide new parser status

--- a/src/lyb.h
+++ b/src/lyb.h
@@ -27,6 +27,9 @@ struct ly_ctx;
 struct lyd_node;
 struct lysc_node;
 
+/**
+ * @brief LYB format parser context
+ */
 struct lylyb_ctx {
     const struct ly_ctx *ctx;
     uint64_t line;             /* current line */
@@ -46,35 +49,6 @@ struct lylyb_ctx {
         struct lysc_node *first_sibling;
         struct hash_table *ht;
     } *sib_hts;
-};
-
-/**
- * @brief Internal structure for LYB parser/printer.
- *
- * Note that the structure maps to the lyd_ctx which is common for all the data parsers
- */
-struct lyd_lyb_ctx {
-    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
-    union {
-        struct {
-            uint32_t parse_opts;   /**< various @ref dataparseroptions. */
-            uint32_t val_opts;     /**< various @ref datavalidationoptions. */
-        };
-        uint32_t print_options;
-    };
-    uint32_t int_opts;             /**< internal data parser options */
-    uint32_t path_len;             /**< used bytes in the path buffer */
-    char path[LYD_PARSER_BUFSIZE]; /**< buffer for the generated path */
-    struct ly_set node_when;       /**< set of nodes with "when" conditions */
-    struct ly_set node_exts;       /**< set of nodes and extensions connected with a plugin providing own validation callback */
-    struct ly_set node_types;      /**< set of nodes validated with LY_EINCOMPLETE result */
-    struct ly_set meta_types;      /**< set of metadata validated with LY_EINCOMPLETE result */
-    struct lyd_node *op_node;      /**< if an RPC/action/notification is being parsed, store the pointer to it */
-
-    /* callbacks */
-    lyd_ctx_free_clb free;           /* destructor */
-
-    struct lylyb_ctx *lybctx;      /* lyb format context */
 };
 
 /**

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -23,7 +23,7 @@ struct lyd_ctx;
 struct ly_in;
 
 /**
- * @brief Callback for lyd_ctx to free the structure
+ * @brief Callback for ::lyd_ctx to free the structure
  *
  * @param[in] ctx Data parser context to free.
  */
@@ -42,7 +42,7 @@ typedef void (*lyd_ctx_free_clb)(struct lyd_ctx *ctx);
 /**
  * @brief Internal (common) context for YANG data parsers.
  *
- * Covers ::lyd_xml_ctx, ::lyd_json_ctx and lyd_lyb_ctx.
+ * Covers ::lyd_xml_ctx, ::lyd_json_ctx and ::lyd_lyb_ctx.
  */
 struct lyd_ctx {
     const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
@@ -69,13 +69,13 @@ struct lyd_ctx {
 };
 
 /**
- * @brief Common part of the lyd_ctx_free_t callbacks.
+ * @brief Common part to supplement the specific ::lyd_ctx_free_clb callbacks.
  */
 void lyd_ctx_free(struct lyd_ctx *);
 
 /**
  * @brief Parse submodule from YANG data.
- * @param[in,out] ctx Parser context.
+ * @param[in,out] context Parser context.
  * @param[in] ly_ctx Context of YANG schemas.
  * @param[in] main_ctx Parser context of main module.
  * @param[in] in Input structure.
@@ -87,7 +87,7 @@ LY_ERR yang_parse_submodule(struct lys_yang_parser_ctx **context, struct ly_ctx 
 
 /**
  * @brief Parse module from YANG data.
- * @param[in] ctx Parser context.
+ * @param[in] context Parser context.
  * @param[in] in Input structure.
  * @param[in,out] mod Prepared module structure where the parsed information, including the parsed
  * module structure, will be filled in.
@@ -182,7 +182,7 @@ LY_ERR lyd_parse_lyb(const struct ly_ctx *ctx, const struct lysc_ext_instance *e
  * @brief Search all the parents for an operation node, check validity based on internal parser flags.
  *
  * @param[in] parent Parent to connect the parsed nodes to.
- * @param[in] int_opt Internal parser options.
+ * @param[in] int_opts Internal parser options.
  * @param[out] op Found operation, if any.
  * @return LY_ERR value.
  */
@@ -201,7 +201,17 @@ LY_ERR lyd_parser_check_schema(struct lyd_ctx *lydctx, const struct lysc_node *s
  * @brief Wrapper around ::lyd_create_term() for data parsers.
  *
  * @param[in] lydctx Data parser context.
- * @param[in] hints Data parser's hint for the value's type.
+ * @param[in] schema Schema node of the new data node.
+ * @param[in] value String value to be parsed.
+ * @param[in] value_len Length of @p value, must be set correctly.
+ * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
+ * @param[in] format Input format of @p value.
+ * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
+ * @param[in] hints [Data parser's hints](@ref lydvalhints) for the value's type.
+ * @param[out] node Created node.
+ * @return LY_SUCCESS on success.
+ * @return LY_EINCOMPLETE in case data tree is needed to finish the validation.
+ * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, const void *value, size_t value_len,
         ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints, struct lyd_node **node);

--- a/src/parser_internal.h
+++ b/src/parser_internal.h
@@ -69,6 +69,77 @@ struct lyd_ctx {
 };
 
 /**
+ * @brief Internal context for XML data parser.
+ */
+struct lyd_xml_ctx {
+    const struct lysc_ext_instance *ext;
+    uint32_t parse_opts;
+    uint32_t val_opts;
+    uint32_t int_opts;
+    uint32_t path_len;
+    char path[LYD_PARSER_BUFSIZE];
+    struct ly_set node_when;
+    struct ly_set node_exts;
+    struct ly_set node_types;
+    struct ly_set meta_types;
+    struct lyd_node *op_node;
+
+    /* callbacks */
+    lyd_ctx_free_clb free;
+
+    struct lyxml_ctx *xmlctx;      /**< XML context */
+};
+
+/**
+ * @brief Internal context for JSON data parser.
+ */
+struct lyd_json_ctx {
+    const struct lysc_ext_instance *ext;
+    uint32_t parse_opts;
+    uint32_t val_opts;
+    uint32_t int_opts;
+    uint32_t path_len;
+    char path[LYD_PARSER_BUFSIZE];
+    struct ly_set node_when;
+    struct ly_set node_exts;
+    struct ly_set node_types;
+    struct ly_set meta_types;
+    struct lyd_node *op_node;
+
+    /* callbacks */
+    lyd_ctx_free_clb free;
+
+    struct lyjson_ctx *jsonctx;    /**< JSON context */
+};
+
+/**
+ * @brief Internal context for LYB data parser/printer.
+ */
+struct lyd_lyb_ctx {
+    const struct lysc_ext_instance *ext;
+    union {
+        struct {
+            uint32_t parse_opts;
+            uint32_t val_opts;
+        };
+        uint32_t print_options;
+    };
+    uint32_t int_opts;
+    uint32_t path_len;
+    char path[LYD_PARSER_BUFSIZE];
+    struct ly_set node_when;
+    struct ly_set node_exts;
+    struct ly_set node_types;
+    struct ly_set meta_types;
+    struct lyd_node *op_node;
+
+    /* callbacks */
+    lyd_ctx_free_clb free;
+
+    struct lylyb_ctx *lybctx;      /* LYB context */
+};
+
+/**
  * @brief Common part to supplement the specific ::lyd_ctx_free_clb callbacks.
  */
 void lyd_ctx_free(struct lyd_ctx *);

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -36,30 +36,6 @@
 #include "validation.h"
 
 /**
- * @brief Internal context for JSON YANG data parser.
- *
- * Note that the structure maps to the lyd_ctx which is common for all the data parsers
- */
-struct lyd_json_ctx {
-    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
-    uint32_t parse_opts;           /**< various @ref dataparseroptions. */
-    uint32_t val_opts;             /**< various @ref datavalidationoptions. */
-    uint32_t int_opts;             /**< internal data parser options */
-    uint32_t path_len;             /**< used bytes in the path buffer */
-    char path[LYD_PARSER_BUFSIZE]; /**< buffer for the generated path */
-    struct ly_set node_when;       /**< set of nodes with "when" conditions */
-    struct ly_set node_exts;       /**< set of nodes and extensions connected with a plugin providing own validation callback */
-    struct ly_set node_types;      /**< set of nodes validated with LY_EINCOMPLETE result */
-    struct ly_set meta_types;      /**< set of metadata validated with LY_EINCOMPLETE result */
-    struct lyd_node *op_node;      /**< if an RPC/action/notification is being parsed, store the pointer to it */
-
-    /* callbacks */
-    lyd_ctx_free_clb free;           /* destructor */
-
-    struct lyjson_ctx *jsonctx;    /**< JSON context */
-};
-
-/**
  * @brief Free the JSON data parser context.
  *
  * JSON implementation of lyd_ctx_free_clb().

--- a/src/parser_xml.c
+++ b/src/parser_xml.c
@@ -33,30 +33,6 @@
 #include "validation.h"
 #include "xml.h"
 
-/**
- * @brief Internal context for XML YANG data parser.
- *
- * Note that the structure maps to the ::lyd_ctx which is common for all the data parsers
- */
-struct lyd_xml_ctx {
-    const struct lysc_ext_instance *ext; /**< extension instance possibly changing document root context of the data being parsed */
-    uint32_t parse_opts;           /**< various @ref dataparseroptions. */
-    uint32_t val_opts;             /**< various @ref datavalidationoptions. */
-    uint32_t int_opts;             /**< internal data parser options */
-    uint32_t path_len;             /**< used bytes in the path buffer */
-    char path[LYD_PARSER_BUFSIZE]; /**< buffer for the generated path */
-    struct ly_set node_when;       /**< set of nodes with "when" conditions */
-    struct ly_set node_exts;       /**< set of nodes and extensions connected with a plugin providing own validation callback */
-    struct ly_set node_types;      /**< set of nodes validated with LY_EINCOMPLETE result */
-    struct ly_set meta_types;      /**< set of metadata validated with LY_EINCOMPLETE result */
-    struct lyd_node *op_node;      /**< if an RPC/action/notification is being parsed, store the pointer to it */
-
-    /* callbacks */
-    lyd_ctx_free_clb free;           /* destructor */
-
-    struct lyxml_ctx *xmlctx;      /**< XML context */
-};
-
 void
 lyd_xml_ctx_free(struct lyd_ctx *lydctx)
 {

--- a/src/path.c
+++ b/src/path.c
@@ -380,7 +380,8 @@ error:
  *
  * @param[in] ctx libyang context.
  * @param[in] cur_node Optional current (original context) node.
- * @param[in] cur_mod Current module of the path (where the path is "instantiated"). Needed for ::LY_VALUE_SCHEMA*.
+ * @param[in] cur_mod Current module of the path (where the path is "instantiated"). Needed for ::LY_VALUE_SCHEMA
+ * and ::LY_VALUE_SCHEMA_RESOLVED.
  * @param[in] prev_ctx_node Previous context node. Needed for ::LY_VALUE_JSON.
  * @param[in] expr Parsed path.
  * @param[in] tok_idx Index in @p expr.
@@ -797,7 +798,7 @@ cleanup:
  *
  * @param[in] ctx libyang context.
  * @param[in] cur_mod Current module of the path (where it was "instantiated"), ignored of @p lref. Used for nodes
- * without a prefix for ::LY_PREF_SCHEMA* format.
+ * without a prefix for ::LY_VALUE_SCHEMA and ::LY_VALUE_SCHEMA_RESOLVED format.
  * @param[in] ctx_node Optional context node, mandatory of @p lref.
  * @param[in] ext Extension instance containing the definition of the data being created. It is used to find the top-level
  * node inside the extension instance instead of a module. Note that this is the case not only if the @p ctx_node is NULL,

--- a/src/path.h
+++ b/src/path.h
@@ -146,7 +146,7 @@ LY_ERR ly_path_parse_predicate(const struct ly_ctx *ctx, const struct lysc_node 
  *
  * @param[in] ctx libyang context.
  * @param[in] cur_mod Current module of the path (where it was "instantiated"). Used for nodes in schema-nodeid
- * without a prefix for ::LY_PREF_SCHEMA* format.
+ * without a prefix for ::LY_VALUE_SCHEMA and ::LY_VALUE_SCHEMA_RESOLVED format.
  * @param[in] ctx_node Optional context node.
  * @param[in] ext Extension instance containing the definition of the data being created. It is used to find the top-level
  * node inside the extension instance instead of a module. Note that this is the case not only if the @p ctx_node is NULL,
@@ -189,7 +189,7 @@ LY_ERR ly_path_compile_leafref(const struct ly_ctx *ctx, const struct lysc_node 
  * @param[in] ctx libyang context.
  * @param[in] cur_node Optional current (original context) node.
  * @param[in] cur_mod Current module of the path (where it was "instantiated"). Used for nodes without a prefix
- * for ::LY_PREF_SCHEMA* format.
+ * for ::LY_VALUE_SCHEMA and ::LY_VALUE_SCHEMA_RESOLVED format.
  * @param[in] ctx_node Context node, node for which the predicate is defined.
  * @param[in] expr Parsed path.
  * @param[in,out] tok_idx Index in @p expr, is adjusted for parsed tokens.

--- a/src/plugins_internal.h
+++ b/src/plugins_internal.h
@@ -68,7 +68,7 @@ void lyplg_clean(void);
  * only the plugins with NULL revision specified.
  * @param[in] name Name of the type/extension which the plugin implements.
  * @return NULL if the plugin matching the restrictions is not present.
- * @return Pointer to the matching ::ly_type_plugin or ::lyext_plugin according to the plugin's @p type.
+ * @return Pointer to the matching ::lyplg_ext or ::lyplg_type according to the plugin's @p type.
  */
 void *lyplg_find(enum LYPLG type, const char *module, const char *revision, const char *name);
 

--- a/src/schema_compile.h
+++ b/src/schema_compile.h
@@ -264,13 +264,13 @@ LY_ERR lys_compile_expr_implement(const struct ly_ctx *ctx, const struct lyxp_ex
  * Steps taken when adding a new module (::ly_ctx_load_module(), ::lys_parse()):
  *
  * 1) parse module and add it into context with all imports and includes also parsed and in context
- *    (::lys_parse_load(), ::lys_parse_in(), ::lys_parse_localfile())
+ *    (::lys_parse_load(), ::lys_parse_in(), lys_parse_localfile() - static)
  * 2) implement it (perform one-time compilation tasks - compile identities and add reference to augment/deviation
  *    target modules, implement those as well, ::_lys_set_implemented())
  * 3) create dep set of the module (::lys_unres_dep_sets_create())
  * 4) (re)compile all the modules in the dep set and collect unres (::lys_compile_dep_set_r())
- * 5) resolve unres (::lys_compile_unres_depset()), new modules may be implemented like in 2) and if require recompilation,
- *    free all compiled modules and do 4)
+ * 5) resolve unres (lys_compile_unres_depset() - static), new modules may be implemented like in 2) and if
+ *    require recompilation, free all compiled modules and do 4)
  * 6) all modules that needed to be (re)compiled are now, with all their dependencies
  *
  * What can cause new modules to be implemented when resolving unres in 5):

--- a/src/schema_compile.h
+++ b/src/schema_compile.h
@@ -75,9 +75,9 @@ struct lys_depset_unres {
  * @brief Unres structure global for compilation.
  */
 struct lys_glob_unres {
-    struct ly_set dep_sets;     /**< set of dependency sets of modules, see ::ly_ctx_compile_deps_mod_r() */
+    struct ly_set dep_sets;     /**< set of dependency sets of modules, see ::lys_compile_dep_set_r() */
     struct ly_set implementing; /**< set of YANG schemas being atomically implemented (compiled); the first added
-                                    module is always the explcitly implemented module, the other ones are dependencies */
+                                    module is always the explicitly implemented module, the other ones are dependencies */
     struct ly_set creating;     /**< set of YANG schemas being atomically created (parsed); it is a subset of implemented
                                     and all these modules are freed if any error occurs */
     struct lys_depset_unres ds_unres;   /**< unres specific for the current dependency set */
@@ -101,6 +101,7 @@ struct lysc_unres_dflt {
  * @param[in] CTX libyang context of the dictionary.
  * @param[in] ORIG String to duplicate.
  * @param[out] DUP Where to store the result.
+ * @param[out] RET Where to store the return code.
  */
 #define DUP_STRING(CTX, ORIG, DUP, RET) if (ORIG) {RET = lydict_insert(CTX, ORIG, 0, &DUP);}
 #define DUP_STRING_RET(CTX, ORIG, DUP) if (ORIG) {LY_ERR __ret = lydict_insert(CTX, ORIG, 0, &DUP); LY_CHECK_RET(__ret);}

--- a/src/schema_compile_amend.h
+++ b/src/schema_compile_amend.h
@@ -124,7 +124,7 @@ void lysp_dev_node_free(const struct ly_ctx *ctx, struct lysp_node *dev_pnode);
  * @param[in] pnode Parsed node to consider.
  * @param[in] parent First compiled parent of @p pnode.
  * @param[out] dev_pnode Copy of parsed node @p pnode with deviations and refines, if any. NULL if there are none.
- * @param[out] no_supported Whether a not-supported deviation is defined for the node.
+ * @param[out] not_supported Whether a not-supported deviation is defined for the node.
  * @return LY_ERR value.
  */
 LY_ERR lys_compile_node_deviations_refines(struct lysc_ctx *ctx, const struct lysp_node *pnode,

--- a/src/schema_compile_node.h
+++ b/src/schema_compile_node.h
@@ -49,7 +49,7 @@ LY_ERR lys_compile_when(struct lysc_ctx *ctx, struct lysp_when *when_p, uint16_t
  *
  * @param[in] ctx Context.
  * @param[in] pattern Pattern to check.
- * @param[in,out] pcre2_code Compiled PCRE2 pattern. If NULL, the compiled information used to validate pattern are freed.
+ * @param[in,out] code Compiled PCRE2 pattern. If NULL, the compiled information used to validate pattern are freed.
  * @return LY_ERR value - LY_SUCCESS, LY_EMEM, LY_EVALID.
  */
 LY_ERR lys_compile_type_pattern_check(struct ly_ctx *ctx, const char *pattern, pcre2_code **code);
@@ -100,6 +100,7 @@ LY_ERR lysc_resolve_schema_nodeid(struct lysc_ctx *ctx, const char *nodeid, size
  * @param[in] ctx Compile context
  * @param[in] child_p Parsed choice children nodes.
  * @param[in] node Compiled choice node to compile and add children to.
+ * @param[in,out] child_set Optional set to add all the compiled nodes into (can be more in case of uses).
  * @return LY_ERR value - LY_SUCCESS or LY_EVALID.
  */
 LY_ERR lys_compile_node_choice_child(struct lysc_ctx *ctx, struct lysp_node *child_p, struct lysc_node *node,

--- a/src/schema_features.h
+++ b/src/schema_features.h
@@ -47,9 +47,9 @@ LY_ERR lys_eval_iffeatures(const struct ly_ctx *ctx, struct lysp_qname *iffeatur
 LY_ERR lys_set_features(struct lysp_module *pmod, const char **features);
 
 /**
- * @brief Compile if-features of features in the current module and all its submodules.
+ * @brief Compile if-features of features in the provided module and all its submodules.
  *
- * @param[in] ctx Compile context.
+ * @param[in] pmod Parsed module to process.
  * @return LY_ERR value.
  */
 LY_ERR lys_compile_feature_iffeatures(struct lysp_module *pmod);

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -360,6 +360,7 @@ LY_ERR lys_value_validate(const struct ly_ctx *ctx, const struct lysc_node *node
 /**
  * @defgroup datahash Data nodes hash manipulation
  * @ingroup datatree
+ * @{
  */
 
 /**

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -268,7 +268,7 @@ void lyd_insert_meta(struct lyd_node *parent, struct lyd_meta *meta, ly_bool cle
  */
 LY_ERR lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
         size_t name_len, const char *value, size_t value_len, ly_bool *dynamic, LY_VALUE_FORMAT format,
-        void *prefix_data, uint32_t hints, ly_bool clear_dlft, ly_bool *incomplete);
+        void *prefix_data, uint32_t hints, ly_bool clear_dflt, ly_bool *incomplete);
 
 /**
  * @brief Insert an attribute (last) into a parent

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -318,7 +318,7 @@ LY_ERR lysp_check_enum_name(struct lys_parser_ctx *ctx, const char *name, size_t
  *
  * @param[in] ctx libyang context.
  * @param[in] name Name of the module to load.
- * @param[in] revison Optional revision of the module to load. If NULL, the newest revision is loaded.
+ * @param[in] revision Optional revision of the module to load. If NULL, the newest revision is loaded.
  * @param[in,out] new_mods Set of all the new mods added to the context. Includes this module and all of its imports.
  * @param[out] mod Created module structure.
  * @return LY_SUCCESS on success.
@@ -670,12 +670,18 @@ void lysp_type_free(struct ly_ctx *ctx, struct lysp_type *type);
 /**
  * @brief Free the parsed extension instance structure.
  * @param[in] ctx libyang context where the string data resides in a dictionary.
- * @param[in] type Parsed extension instance structure to free. Note that the instance itself is not freed.
+ * @param[in] ext Parsed extension instance structure to free. Note that the instance itself is not freed.
  */
 void lysp_ext_instance_free(struct ly_ctx *ctx, struct lysp_ext_instance *ext);
 
 /**
+ * @brief Parse generic statement structure into a specific parsed-schema structure.
+ *
+ * @param[in] ctx The compilation context of the @p stmt being processed
+ * @param[in] stmt Generic statement structure to process.
+ * @param[out] result Specific parsed-schema structure for the given statement. For the specific type for the particular statement, check the function code.
  * @param[in,out] exts [sized array](@ref sizedarrays) For extension instances in case of statements that do not store extension instances in their own list.
+ * @return LY_ERR value.
  */
 LY_ERR lysp_stmt_parse(struct lysc_ctx *ctx, const struct lysp_stmt *stmt, void **result, struct lysp_ext_instance **exts);
 
@@ -828,15 +834,15 @@ const struct lysc_node *lysc_data_node(const struct lysc_node *schema);
 /**
  * @brief Get format-specific prefix for a module.
  *
- * For type plugins available as ::ly_type_print_get_prefix().
+ * This function is available for type plugins via ::lyplg_type_get_prefix() API function.
  *
  * @param[in] mod Module whose prefix to get.
  * @param[in] format Format of the prefix.
  * @param[in] prefix_data Format-specific data based on @p format:
  *      LY_VALUE_CANON           - NULL
- *      LY_VALUE_SCHEMA          - const struct lysp_module * (module used for resolving imports to prefixes)
- *      LY_VALUE_SCHEMA_RESOLVED - struct lyd_value_prefix * (sized array of pairs: prefix - module)
- *      LY_VALUE_XML             - struct ly_set * (set of all returned modules as ::struct lys_module)
+ *      LY_VALUE_SCHEMA          - const struct ::lysp_module* (module used for resolving imports to prefixes)
+ *      LY_VALUE_SCHEMA_RESOLVED - struct ::lysc_prefix* (sized array of pairs: prefix - module)
+ *      LY_VALUE_XML             - struct ::ly_set* (set of all returned modules as struct ::lys_module)
  *      LY_VALUE_JSON            - NULL
  *      LY_VALUE_LYB             - NULL
  * @return Module prefix to print.
@@ -846,8 +852,6 @@ const char *ly_get_prefix(const struct lys_module *mod, LY_VALUE_FORMAT format, 
 
 /**
  * @brief Resolve format-specific prefixes to modules.
- *
- * For type plugins available as ::ly_type_store_resolve_prefix().
  *
  * @param[in] ctx libyang context.
  * @param[in] prefix Prefix to resolve.

--- a/src/validation.h
+++ b/src/validation.h
@@ -88,7 +88,7 @@ LY_ERR lyd_validate_new(struct lyd_node **first, const struct lysc_node *sparent
  * @param[in] val_opts Validation options, see @ref datavalidationoptions.
  * @param[in] validate_subtree Whether subtree was already validated (as part of data parsing) or not (separate validation).
  * @param[in] node_when_p Set of nodes with when conditions, if NULL a local set is used.
- * @param[in] node_exts Set with nodes with extension instances with validation plugin callback, if NULL a local set is used.
+ * @param[in] node_exts_p Set with nodes with extension instances with validation plugin callback, if NULL a local set is used.
  * @param[in] node_types_p Set of unres node types, if NULL a local set is used.
  * @param[in] meta_types_p Set of unres metadata types, if NULL a local set is used.
  * @param[out] diff Generated validation diff, not generated if NULL.

--- a/src/xml.h
+++ b/src/xml.h
@@ -136,10 +136,8 @@ LY_ERR lyxml_ctx_peek(struct lyxml_ctx *xmlctx, enum LYXML_PARSER_STATUS *next);
  * @brief Get a namespace record for the given prefix in the current context.
  *
  * @param[in] ns_set Set with namespaces from the XML context.
- * @param[in] prefix Pointer to the namespace prefix as taken from ::lyxml_get_attribute() or ::lyxml_get_element().
- * Can be NULL for default namespace.
- * @param[in] prefix_len Length of the prefix string (since it is not NULL-terminated when returned from ::lyxml_get_attribute() or
- * ::lyxml_get_element()).
+ * @param[in] prefix Pointer to the namespace prefix. Can be NULL for default namespace.
+ * @param[in] prefix_len Length of the prefix string (since it might not be NULL-terminated).
  * @return The namespace record or NULL if the record for the specified prefix not found.
  */
 const struct lyxml_ns *lyxml_ns_get(const struct ly_set *ns_set, const char *prefix, size_t prefix_len);

--- a/src/xpath.h
+++ b/src/xpath.h
@@ -26,11 +26,15 @@
 struct ly_ctx;
 struct lyd_node;
 
-/*
+/**
+ * @internal
+ * @page internals
+ * @section internalsXpath XPath Implementation
+ *
  * XPath evaluator fully compliant with http://www.w3.org/TR/1999/REC-xpath-19991116/
  * except the following restrictions in the grammar.
  *
- * PARSED GRAMMAR
+ * @subsection internalsXpathGrammar Parsed Grammar
  *
  * Full axes are not supported, abbreviated forms must be used,
  * variables are not supported, "id()" function is not supported,
@@ -39,7 +43,7 @@ struct lyd_node;
  * constants are tokens.
  *
  * Modified full grammar:
- *
+ * @code
  * [1] Expr ::= OrExpr // just an alias
  *
  * [2] LocationPath ::= RelativeLocationPath | AbsoluteLocationPath
@@ -73,6 +77,7 @@ struct lyd_node;
  *                     | MultiplicativeExpr 'mod' UnaryExpr
  * [19] UnaryExpr ::= UnionExpr | '-' UnaryExpr
  * [20] UnionExpr ::= PathExpr | UnionExpr '|' PathExpr
+ * @endcode
  */
 
 /* expression tokens allocation */


### PR DESCRIPTION
Allow to include even internal documentation into the doxygen output.

@michalvasko please take a look at the current issues reported by doxygen when the internal docs are enabled, there are 2 groups:
1. parser_internal.h - caused by different approach to LYB and other formats regarding their internal API. maybe it can be ignored for now or the headers should be redesigned. I just didn't want to do such a change in this PR.
2. schema_compile.h - there some inconsistencies probably caused by some recent changes in parser-compiler design, since you are more familiar with it, please look at it and fix the unresolved links.

This PR just introduces the option to add internal docs into generated doxygen documentation. It fixes the issues reported by doxygen, but there is probably still much to fix mainly because some of the links are not marked explicitly (by double semicolon), so doxygen does not complain about them.