### PR TITLE
yang printer CHANGE some tunning of printer to unify output with pyang

### DIFF
--- a/src/printer_internal.h
+++ b/src/printer_internal.h
@@ -30,6 +30,7 @@ struct lysp_submodule;
 struct lyspr_ctx {
     struct ly_out *out;              /**< output specification */
     uint16_t level;                  /**< current indentation level: 0 - no formatting, >= 1 indentation levels */
+    uint16_t flags;                  /**< internal flags for use by printer */
     uint32_t options;                /**< Schema output options (see @ref schemaprinterflags). */
     const struct lys_module *module; /**< schema to print */
 };

--- a/tests/utests/extensions/test_yangdata.c
+++ b/tests/utests/extensions/test_yangdata.c
@@ -109,7 +109,7 @@ test_schema(void **state)
             "container b { rc:yang-data template { container x { leaf x {type string;}}}}}";
     info = "module b {\n"
             "  namespace \"urn:tests:extensions:yangdata:b\";\n"
-            "  prefix self;\n"
+            "  prefix self;\n\n"
             "  container b {\n"
             "    config true;\n"
             "    status current;\n"
@@ -144,7 +144,7 @@ test_schema(void **state)
             "      presence \"true\";\n"
             "      status current;\n"
             "    }\n"
-            "  }\n"
+            "  }\n\n"
             "  leaf d {\n"
             "    type string;\n"
             "    config true;\n"

--- a/tests/utests/node/list.c
+++ b/tests/utests/node/list.c
@@ -690,6 +690,7 @@ test_schema_print(void **state)
 
     /* test print yin to yang */
     schema_yang = MODULE_CREATE_YANG("PRINT1",
+            "\n"
             "  list user {\n"
             "    key \"uid name\";\n"
             "    unique \"name\";\n"

--- a/tests/utests/restriction/test_pattern.c
+++ b/tests/utests/restriction/test_pattern.c
@@ -320,6 +320,7 @@ test_schema_print(void **state)
 
     /* test print yin to yang */
     schema_yang = MODULE_CREATE_YANG("PRINT1",
+            "\n"
             "  leaf port {\n"
             "    type string {\n"
             "      pattern \"[A-Z]*\" {\n"

--- a/tests/utests/restriction/test_range.c
+++ b/tests/utests/restriction/test_range.c
@@ -333,6 +333,7 @@ test_schema_print(void **state)
 
     /* test print yin to yang */
     schema_yang = MODULE_CREATE_YANG("PRINT1",
+            "\n"
             "  leaf port {\n"
             "    type int32 {\n"
             "      range \"0 .. 50\" {\n"

--- a/tests/utests/types/bits.c
+++ b/tests/utests/types/bits.c
@@ -522,7 +522,7 @@ test_schema_print(void **state)
             "      }\n"
             "      bit twelve;\n"
             "    }\n"
-            "  }\n"
+            "  }\n\n"
             "  leaf port {\n"
             "    type my_type {\n"
             "      bit ten {\n"

--- a/tests/utests/types/int8.c
+++ b/tests/utests/types/int8.c
@@ -1027,7 +1027,7 @@ test_schema_print(void **state)
     schema_yang = MODULE_CREATE_YANG("PRINT1",
             "\n"
             "  description\n"
-            "    \"desc\";\n"
+            "    \"desc\";\n\n"
             "  leaf port {\n"
             "    type int8 {\n"
             "      range \"0 .. 50 | 127\";\n"
@@ -1072,6 +1072,7 @@ test_schema_print(void **state)
 
     /* test print yin to yang */
     schema_yang = MODULE_CREATE_YANG("PRINT3",
+            "\n"
             "  leaf port {\n"
             "    type int8;\n"
             "  }\n");

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -647,6 +647,7 @@ test_schema_print(void **state)
 
     /* test print yin to yang */
     schema_yang = MODULE_CREATE_YANG("PRINT1",
+            "\n"
             "  leaf port {\n"
             "    type string {\n"
             "      length \"min .. 20 | 50\";\n"


### PR DESCRIPTION
Make adding empty lines into YANG output more readable/visible in the code and try to (more) unify output with pyang.