### PR TITLE
Testing multiple/chained error messages

### DIFF
--- a/tests/utests/basic/test_context.c
+++ b/tests/utests/basic/test_context.c
@@ -237,7 +237,8 @@ test_models(void **state)
     assert_int_equal(LY_EVALID, lys_parse_in(UTEST_LYCTX, in, LYS_IN_YANG, NULL, NULL, &unres.creating, &mod1));
     lys_unres_glob_erase(&unres);
     ly_in_free(in, 0);
-    CHECK_LOG_CTX("Name collision between module and submodule of name \"y\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"y\" failed.", NULL,
+            "Name collision between module and submodule of name \"y\".", "Line number 1.");
 
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("module a {namespace urn:a;prefix a;include y;revision 2018-10-30; }", &in));
     assert_int_equal(LY_SUCCESS, lys_parse_in(UTEST_LYCTX, in, LYS_IN_YANG, NULL, NULL, &unres.creating, &mod1));
@@ -246,7 +247,8 @@ test_models(void **state)
     assert_int_equal(LY_EVALID, lys_parse_in(UTEST_LYCTX, in, LYS_IN_YANG, NULL, NULL, &unres.creating, &mod1));
     lys_unres_glob_erase(&unres);
     ly_in_free(in, 0);
-    CHECK_LOG_CTX("Name collision between module and submodule of name \"y\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"y\" failed.", NULL,
+            "Name collision between module and submodule of name \"y\".", "Line number 1.");
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule y {belongs-to b {prefix b;}}");
     assert_int_equal(LY_SUCCESS, ly_in_new_memory("module b {namespace urn:b;prefix b;include y;}", &in));
@@ -254,7 +256,9 @@ test_models(void **state)
     lys_unres_glob_revert(UTEST_LYCTX, &unres);
     lys_unres_glob_erase(&unres);
     ly_in_free(in, 0);
-    CHECK_LOG_CTX("Including \"y\" submodule into \"b\" failed.", NULL,
+    CHECK_LOG_CTX("Parsing module \"b\" failed.", NULL,
+            "Including \"y\" submodule into \"b\" failed.", NULL,
+            "Parsing submodule failed.", NULL,
             "Name collision between submodules of name \"y\".", "Line number 1.");
 
     /* selecting correct revision of the submodules */

--- a/tests/utests/node/list.c
+++ b/tests/utests/node/list.c
@@ -169,8 +169,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"max-elements\".",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Invalid value \"-1\" of \"max-elements\".", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_0", "list user {"
             "key uid;"
@@ -181,8 +181,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Value \"4294967298\" is out of \"max-elements\" bounds.",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Value \"4294967298\" is out of \"max-elements\" bounds.", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_0", "list user {"
             "key uid;"
@@ -193,8 +193,7 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("List min-elements 20 is bigger than max-elements 10.",
-            "/TERR_0:user");
+    CHECK_LOG_CTX("List min-elements 20 is bigger than max-elements 10.", "/TERR_0:user");
 
     schema = MODULE_CREATE_YANG("TERR_0", "list user {"
             "key uid;"
@@ -205,8 +204,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"min-elements\".",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Invalid value \"-1\" of \"min-elements\".", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_0", "list user {"
             "key uid;"
@@ -216,8 +215,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Duplicate keyword \"key\".",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Duplicate keyword \"key\".", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("T6", "list user {"
             "config false;"
@@ -283,8 +282,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"systeme\" of \"ordered-by\".",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERROR0\" failed.", NULL,
+            "Invalid value \"systeme\" of \"ordered-by\".", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERROR0", "list \"\" {"
             "key uid;"
@@ -295,8 +294,8 @@ test_schema_yang(void **state)
             "leaf group{type string;}"
             "}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Statement argument is required.",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERROR0\" failed.", NULL,
+            "Statement argument is required.", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("T9", "list user {"
             "key uid;"
@@ -390,8 +389,7 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"><type name=\"string\"/></leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("The list's key \"u<id\" not found.",
-            "/T00:user");
+    CHECK_LOG_CTX("The list's key \"u<id\" not found.", "/T00:user");
 
     schema = MODULE_CREATE_YIN("T1", "<list name=\"user\"> "
             "   <key value=\"uid\"/>"
@@ -500,8 +498,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"uid\"> <type name=\"int32\"> </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"value\" attribute in \"max-elements\" element.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Invalid value \"-1\" of \"value\" attribute in \"max-elements\" element.", "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_0",
             "<list name=\"user\">"
@@ -513,8 +511,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"> <type name=\"string\"/>  </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Value \"4294967298\" of \"value\" attribute in \"max-elements\" element is out of bounds.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Value \"4294967298\" of \"value\" attribute in \"max-elements\" element is out of bounds.", "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_0",
             "<list name=\"user\">"
@@ -526,8 +524,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"> <type name=\"string\"/> </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid combination of min-elements and max-elements: min value 20 is bigger than the max value 10.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Invalid combination of min-elements and max-elements: min value 20 is bigger than the max value 10.", "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_0",
             "<list name=\"user\">"
@@ -539,8 +537,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"> <type name=\"string\"/> </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Value \"-1\" of \"value\" attribute in \"min-elements\" element is out of bounds.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Value \"-1\" of \"value\" attribute in \"min-elements\" element is out of bounds.", "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_0",
             "<list name=\"user\">"
@@ -551,8 +549,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"> <type name=\"string\"/> </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Redefinition of \"key\" sub-element in \"list\" element.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_0\" failed.", NULL,
+            "Redefinition of \"key\" sub-element in \"list\" element.", "Line number 10.");
 
     schema = MODULE_CREATE_YIN("T6",
             "<list name=\"user\">"
@@ -622,7 +620,8 @@ test_schema_yin(void **state)
             "   <leaf name=\"group\"><type name=\"string\"/> </leaf>"
             "</list>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"systeme\" of \"value\" attribute in \"ordered-by\" element. Valid values are \"system\" and \"user\".",
+    CHECK_LOG_CTX("Parsing module \"TERROR0\" failed.", NULL,
+            "Invalid value \"systeme\" of \"value\" attribute in \"ordered-by\" element. Valid values are \"system\" and \"user\".",
             "Line number 10.");
 
     schema = MODULE_CREATE_YIN("T_DEFS1",

--- a/tests/utests/schema/test_parser_yang.c
+++ b/tests/utests/schema/test_parser_yang.c
@@ -702,12 +702,12 @@ test_module(void **state)
     ly_ctx_set_module_imp_clb(YCTX->parsed_mod->mod->ctx, test_imp_clb, "module xxx { namespace urn:xxx; prefix x;}");
     in.current = "module" SCHEMA_BEGINNING "include xxx;}";
     assert_int_equal(lys_parse_mem(YCTX->parsed_mod->mod->ctx, in.current, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG_CTX("Including \"xxx\" submodule into \"name\" failed.", NULL);
+    CHECK_LOG_CTX("Parsing module \"name\" failed.", NULL, "Including \"xxx\" submodule into \"name\" failed.", NULL);
 
     ly_ctx_set_module_imp_clb(YCTX->parsed_mod->mod->ctx, test_imp_clb, "submodule xxx {belongs-to wrong-name {prefix w;}}");
     in.current = "module" SCHEMA_BEGINNING "include xxx;}";
     assert_int_equal(lys_parse_mem(YCTX->parsed_mod->mod->ctx, in.current, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG_CTX("Including \"xxx\" submodule into \"name\" failed.", NULL);
+    CHECK_LOG_CTX("Parsing module \"name\" failed.", NULL, "Including \"xxx\" submodule into \"name\" failed.", NULL);
 
     ly_ctx_set_module_imp_clb(YCTX->parsed_mod->mod->ctx, test_imp_clb, "submodule xxx {belongs-to name {prefix x;}}");
     TEST_GENERIC("include xxx;}", mod->includes,

--- a/tests/utests/schema/test_schema.c
+++ b/tests/utests/schema/test_schema.c
@@ -18,6 +18,7 @@
 
 #include "log.h"
 #include "parser_schema.h"
+#include "set.h"
 #include "tree_schema.h"
 
 LY_ERR

--- a/tests/utests/schema/test_schema.h
+++ b/tests/utests/schema/test_schema.h
@@ -23,7 +23,7 @@
 #include "tests_config.h"
 
 LY_ERR test_imp_clb(const char *UNUSED(mod_name), const char *UNUSED(mod_rev), const char *UNUSED(submod_name),
-        const char *UNUSED(sub_rev), void *user_data, LYS_INFORMAT *format,
+        const char *UNUSED(sub_rev), void *user_data, LYS_INFORMAT * format,
         const char **module_data, void (**free_module_data)(void *model_data, void *user_data));
 
 #define TEST_YANG_MODULE_10(MOD_NAME, MOD_PREFIX, MOD_NS, CONTENT) \

--- a/tests/utests/schema/test_schema_common.c
+++ b/tests/utests/schema/test_schema_common.c
@@ -15,6 +15,7 @@
 
 #include <string.h>
 
+#include "compat.h"
 #include "context.h"
 #include "log.h"
 #include "tree_edit.h"
@@ -221,61 +222,80 @@ test_collision_typedef(void **state)
     /* collision with a built-in type */
     str = "module a {namespace urn:a; prefix a; typedef binary {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"binary\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"binary\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef bits {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"bits\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"bits\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef boolean {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"boolean\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"boolean\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef decimal64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"decimal64\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"decimal64\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef empty {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"empty\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"empty\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef enumeration {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"enumeration\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"enumeration\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int8 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"int8\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"int8\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int16 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"int16\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"int16\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int32 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"int32\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"int32\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef int64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"int64\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"int64\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef instance-identifier {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"instance-identifier\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"instance-identifier\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef identityref {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"identityref\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"identityref\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef leafref {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"leafref\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"leafref\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef string {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"string\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"string\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef union {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"union\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"union\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint8 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"uint8\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"uint8\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint16 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"uint16\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"uint16\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint32 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"uint32\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"uint32\" of typedef statement - name collision with a built-in type.", NULL);
     str = "module a {namespace urn:a; prefix a; typedef uint64 {type string;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"uint64\" of typedef statement - name collision with a built-in type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"uint64\" of typedef statement - name collision with a built-in type.", NULL);
 
     str = "module mytypes {namespace urn:types; prefix t; typedef binary_ {type string;} typedef bits_ {type string;} typedef boolean_ {type string;} "
             "typedef decimal64_ {type string;} typedef empty_ {type string;} typedef enumeration_ {type string;} typedef int8_ {type string;} typedef int16_ {type string;}"
@@ -287,29 +307,34 @@ test_collision_typedef(void **state)
     /* collision in node's scope */
     str = "module a {namespace urn:a; prefix a; container c {typedef y {type int8;} typedef y {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"y\" of typedef statement - name collision with sibling type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"y\" of typedef statement - name collision with sibling type.", NULL);
 
     /* collision with parent node */
     str = "module a {namespace urn:a; prefix a; container c {container d {typedef y {type int8;}} typedef y {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"y\" of typedef statement - name collision with another scoped type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"y\" of typedef statement - name collision with another scoped type.", NULL);
 
     /* collision with module's top-level */
     str = "module a {namespace urn:a; prefix a; typedef x {type string;} container c {typedef x {type int8;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
 
     /* collision of submodule's node with module's top-level */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} container c {typedef x {type string;}}}");
     str = "module a {namespace urn:a; prefix a; include b; typedef x {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
 
     /* collision of module's node with submodule's top-level */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} typedef x {type int8;}}");
     str = "module a {namespace urn:a; prefix a; include b; container c {typedef x {type string;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of typedef statement - scoped type collide with a top-level type.", NULL);
 
     /* collision of submodule's node with another submodule's top-level */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -317,25 +342,29 @@ test_collision_typedef(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} container c {typedef g {type int;}}}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of typedef statement - scoped type collide with a top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of typedef statement - scoped type collide with a top-level type.", NULL);
 
     /* collision of module's top-levels */
     str = "module a {namespace urn:a; prefix a; typedef test {type string;} typedef test {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"test\" of typedef statement - name collision with another top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"test\" of typedef statement - name collision with another top-level type.", NULL);
 
     /* collision of submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} typedef g {type int;} typedef g {type int;}}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of typedef statement - name collision with another top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of typedef statement - name collision with another top-level type.", NULL);
 
     /* collision of module's top-level with submodule's top-levels */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} typedef x {type string;}}");
     str = "module a {namespace urn:a; prefix a; include b; typedef x {type int8;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of typedef statement - name collision with another top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of typedef statement - name collision with another top-level type.", NULL);
 
     /* collision of submodule's top-level with another submodule's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -343,12 +372,14 @@ test_collision_typedef(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} typedef g {type int;}}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of typedef statement - name collision with another top-level type.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of typedef statement - name collision with another top-level type.", NULL);
 
     /* error in type-stmt */
     str = "module a {namespace urn:a; prefix a; container c {typedef x {type t{}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_STRING(_UC->err_msg, "Unexpected end-of-input.");
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Unexpected end-of-input.", "Line number 1.");
     UTEST_LOG_CLEAN;
 
     /* no collision if the same names are in different scope */
@@ -370,29 +401,34 @@ test_collision_grouping(void **state)
     /* collision in node's scope */
     str = "module a {namespace urn:a; prefix a; container c {grouping y; grouping y;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"y\" of grouping statement - name collision with sibling grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"y\" of grouping statement - name collision with sibling grouping.", NULL);
 
     /* collision with parent node */
     str = "module a {namespace urn:a; prefix a; container c {container d {grouping y;} grouping y;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"y\" of grouping statement - name collision with another scoped grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"y\" of grouping statement - name collision with another scoped grouping.", NULL);
 
     /* collision with module's top-level */
     str = "module a {namespace urn:a; prefix a; grouping x; container c {grouping x;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
 
     /* collision of submodule's node with module's top-level */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} container c {grouping x;}}");
     str = "module a {namespace urn:a; prefix a; include b; grouping x;}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
 
     /* collision of module's node with submodule's top-level */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} grouping x;}");
     str = "module a {namespace urn:a; prefix a; include b; container c {grouping x;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
 
     /* collision of submodule's node with another submodule's top-level */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -400,25 +436,29 @@ test_collision_grouping(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} container c {grouping g;}}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
 
     /* collision of module's top-levels */
     str = "module a {namespace urn:a; prefix a; grouping test; grouping test;}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"test\" of grouping statement - name collision with another top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"test\" of grouping statement - name collision with another top-level grouping.", NULL);
 
     /* collision of submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} grouping g; grouping g;}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of grouping statement - name collision with another top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of grouping statement - name collision with another top-level grouping.", NULL);
 
     /* collision of module's top-level with submodule's top-levels */
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule b {belongs-to a {prefix a;} grouping x;}");
     str = "module a {namespace urn:a; prefix a; include b; grouping x;}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"x\" of grouping statement - name collision with another top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"x\" of grouping statement - name collision with another top-level grouping.", NULL);
 
     /* collision of submodule's top-level with another submodule's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -426,17 +466,20 @@ test_collision_grouping(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} grouping g;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of grouping statement - name collision with another top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of grouping statement - name collision with another top-level grouping.", NULL);
 
     /* collision in nested groupings, top-level */
     str = "module a {namespace urn:a; prefix a; grouping g {grouping g;}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"g\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of grouping statement - scoped grouping collide with a top-level grouping.", NULL);
 
     /* collision in nested groupings, in node */
     str = "module a {namespace urn:a; prefix a; container c {grouping g {grouping g;}}}";
     assert_int_equal(lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL), LY_EVALID);
-    CHECK_LOG("Duplicate identifier \"g\" of grouping statement - name collision with another scoped grouping.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of grouping statement - name collision with another scoped grouping.", NULL);
 
     /* no collision if the same names are in different scope */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a;"
@@ -457,21 +500,24 @@ test_collision_identity(void **state)
     /* collision of module's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; identity g; identity g;}";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
 
     /* collision of submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} identity g; identity g;}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
 
     /* collision of module's top-level with submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} identity g;}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; identity g;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
 
     /* collision of submodule's top-level with another submodule's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -479,7 +525,8 @@ test_collision_identity(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} identity g;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of identity statement - name collision with another top-level identity.", NULL);
 }
 
 void
@@ -495,21 +542,24 @@ test_collision_feature(void **state)
     /* collision of module's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; feature g; feature g;}";
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
 
     /* collision of submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} feature g; feature g;}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
 
     /* collision of module's top-level with submodule's top-levels */
     submod = "submodule asub {belongs-to a {prefix a;} feature g;}";
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; feature g;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, submod);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
 
     /* collision of submodule's top-level with another submodule's top-levels */
     str = "module a {yang-version 1.1; namespace urn:a; prefix a; include asub; include bsub;}";
@@ -517,7 +567,8 @@ test_collision_feature(void **state)
     list[1].data = "submodule bsub {belongs-to a {prefix a;} feature g;}";
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, module_clb, list);
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, str, LYS_IN_YANG, NULL));
-    CHECK_LOG("Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
+    CHECK_LOG_CTX("Parsing module \"a\" failed.", NULL,
+            "Duplicate identifier \"g\" of feature statement - name collision with another top-level feature.", NULL);
 }
 
 void
@@ -908,10 +959,13 @@ test_includes(void **state)
         assert_null(mod);
         CHECK_LOG_CTX("Loading \"main_b\" module failed.", NULL,
                 "Data model \"main_b\" not found in local searchdirs.", NULL,
+                "Parsing module \"main_b\" failed.", NULL,
                 "Including \"sub_b_one\" submodule into \"main_b\" failed.", NULL,
                 "Data model \"sub_b_one\" not found in local searchdirs.", NULL,
+                "Parsing submodule \"sub_b_one\" failed.", NULL,
                 "YANG 1.1 requires all submodules to be included from main module. But submodule \"sub_b_one\" includes "
-                "submodule \"sub_b_two\" which is not included by main module \"main_b\".", NULL);
+                "submodule \"sub_b_two\" which is not included by main module \"main_b\".", NULL,
+                "YANG version 1.1 expects all includes in main module, includes in submodules (sub_b_one) are not necessary.", NULL);
     }
 
     {

--- a/tests/utests/schema/test_schema_stmts.c
+++ b/tests/utests/schema/test_schema_stmts.c
@@ -72,7 +72,7 @@ test_identity(void **state)
     assert_string_equal(mod->parsed->identities[0].name, "ident-name");
 
     /* invalid substatement */
-    TEST_SCHEMA_ERR(0, 1, "inv", "<identity name=\"ident-name\"><if-feature name=\"iff\"/></identity>",
+    TEST_SCHEMA_PARSE_ERR(0, 1, "inv", "<identity name=\"ident-name\"><if-feature name=\"iff\"/></identity>",
             "Invalid sub-elemnt \"if-feature\" of \"identity\" element - "
             "this sub-element is allowed only in modules with version 1.1 or newer.", "Line number 1.");
 
@@ -185,7 +185,7 @@ test_feature(void **state)
     assert_string_equal(mod->parsed->features[0].name, "feature-name");
 
     /* invalid substatement */
-    TEST_SCHEMA_ERR(0, 1, "inv", "<feature name=\"feature-name\"><organization><text>org</text></organization></feature>",
+    TEST_SCHEMA_PARSE_ERR(0, 1, "inv", "<feature name=\"feature-name\"><organization><text>org</text></organization></feature>",
             "Unexpected sub-element \"organization\" of \"feature\" element.", "Line number 1.");
 
     /*
@@ -208,37 +208,37 @@ test_feature(void **state)
     }
 
     /* some invalid expressions */
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f{if-feature f1;}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f{if-feature f1;}",
             "Invalid value \"f1\" of if-feature - unable to find feature \"f1\".", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f2{if-feature 'f and';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f2{if-feature 'f and';}",
             "Invalid value \"f and\" of if-feature - unexpected end of expression.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f{if-feature 'or';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f{if-feature 'or';}",
             "Invalid value \"or\" of if-feature - unexpected end of expression.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f2{if-feature '(f1';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f2{if-feature '(f1';}",
             "Invalid value \"(f1\" of if-feature - non-matching opening and closing parentheses.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f2{if-feature 'f1)';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f2{if-feature 'f1)';}",
             "Invalid value \"f1)\" of if-feature - non-matching opening and closing parentheses.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f2{if-feature ---;}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f2{if-feature ---;}",
             "Invalid value \"---\" of if-feature - unable to find feature \"---\".", NULL);
-    TEST_SCHEMA_ERR(0, 0, "inv", "feature f1; feature f2{if-feature 'not f1';}",
+    TEST_SCHEMA_PARSE_ERR(0, 0, "inv", "feature f1; feature f2{if-feature 'not f1';}",
             "Invalid value \"not f1\" of if-feature - YANG 1.1 expression in YANG 1.0 module.", NULL);
 
     ly_ctx_set_module_imp_clb(UTEST_LYCTX, test_imp_clb, "submodule inv_sub {belongs-to inv {prefix inv;} feature f1;}");
-    TEST_SCHEMA_ERR(0, 0, "inv", "feature f1 {if-feature f2;} feature f2 {if-feature f1;}",
+    TEST_SCHEMA_PARSE_ERR(0, 0, "inv", "feature f1 {if-feature f2;} feature f2 {if-feature f1;}",
             "Feature \"f1\" is indirectly referenced from itself.", NULL);
-    TEST_SCHEMA_ERR(0, 0, "inv", "feature f1 {if-feature f1;}",
+    TEST_SCHEMA_PARSE_ERR(0, 0, "inv", "feature f1 {if-feature f1;}",
             "Feature \"f1\" is referenced from itself.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f {if-feature ();}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f {if-feature ();}",
             "Invalid value \"()\" of if-feature - number of features in expression does not match the required number of operands for the operations.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1(';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1(';}",
             "Invalid value \"f1(\" of if-feature - non-matching opening and closing parentheses.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'and f1';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'and f1';}",
             "Invalid value \"and f1\" of if-feature - missing feature/expression before \"and\" operation.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1 not ';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1 not ';}",
             "Invalid value \"f1 not \" of if-feature - unexpected end of expression.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1 not not ';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f {if-feature 'f1 not not ';}",
             "Invalid value \"f1 not not \" of if-feature - unexpected end of expression.", NULL);
-    TEST_SCHEMA_ERR(1, 0, "inv", "feature f1; feature f2; feature f {if-feature 'or f1 f2';}",
+    TEST_SCHEMA_PARSE_ERR(1, 0, "inv", "feature f1; feature f2; feature f {if-feature 'or f1 f2';}",
             "Invalid value \"or f1 f2\" of if-feature - missing feature/expression before \"or\" operation.", NULL);
 
     /*

--- a/tests/utests/schema/test_tree_schema_compile.c
+++ b/tests/utests/schema/test_tree_schema_compile.c
@@ -543,7 +543,8 @@ test_node_anydata(void **state)
 
     /* invalid */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;anydata any;}", LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Invalid keyword \"anydata\" as a child of \"module\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid keyword \"anydata\" as a child of \"module\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
 }
 
 static void
@@ -577,7 +578,8 @@ test_action(void **state)
     /* invalid */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;container top {action x;}}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Invalid keyword \"action\" as a child of \"container\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid keyword \"action\" as a child of \"container\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
 
     assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb;leaf x{type string;} rpc x;}",
             LYS_IN_YANG, NULL));
@@ -647,7 +649,8 @@ test_notification(void **state)
     /* invalid */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa;container top {notification x;}}",
             LYS_IN_YANG, NULL));
-    CHECK_LOG_CTX("Invalid keyword \"notification\" as a child of \"container\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid keyword \"notification\" as a child of \"container\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
 
     assert_int_equal(LY_EEXIST, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb;leaf x{type string;} notification x;}", LYS_IN_YANG, NULL));
     CHECK_LOG_CTX("Duplicate identifier \"x\" of data definition/RPC/action/notification statement.", "/bb:x");
@@ -1148,25 +1151,32 @@ test_type_enum(void **state)
     /* invalid cases */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; feature f; leaf l {type enumeration {"
             "enum one {if-feature f;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid keyword \"if-feature\" as a child of \"enum\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid keyword \"if-feature\" as a child of \"enum\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum one {value -2147483649;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"-2147483649\" of \"value\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"-2147483649\" of \"value\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum one {value 2147483648;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"2147483648\" of \"value\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"2147483648\" of \"value\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum one; enum one;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Duplicate identifier \"one\" of enum statement.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Duplicate identifier \"one\" of enum statement.", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum '';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Enum name must not be zero-length.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Enum name must not be zero-length.", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum ' x';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Enum name must not have any leading or trailing whitespaces (\" x\").", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Enum name must not have any leading or trailing whitespaces (\" x\").", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum 'x ';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Enum name must not have any leading or trailing whitespaces (\"x \").", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Enum name must not have any leading or trailing whitespaces (\"x \").", "Line number 1.");
     assert_int_equal(LY_SUCCESS, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type enumeration {"
             "enum 'inva\nlid';}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Control characters in enum name should be avoided (\"inva\nlid\", character number 5).", NULL);
@@ -1244,44 +1254,56 @@ test_type_bits(void **state)
     /* invalid cases */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; feature f; leaf l {type bits {"
             "bit one {if-feature f;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid keyword \"if-feature\" as a child of \"bit\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid keyword \"if-feature\" as a child of \"bit\" - the statement is allowed only in YANG 1.1 modules.", "Line number 1.");
 
 #if 0
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
             "bit one {position -1;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"position\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"-1\" of \"position\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
             "bit one {position 4294967296;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"4294967296\" of \"position\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"4294967296\" of \"position\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
             "bit one; bit one;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Duplicate identifier \"one\" of bit statement.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Duplicate identifier \"one\" of bit statement.", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
             "bit '11';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid identifier first character '1' (0x0031).", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid identifier first character '1' (0x0031).", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type bits {"
             "bit 'x1$1';}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid identifier character '$' (0x0024).", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid identifier character '$' (0x0024).", "Line number 1.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module bb {namespace urn:bb;prefix bb; leaf l {type bits;}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Missing bit substatement for bits type.", "/bb:l");
+    CHECK_LOG_CTX("Parsing module \"bb\" failed.", NULL,
+            "Missing bit substatement for bits type.", "/bb:l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module cc {yang-version 1.1;namespace urn:cc;prefix cc;typedef mytype {type bits {bit one;}}"
             "leaf l {type mytype {bit two;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid bits - derived type adds new item \"two\".", "/cc:l");
+    CHECK_LOG_CTX("Parsing module \"cc\" failed.", NULL,
+            "Invalid bits - derived type adds new item \"two\".", "/cc:l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module dd {yang-version 1.1;namespace urn:dd;prefix dd;typedef mytype {type bits {bit one;}}"
             "leaf l {type mytype {bit one {position 1;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid bits - position of the item \"one\" has changed from 0 to 1 in the derived type.", "/dd:l");
+    CHECK_LOG_CTX("Parsing module \"dd\" failed.", NULL,
+            "Invalid bits - position of the item \"one\" has changed from 0 to 1 in the derived type.", "/dd:l");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;leaf l {type bits {bit x {position 4294967295;}bit y;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid bits - it is not possible to auto-assign bit position for \"y\" since the highest value is already 4294967295.", "/ee:l");
+    CHECK_LOG_CTX("Parsing module \"ee\" failed.", NULL,
+            "Invalid bits - it is not possible to auto-assign bit position for \"y\" since the highest value is already 4294967295.", "/ee:l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ff {namespace urn:ff;prefix ff;leaf l {type bits {bit x {position 1;}bit y {position 1;}}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid bits - position 1 collide in items \"y\" and \"x\".", "/ff:l");
+    CHECK_LOG_CTX("Parsing module \"ff\" failed.", NULL,
+            "Invalid bits - position 1 collide in items \"y\" and \"x\".", "/ff:l");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module gg {namespace urn:gg;prefix gg;typedef mytype {type bits;}"
             "leaf l {type mytype {bit one;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Missing bit substatement for bits type mytype.", "/gg:l");
+    CHECK_LOG_CTX("Parsing module \"gg\" failed.", NULL,
+            "Missing bit substatement for bits type mytype.", "/gg:l");
 #endif
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module hh {namespace urn:hh;prefix hh; typedef mytype {type bits {bit one;}}"
@@ -1337,11 +1359,14 @@ test_type_dec64(void **state)
 
     /* invalid cases */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type decimal64 {fraction-digits 0;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"0\" of \"fraction-digits\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"0\" of \"fraction-digits\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type decimal64 {fraction-digits -1;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"fraction-digits\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"-1\" of \"fraction-digits\".", "Line number 1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type decimal64 {fraction-digits 19;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Value \"19\" is out of \"fraction-digits\" bounds.", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Value \"19\" is out of \"fraction-digits\" bounds.", "Line number 1.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type decimal64;}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Missing fraction-digits substatement for decimal64 type.", "/aa:l");
@@ -1399,7 +1424,8 @@ test_type_instanceid(void **state)
 
     /* invalid cases */
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type instance-identifier {require-instance yes;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid value \"yes\" of \"require-instance\".", "Line number 1.");
+    CHECK_LOG_CTX("Parsing module \"aa\" failed.", NULL,
+            "Invalid value \"yes\" of \"require-instance\".", "Line number 1.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module aa {namespace urn:aa;prefix aa; leaf l {type instance-identifier {fraction-digits 1;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid type restrictions for instance-identifier type.", "/aa:l");
@@ -1692,7 +1718,8 @@ test_type_leafref(void **state)
     CHECK_LOG_CTX("List predicate defined for container \"a\" in path.", "Schema location /dd:ref1.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ee {namespace urn:ee;prefix ee;\n  container a {leaf target2 {type uint8;}}\n"
             "leaf ref1 {type leafref {path /a!invalid;}}}", LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x21 ('!'), perhaps \"a\" is supposed to be a function call.", "Line number 3.");
+    CHECK_LOG_CTX("Parsing module \"ee\" failed.", NULL,
+            "Invalid character 0x21 ('!'), perhaps \"a\" is supposed to be a function call.", "Line number 3.");
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ff {namespace urn:ff;prefix ff;container a {leaf target2 {type uint8;}}"
             "leaf ref1 {type leafref {path /a;}}}", LYS_IN_YANG, &mod));
     CHECK_LOG_CTX("Invalid leafref path \"/a\" - target node is container instead of leaf or leaf-list.", "Schema location /ff:ref1.");
@@ -1721,14 +1748,16 @@ test_type_leafref(void **state)
             "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
             "leaf address {type leafref{\n path \"/interface[name is current()/../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x69 ('i'), perhaps \"name\" is supposed to be a function call.", "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"nn\" failed.", NULL,
+            "Invalid character 0x69 ('i'), perhaps \"name\" is supposed to be a function call.", "Line number 5.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module oo {namespace urn:oo;prefix oo;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}\n"
             "leaf address {type leafref{\n path \"/interface[name=current()/../ifname/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath expression end.", "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"oo\" failed.", NULL,
+            "Unexpected XPath expression end.", "Line number 5.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module pp {namespace urn:pp;prefix pp;"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}"
@@ -1749,49 +1778,56 @@ test_type_leafref(void **state)
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name=current() /  .. / ifname][name=current()/../test]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Duplicate predicate key \"name\" in path.", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"rr\" failed.", NULL,
+            "Duplicate predicate key \"name\" in path.", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ss {namespace urn:ss;prefix ss;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = ../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"FunctionName\".", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"ss\" failed.", NULL,
+            "Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"FunctionName\".", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module tt {namespace urn:tt;prefix tt;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()../ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"]\".", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"tt\" failed.", NULL,
+            "Unexpected XPath token \"..\" (\"../ifname]/ip\"), expected \"]\".", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module uu {namespace urn:uu;prefix uu;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/..ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 'i'[31] of expression '/interface[name = current()/..ifname]/ip'.", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"uu\" failed.", NULL,
+            "Invalid character 'i'[31] of expression '/interface[name = current()/..ifname]/ip'.", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module vv {namespace urn:vv;prefix vv;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/ifname]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"NameTest\" (\"ifname]/ip\"), expected \"..\".", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"vv\" failed.", NULL,
+            "Unexpected XPath token \"NameTest\" (\"ifname]/ip\"), expected \"..\".", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module ww {namespace urn:ww;prefix ww;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/../]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Unexpected XPath token \"]\" (\"]/ip\").", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"ww\" failed.", NULL,
+            "Unexpected XPath token \"]\" (\"]/ip\").", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module xx {namespace urn:xx;prefix xx;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"
             "leaf ifname{type leafref{ path \"../interface/name\";}}leaf test{type string;}\n"
             "leaf address {type leafref{ path \"/interface[name = current()/../$node]/ip\";}}}",
             LYS_IN_YANG, &mod));
-    CHECK_LOG_CTX("Invalid character 0x24 ('$'), perhaps \"\" is supposed to be a function call.", "Line number 4.");
+    CHECK_LOG_CTX("Parsing module \"xx\" failed.", NULL,
+            "Invalid character 0x24 ('$'), perhaps \"\" is supposed to be a function call.", "Line number 4.");
 
     assert_int_equal(LY_EVALID, lys_parse_mem(UTEST_LYCTX, "module yy {namespace urn:yy;prefix yy;\n"
             "list interface{key name;leaf name{type string;}leaf ip {type string;}}\n"

--- a/tests/utests/types/bits.c
+++ b/tests/utests/types/bits.c
@@ -163,8 +163,7 @@ test_schema_yang(void **state)
             "leaf port {type my_type {"
             "   bit ten {position 11;} bit two;}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid bits - position of the item \"ten\" has changed from 10 to 11 in the derived type.",
-            "/TERR_0:port");
+    CHECK_LOG_CTX("Invalid bits - position of the item \"ten\" has changed from 10 to 11 in the derived type.", "/TERR_0:port");
 
     /* add new bit */
     schema = MODULE_CREATE_YANG("TERR_1", "typedef my_type{type bits {"
@@ -172,16 +171,15 @@ test_schema_yang(void **state)
             "leaf port {type my_type {"
             "   bit ten {position 10;} bit two;  bit test;}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid bits - derived type adds new item \"test\".",
-            "/TERR_1:port");
+    CHECK_LOG_CTX("Invalid bits - derived type adds new item \"test\".", "/TERR_1:port");
 
     /* different max value => autoadd index */
     schema = MODULE_CREATE_YANG("TERR_2", "leaf port {type bits {"
             " bit first {position -1;} bit second;"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"position\".",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_2\" failed.", NULL,
+            "Invalid value \"-1\" of \"position\".", "Line number 5.");
 
     /* different max value => autoadd index */
     schema = MODULE_CREATE_YANG("TERR_3", "leaf port {type bits {"
@@ -195,43 +193,42 @@ test_schema_yang(void **state)
             " bit first {position 10;} bit \"\";"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Statement argument is required.",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_4\" failed.", NULL,
+            "Statement argument is required.", "Line number 5.");
 
     /* wrong character */
     schema = MODULE_CREATE_YANG("TERR_5", "leaf port {type bits {"
             " bit first {position 10;} bit abcd^;"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier character '^' (0x005e).",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_5\" failed.", NULL,
+            "Invalid identifier character '^' (0x005e).", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_6", "leaf port {type bits {"
             " bit hi; bit hi;"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Duplicate identifier \"hi\" of bit statement.",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_6\" failed.", NULL,
+            "Duplicate identifier \"hi\" of bit statement.", "Line number 5.");
 
     /* wrong character */
     schema = MODULE_CREATE_YANG("TERR_7", "leaf port {type bits {"
             " bit first {position 10;} bit \"ab&cd\";"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier character '&' (0x0026).",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_7\" failed.", NULL,
+            "Invalid identifier character '&' (0x0026).", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_8", "leaf port {type bits {"
             " bit first {position 10;} bit \"4abcd\";"
             "}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier first character '4' (0x0034).",
-            "Line number 5.");
+    CHECK_LOG_CTX("Parsing module \"TERR_8\" failed.", NULL,
+            "Invalid identifier first character '4' (0x0034).", "Line number 5.");
 
     schema = MODULE_CREATE_YANG("TERR_9", "leaf port {type bits;}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Missing bit substatement for bits type.",
-            "/TERR_9:port");
+    CHECK_LOG_CTX("Missing bit substatement for bits type.", "/TERR_9:port");
 
     /* feature is not present */
     schema = MODULE_CREATE_YANG("IF_0", "feature f;"
@@ -379,8 +376,7 @@ test_schema_yin(void **state)
             "   <bit name=\"ten\"> <position value=\"11\"/> </bit> <bit name=\"two\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid bits - position of the item \"ten\" has changed from 10 to 11 in the derived type.",
-            "/TERR_0:port");
+    CHECK_LOG_CTX("Invalid bits - position of the item \"ten\" has changed from 10 to 11 in the derived type.", "/TERR_0:port");
 
     /* add new bit */
     schema = MODULE_CREATE_YIN("TERR_1",
@@ -396,8 +392,7 @@ test_schema_yin(void **state)
             "   <bit name=\"test\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid bits - derived type adds new item \"test\".",
-            "/TERR_1:port");
+    CHECK_LOG_CTX("Invalid bits - derived type adds new item \"test\".", "/TERR_1:port");
 
     /* different max value => autoadd index */
     schema = MODULE_CREATE_YIN("TERR_2",
@@ -406,8 +401,8 @@ test_schema_yin(void **state)
             "   <bit name=\"second\">"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid value \"-1\" of \"value\" attribute in \"position\" element.",
-            "Line number 10.");
+    CHECK_LOG_CTX("Parsing module \"TERR_2\" failed.", NULL,
+            "Invalid value \"-1\" of \"value\" attribute in \"position\" element.", "Line number 10.");
 
     /* different max value => autoadd index */
     schema = MODULE_CREATE_YIN("TERR_3",
@@ -425,7 +420,8 @@ test_schema_yin(void **state)
             "  <bit name=\"second\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier first character ' ' (0x0020).",
+    CHECK_LOG_CTX("Parsing module \"TERR_4\" failed.", NULL,
+            "Invalid identifier first character ' ' (0x0020).",
             "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_5",
@@ -434,7 +430,8 @@ test_schema_yin(void **state)
             "  <bit name=\"second\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier character ' ' (0x0020).",
+    CHECK_LOG_CTX("Parsing module \"TERR_5\" failed.", NULL,
+            "Invalid identifier character ' ' (0x0020).",
             "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_6",
@@ -443,7 +440,8 @@ test_schema_yin(void **state)
             "  <bit name=\"hi\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Duplicate identifier \"hi\" of bit statement.",
+    CHECK_LOG_CTX("Parsing module \"TERR_6\" failed.", NULL,
+            "Duplicate identifier \"hi\" of bit statement.",
             "Line number 10.");
 
     schema = MODULE_CREATE_YIN("TERR_7",
@@ -452,7 +450,8 @@ test_schema_yin(void **state)
             "  <bit name=\"second\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid identifier first character '4' (0x0034).",
+    CHECK_LOG_CTX("Parsing module \"TERR_7\" failed.", NULL,
+            "Invalid identifier first character '4' (0x0034).",
             "Line number 10.");
 
     /* TEST EMPTY NAME*/
@@ -462,7 +461,8 @@ test_schema_yin(void **state)
             "  <bit name=\"second\"/>"
             "</type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Empty identifier is not allowed.",
+    CHECK_LOG_CTX("Parsing module \"TERR_8\" failed.", NULL,
+            "Empty identifier is not allowed.",
             "Line number 10.");
 }
 

--- a/tests/utests/types/int8.c
+++ b/tests/utests/types/int8.c
@@ -224,26 +224,22 @@ test_schema_yang(void **state)
     /* TEST ERROR -60 .. 0 | 0 .. 127 */
     schema = MODULE_CREATE_YANG("ERR0", "leaf port {type int8 {range \"-60 .. 0 | 0 .. 127\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EEXIST);
-    CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).",
-            "/ERR0:port");
+    CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).", "/ERR0:port");
 
     /* TEST ERROR 0 .. 128 */
     schema = MODULE_CREATE_YANG("ERR1", "leaf port {type int8 {range \"0 .. 128\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.",
-            "/ERR1:port");
+    CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.", "/ERR1:port");
 
     /* TEST ERROR -129 .. 126 */
     schema = MODULE_CREATE_YANG("ERR2", "leaf port {type int8 {range \"-129 .. 0\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
-            "/ERR2:port");
+    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.", "/ERR2:port");
 
     /* TEST ERROR 0 */
     schema = MODULE_CREATE_YANG("ERR3", "leaf port {type int8 {range \"-129\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
-            "/ERR3:port");
+    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.", "/ERR3:port");
 
     /*
      * TEST MODULE SUBTYPE
@@ -733,8 +729,7 @@ test_schema_yin(void **state)
             "   <type name=\"int8\"> <range value = \"min .. 0 | 0 .. 12\"/>  </type>"
             "</leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EEXIST);
-    CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).",
-            "/TE0:port");
+    CHECK_LOG_CTX("Invalid range restriction - values are not in ascending order (0).", "/TE0:port");
 
     /* TEST ERROR 0 .. 128 */
     schema = MODULE_CREATE_YIN("TE1",
@@ -742,8 +737,7 @@ test_schema_yin(void **state)
             "   <type name=\"int8\"> <range value = \"0 .. 128\"/>  </type>"
             "</leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.",
-            "/TE1:port");
+    CHECK_LOG_CTX("Invalid range restriction - value \"128\" does not fit the type limitations.", "/TE1:port");
 
     /* TEST ERROR -129 .. 126 */
     schema = MODULE_CREATE_YIN("TE2",
@@ -751,8 +745,7 @@ test_schema_yin(void **state)
             "   <type name=\"int8\"> <range value =\"-129 .. 126\"/>  </type>"
             "</leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.",
-            "/TE2:port");
+    CHECK_LOG_CTX("Invalid range restriction - value \"-129\" does not fit the type limitations.", "/TE2:port");
 
     /* TEST YIN */
     schema = MODULE_CREATE_YIN("TS0",

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -184,18 +184,15 @@ test_schema_yang(void **state)
     /* ERROR TESTS NEGATIVE VALUE */
     schema = MODULE_CREATE_YANG("ERR0", "leaf port {type string {length \"-1 .. 20\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
-            "/ERR0:port");
+    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.", "/ERR0:port");
 
     schema = MODULE_CREATE_YANG("ERR1", "leaf port {type string {length \"100 .. 18446744073709551616\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid length restriction - invalid value \"18446744073709551616\".",
-            "/ERR1:port");
+    CHECK_LOG_CTX("Invalid length restriction - invalid value \"18446744073709551616\".", "/ERR1:port");
 
     schema = MODULE_CREATE_YANG("ERR2", "leaf port {type string {length \"10 .. 20 | 20 .. 30\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EEXIST);
-    CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).",
-            "/ERR2:port");
+    CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).", "/ERR2:port");
 
     schema = MODULE_CREATE_YANG("ERR3",
             "typedef my_type {"
@@ -203,8 +200,7 @@ test_schema_yang(void **state)
             "}"
             "leaf port {type my_type {length \"-1 .. 15\";}}");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
-            "/ERR3:port");
+    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.", "/ERR3:port");
 
     /*
      * PATTERN
@@ -437,30 +433,26 @@ test_schema_yin(void **state)
     schema = MODULE_CREATE_YIN("ERR0", "<leaf name=\"port\"> <type name=\"string\">"
             "<length value =\"-1 .. 20\"/> </type></leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
-            "/ERR0:port");
+    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.", "/ERR0:port");
 
     schema = MODULE_CREATE_YIN("ERR1", "<leaf name=\"port\"> <type name=\"string\">"
             "<length value=\"100 .. 18446744073709551616\"/>"
             "</type> </leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EVALID);
-    CHECK_LOG_CTX("Invalid length restriction - invalid value \"18446744073709551616\".",
-            "/ERR1:port");
+    CHECK_LOG_CTX("Invalid length restriction - invalid value \"18446744073709551616\".", "/ERR1:port");
 
     schema = MODULE_CREATE_YIN("ERR2", "<leaf name=\"port\">"
             "<type name=\"string\"> <length value=\"10 .. 20 | 20 .. 30\"/>"
             "</type> </leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EEXIST);
-    CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).",
-            "/ERR2:port");
+    CHECK_LOG_CTX("Invalid length restriction - values are not in ascending order (20).", "/ERR2:port");
 
     schema = MODULE_CREATE_YIN("ERR3",
             "<typedef name=\"my_type\"> <type name=\"string\"/> </typedef>"
             "<leaf name=\"port\"> <type name=\"my_type\"> <length value=\"-1 .. 15\"/>"
             "</type> </leaf>");
     UTEST_INVALID_MODULE(schema, LYS_IN_YIN, NULL, LY_EDENIED);
-    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.",
-            "/ERR3:port");
+    CHECK_LOG_CTX("Invalid length restriction - value \"-1\" does not fit the type limitations.", "/ERR3:port");
 
     /*
      * PATTERN

--- a/tests/utests/utests.h
+++ b/tests/utests/utests.h
@@ -1199,9 +1199,30 @@ struct utest_context {
         _CHECK_LOG_CTX(ly_err_last(_UC->ctx)->prev->prev->prev->prev, MSG5, PATH5)
 
 /**
+ * @brief Internal macro to check the last three libyang's context error.
+ */
+#define _CHECK_LOG_CTX6(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5, MSG6, PATH6) \
+        _CHECK_LOG_CTX5(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5); \
+        _CHECK_LOG_CTX(ly_err_last(_UC->ctx)->prev->prev->prev->prev->prev, MSG6, PATH6)
+
+/**
+ * @brief Internal macro to check the last three libyang's context error.
+ */
+#define _CHECK_LOG_CTX7(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5, MSG6, PATH6, MSG7, PATH7) \
+        _CHECK_LOG_CTX6(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5, MSG6, PATH6); \
+        _CHECK_LOG_CTX(ly_err_last(_UC->ctx)->prev->prev->prev->prev->prev->prev, MSG7, PATH7)
+
+/**
+ * @brief Internal macro to check the last three libyang's context error.
+ */
+#define _CHECK_LOG_CTX8(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5, MSG6, PATH6, MSG7, PATH7, MSG8, PATH8) \
+        _CHECK_LOG_CTX7(MSG1, PATH1, MSG2, PATH2, MSG3, PATH3, MSG4, PATH4, MSG5, PATH5, MSG6, PATH6, MSG7, PATH7); \
+        _CHECK_LOG_CTX(ly_err_last(_UC->ctx)->prev->prev->prev->prev->prev->prev->prev, MSG8, PATH8)
+
+/**
  * @brief Internal helper macro to select _CHECK_LOG_CTX* macro according to the provided parameters.
  */
-#define _GET_CHECK_LOG_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...) NAME
+#define _GET_CHECK_LOG_MACRO(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, NAME, ...) NAME
 
 /**
  * @brief Check expected error(s) in libyang context.
@@ -1214,7 +1235,8 @@ struct utest_context {
  * @param[in] PATH Expected error path.
  */
 #define CHECK_LOG_CTX(...) \
-    _GET_CHECK_LOG_MACRO(__VA_ARGS__, _CHECK_LOG_CTX5, _INVAL, _CHECK_LOG_CTX4, _INVAL, \
+    _GET_CHECK_LOG_MACRO(__VA_ARGS__, _CHECK_LOG_CTX8, _INVAL, _CHECK_LOG_CTX7, _INVAL, \
+            _CHECK_LOG_CTX6, _INVAL, _CHECK_LOG_CTX5, _INVAL, _CHECK_LOG_CTX4, _INVAL, \
             _CHECK_LOG_CTX3, _INVAL, _CHECK_LOG_CTX2, _INVAL, _CHECK_LOG_CTX1)(__VA_ARGS__); \
     ly_err_clean(_UC->ctx, NULL)
 


### PR DESCRIPTION
Use the ability of libyang to provide a chain of error messages and check for all/more the messages in unit tests.