### PR TITLE
Fix some build warnings with GCC11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ set(LIBYANG_MICRO_SOVERSION 15)
 set(LIBYANG_SOVERSION_FULL ${LIBYANG_MAJOR_SOVERSION}.${LIBYANG_MINOR_SOVERSION}.${LIBYANG_MICRO_SOVERSION})
 set(LIBYANG_SOVERSION ${LIBYANG_MAJOR_SOVERSION})
 
-set(CMAKE_C_FLAGS                "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-missing-field-initializers -std=c99")
+set(CMAKE_C_FLAGS                "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-missing-field-initializers -std=c11")
 set(CMAKE_C_FLAGS_RELEASE        "-DNDEBUG -O2")
 set(CMAKE_C_FLAGS_DEBUG          "-g3 -O0")
 set(CMAKE_C_FLAGS_ABICHECK       "-g -Og")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,17 +23,21 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Debug)
 endif()
 # normalize build type string
+# see https://github.com/CESNET/libyang/pull/1692 for why CMAKE_C_FLAGS_<type> are not used directly
 string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
 if ("${BUILD_TYPE_UPPER}" STREQUAL "RELEASE")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build Type" FORCE)
+    set(CMAKE_C_FLAGS "-DNDEBUG -O2 ${CMAKE_C_FLAGS}")
 elseif("${BUILD_TYPE_UPPER}" STREQUAL "DEBUG")
     set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build Type" FORCE)
+    set(CMAKE_C_FLAGS "-g3 -O0 ${CMAKE_C_FLAGS}")
 elseif("${BUILD_TYPE_UPPER}" STREQUAL "RELWITHDEBINFO")
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build Type" FORCE)
 elseif("${BUILD_TYPE_UPPER}" STREQUAL "RELWITHDEBUG")
     set(CMAKE_BUILD_TYPE "RelWithDebug" CACHE STRING "Build Type" FORCE)
 elseif("${BUILD_TYPE_UPPER}" STREQUAL "ABICHECK")
     set(CMAKE_BUILD_TYPE "ABICheck" CACHE STRING "Build Type" FORCE)
+    set(CMAKE_C_FLAGS "-g -Og ${CMAKE_C_FLAGS}")
 elseif("${BUILD_TYPE_UPPER}" STREQUAL "DOCONLY")
     set(CMAKE_BUILD_TYPE "DocOnly" CACHE STRING "Build Type" FORCE)
 endif()
@@ -68,9 +72,6 @@ set(LIBYANG_SOVERSION_FULL ${LIBYANG_MAJOR_SOVERSION}.${LIBYANG_MINOR_SOVERSION}
 set(LIBYANG_SOVERSION ${LIBYANG_MAJOR_SOVERSION})
 
 set(CMAKE_C_FLAGS                "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-missing-field-initializers -std=c11")
-set(CMAKE_C_FLAGS_RELEASE        "-DNDEBUG -O2")
-set(CMAKE_C_FLAGS_DEBUG          "-g3 -O0")
-set(CMAKE_C_FLAGS_ABICHECK       "-g -Og")
 
 include_directories(${PROJECT_BINARY_DIR}/src ${PROJECT_SOURCE_DIR}/src)
 

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -896,7 +896,7 @@ ly_time_ts2str(const struct timespec *ts, char **str)
 {
     char frac_buf[10];
 
-    LY_CHECK_ARG_RET(NULL, ts, str, ts->tv_nsec <= 999999999, LY_EINVAL);
+    LY_CHECK_ARG_RET(NULL, ts, str, ((ts->tv_nsec <= 999999999) && (ts->tv_nsec >= 0)), LY_EINVAL);
 
     /* convert nanoseconds to fractions of a second */
     if (ts->tv_nsec) {


### PR DESCRIPTION
## ly_time_ts2str: check against a negative value as well
    
This was found by GCC11:
    
```
[11/205] Building C object CMakeFiles/yangobj.dir/src/tree_data_helpers.c.o
/home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_data_helpers.c: In function ‘ly_time_ts2str’:
/home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_data_helpers.c:903:28: warning: ‘%09ld’ directive writing between 9 and 20 bytes into a region of size 10 [-Wformat-overflow=]
  903 |         sprintf(frac_buf, "%09ld", ts->tv_nsec);
      |                            ^~~~~
/home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_data_helpers.c:903:27: note: directive argument in the range [-9223372036854775808, 999999999]
  903 |         sprintf(frac_buf, "%09ld", ts->tv_nsec);
      |                           ^~~~~~~
In file included from /nix/store/iwd8ic5hhwdxn5dga0im55g5hjl270cd-glibc-2.33-47-dev/include/stdio.h:866,
                 from /home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_schema.h:23,
                 from /home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_data.h:31,
                 from /home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/context.h:22,
                 from /home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/common.h:23,
                 from /home/jkt/work/cesnet/gerrit/github/CESNET/libyang/src/tree_data_helpers.c:24:
/nix/store/iwd8ic5hhwdxn5dga0im55g5hjl270cd-glibc-2.33-47-dev/include/bits/stdio2.h:38:10: note: ‘__builtin___sprintf_chk’ output between 10 and 21 bytes into a destination of size 10
   38 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   39 |                                   __glibc_objsize (__s), __fmt,
      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   40 |                                   __va_arg_pack ());
      |                                   ~~~~~~~~~~~~~~~~~
```
## tests: fix warnings about unused variables

## build: Enable some optimizations even in a debug build
    
My distribution sets `_FORTIFY_SOURCE`, and the glibc headers issue a warning when optimizations are completely disabled. Apart from that, even the GCC manual suggests to use `-Og` instead of `-O0` for debugging.

## build: Require C11
    
This project uses anonymous structs, and modern versions of GCC and clang both warn about these unless the C standard version is properly set.
    
For some reason I was getting these warnings even though the CMakeLists.txt tries to set the `-std=` parameter manually. Let's use a native CMake feature for this.