### PR TITLE
lydjson_data_skip object key-value pair parsing fix

### DIFF
--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -303,8 +303,6 @@ lydjson_data_skip(struct lyjson_ctx *jsonctx)
             sublevels++;
         } else if ((status == LYJSON_OBJECT) && (current == LYJSON_OBJECT_CLOSED)) {
             sublevels--;
-        } else if ((status == LYJSON_ARRAY) && (current == LYJSON_ARRAY_CLOSED)) {
-            sublevels--;
         }
     } while (current != status + 1 || sublevels);
     /* open the next sibling */

--- a/tests/fuzz/corpus/lyd_parse_mem_json/pull1696_1
+++ b/tests/fuzz/corpus/lyd_parse_mem_json/pull1696_1
@@ -1,0 +1,1 @@
+{"types:cont":{"leaflt30,1,10,2]xxnt32":1,"types:uint":1,"types:uinis2":922337203685477}}

--- a/tests/fuzz/corpus/lyd_parse_mem_json/pull1696_2
+++ b/tests/fuzz/corpus/lyd_parse_mem_json/pull1696_2
@@ -1,0 +1,1 @@
+{"types:cont":{"leaflt30,1,GGGGGGGGGGGGGGGGGGGGGGGGGGGGG10,2]xxnt32":1,"types:ui~t":1,"types:uinis2":922337203685477}}


### PR DESCRIPTION
This PR should fix an issue found by OSS-Fuzz in `lyd_parse_mem_json`. 
This should fix OSS-Fuzz issues 38007 and 38372, which seem to be duplicates (it seems like 38007 was somehow
incorrectly detected as fixed by OSS-Fuzz, and then it found the same issue again and opened 38372).

The issue can be reproduced by running the `lyd_parse_mem_json` fuzz harness with the input.
Here is the valgrind output:

```
$ valgrind ./tests/fuzz/lyd_parse_mem_json/regress_fuzz_lyd_parse_mem_json < ~/libyang-fork/tests/fuzz/corpus/lyd_parse_mem_json/pull1696_1
==549743== Memcheck, a memory error detector
==549743== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==549743== Using Valgrind-3.17.0 and LibVEX; rerun with -h for copyright info
==549743== Command: ./tests/fuzz/lyd_parse_mem_json/regress_fuzz_lyd_parse_mem_json
==549743==
regress_fuzz_lyd_parse_mem_json: /home/user/libyang/src/parser_json.c:1293: lydjson_subtree_r: Assertion `status == LYJSON_OBJECT' failed.
==549743==
==549743== Process terminating with default action of signal 6 (SIGABRT): dumping core
==549743==    at 0x4BFAD22: raise (in /usr/lib/libc-2.33.so)
==549743==    by 0x4BE4861: abort (in /usr/lib/libc-2.33.so)
==549743==    by 0x4BE4746: __assert_fail_base.cold (in /usr/lib/libc-2.33.so)
==549743==    by 0x4BF3615: __assert_fail (in /usr/lib/libc-2.33.so)
==549743==    by 0x14676B: lydjson_subtree_r (parser_json.c:1293)
==549743==    by 0x146149: lydjson_parse_instance (parser_json.c:1190)
==549743==    by 0x146CA7: lydjson_subtree_r (parser_json.c:1409)
==549743==    by 0x14727A: lyd_parse_json (parser_json.c:1544)
==549743==    by 0x12C98F: lyd_parse (tree_data.c:366)
==549743==    by 0x12CF06: lyd_parse_data (tree_data.c:438)
==549743==    by 0x12CF85: lyd_parse_data_mem (tree_data.c:449)
==549743==    by 0x1128A2: LLVMFuzzerTestOneInput (lyd_parse_mem_json.c:77)
==549743==
==549743== HEAP SUMMARY:
==549743==     in use at exit: 137,817 bytes in 1,029 blocks
==549743==   total heap usage: 4,825 allocs, 3,796 frees, 1,128,287 bytes allocated
==549743==
==549743== LEAK SUMMARY:
==549743==    definitely lost: 48 bytes in 6 blocks
==549743==    indirectly lost: 0 bytes in 0 blocks
==549743==      possibly lost: 0 bytes in 0 blocks
==549743==    still reachable: 137,769 bytes in 1,023 blocks
==549743==                       of which reachable via heuristic:
==549743==                         newarray           : 16,592 bytes in 121 blocks
==549743==         suppressed: 0 bytes in 0 blocks
==549743== Rerun with --leak-check=full to see details of leaked memory
==549743==
==549743== For lists of detected and suppressed errors, rerun with: -s
==549743== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
Aborted
```

The issue seems to be caused by the way that `lyjson_ctx_next()` is used in `lydjson_data_skip()`.

After an object key-value pair was successfully parsed in `lydjson_data_skip()`
`lyjson_ctx_next()` parses the next key and returns `LYJSON_OBJECT`.
This causes `lydjson_data_skip()` to increment the sublevel,
even though a new nested object wasn't actually encountered.

This patch adds a check to see whether a nested object was actually parsed
or whether it was the next key.

At first it looks like the same issue might still appear for arrays, as `jsonctx->depth` is changed only for objects.
However, I haven't managed to cause such an issue. Also, looking at the `lyjson_ctx_next()` code, it looks like such
a case can't happen for arrays. The relevant part of the code from `src/json.c:976` looks like this:
```C
   if (*jsonctx->in->current == ',') {
        /* sibling item in the ... */
        ly_in_skip(jsonctx->in, 1);
        LY_CHECK_RET(skip_ws(jsonctx));

        if (prev == LYJSON_OBJECT) {
            /* ... object - get another object's member */
            ret = lyjson_object_name(jsonctx);
        } else { /* LYJSON_ARRAY */
            /* ... array - get another complete value */
            ret = lyjson_value(jsonctx);
        }
```

From what I can tell, in case of an array `lysjon_value()` is called, which should then push a new `LYJSON` status object.
A new status isn't pushed for objects, as only the key is parsed by `lyjson_ctx_next`, so the issue shouldn't happen for arrays.