### PR TITLE
parser BUGFIX allow empty pattern

### DIFF
--- a/src/parser_yang.c
+++ b/src/parser_yang.c
@@ -2057,12 +2057,6 @@ parse_type_pattern(struct lys_yang_parser_ctx *ctx, struct lysp_restr **patterns
     /* get value */
     LY_CHECK_RET(get_argument(ctx, Y_STR_ARG, NULL, &word, &buf, &word_len));
 
-    /* empty pattern is not valid */
-    if (!strlen(word)) {
-        LOGVAL_PARSER(ctx, LY_VCODE_INVAL, word_len, word, "pattern");
-        return LY_EVALID;
-    }
-
     /* add special meaning first byte */
     if (buf) {
         buf = ly_realloc(buf, word_len + 2);

--- a/src/parser_yin.c
+++ b/src/parser_yin.c
@@ -650,13 +650,6 @@ yin_parse_pattern(struct lys_yin_parser_ctx *ctx, struct lysp_type *type)
     LY_CHECK_RET(yin_parse_attribute(ctx, YIN_ARG_VALUE, &real_value, Y_STR_ARG, LY_STMT_PATTERN));
     size_t len = strlen(real_value);
 
-    /* empty pattern is not valid */
-    if (!len) {
-        LOGVAL_PARSER((struct lys_parser_ctx *)ctx, LY_VCODE_INVAL_YIN, real_value, "value", ly_stmt2str(LY_STMT_PATTERN));
-        lydict_remove(ctx->xmlctx->ctx, real_value);
-        return LY_EVALID;
-    }
-
     saved_value = malloc(len + 2);
     LY_CHECK_ERR_RET(!saved_value, LOGMEM(ctx->xmlctx->ctx), LY_EMEM);
     memmove(saved_value + 1, real_value, len);


### PR DESCRIPTION
Empty regular expression is explicitly allowed by the standard:

```
+---------------------------------+----------------------------------+
| For all branches S, and for all | Denoting the set of strings L(R) |
| regular expressions T, valid    | containing:                      |
| regular expressions R are:      |                                  |
+---------------------------------+----------------------------------+
| (empty string)                  | the set containing just the      |
|                                 | empty string                     |
+---------------------------------+----------------------------------+
| S                               | all strings in L(S)              |
+---------------------------------+----------------------------------+
| S|T                             | all strings in L(S) and          |
|                                 | and all strings in L(T)          |
+---------------------------------+----------------------------------+
```

Signed-off-by: Igor Ryzhov <iryzhov@nfware.com>