### PR TITLE
compat: remove unused `pthread_mutex_timedlock`

### DIFF
--- a/CMakeModules/UseCompat.cmake
+++ b/CMakeModules/UseCompat.cmake
@@ -27,7 +27,6 @@ macro(USE_COMPAT)
     set(CMAKE_REQUIRED_DEFINITIONS -D_POSIX_C_SOURCE=200809L)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
     list(APPEND CMAKE_REQUIRED_DEFINITIONS -D__BSD_VISIBLE=1)
-    set(CMAKE_REQUIRED_LIBRARIES pthread)
 
     check_symbol_exists(vdprintf "stdio.h;stdarg.h" HAVE_VDPRINTF)
     check_symbol_exists(asprintf "stdio.h" HAVE_ASPRINTF)
@@ -40,8 +39,6 @@ macro(USE_COMPAT)
     check_symbol_exists(strchrnul "string.h" HAVE_STRCHRNUL)
 
     check_symbol_exists(get_current_dir_name "unistd.h" HAVE_GET_CURRENT_DIR_NAME)
-
-    check_function_exists(pthread_mutex_timedlock HAVE_PTHREAD_MUTEX_TIMEDLOCK)
 
     TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 

--- a/compat/check_includes.sh
+++ b/compat/check_includes.sh
@@ -37,7 +37,6 @@ check_compat_func strnstr
 check_compat_func strdupa
 check_compat_func strchrnul
 check_compat_func get_current_dir_name
-check_compat_func pthread_mutex_timedlock
 check_compat_func UNUSED
 check_compat_macro _PACKED
 

--- a/compat/compat.c
+++ b/compat/compat.c
@@ -19,7 +19,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
-#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -196,55 +195,6 @@ get_current_dir_name(void)
     }
 
     return retval;
-}
-
-#endif
-
-#ifndef HAVE_PTHREAD_MUTEX_TIMEDLOCK
-int
-pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime)
-{
-    int64_t nsec_diff;
-    int32_t diff;
-    struct timespec cur, dur;
-    int rc;
-
-    /* try to acquire the lock and, if we fail, sleep for 5ms. */
-    while ((rc = pthread_mutex_trylock(mutex)) == EBUSY) {
-        /* get real time */
-#ifdef CLOCK_REALTIME
-        clock_gettime(CLOCK_REALTIME, &cur);
-#else
-        struct timeval tv;
-
-        gettimeofday(&tv, NULL);
-        cur.tv_sec = (time_t)tv.tv_sec;
-        cur.tv_nsec = 1000L * (long)tv.tv_usec;
-#endif
-
-        /* get time diff */
-        nsec_diff = 0;
-        nsec_diff += (((int64_t)abstime->tv_sec) - ((int64_t)cur.tv_sec)) * 1000000000L;
-        nsec_diff += ((int64_t)abstime->tv_nsec) - ((int64_t)cur.tv_nsec);
-        diff = (nsec_diff ? nsec_diff / 1000000L : 0);
-
-        if (diff < 1) {
-            /* timeout */
-            break;
-        } else if (diff < 5) {
-            /* sleep until timeout */
-            dur.tv_sec = 0;
-            dur.tv_nsec = (long)diff * 1000000;
-        } else {
-            /* sleep 5 ms */
-            dur.tv_sec = 0;
-            dur.tv_nsec = 5000000;
-        }
-
-        nanosleep(&dur, NULL);
-    }
-
-    return rc;
 }
 
 #endif

--- a/compat/compat.h.in
+++ b/compat/compat.h.in
@@ -16,7 +16,6 @@
 #define _COMPAT_H_
 
 #include <limits.h>
-#include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <sys/types.h>
@@ -57,7 +56,6 @@
 #cmakedefine HAVE_STRDUPA
 #cmakedefine HAVE_STRCHRNUL
 #cmakedefine HAVE_GET_CURRENT_DIR_NAME
-#cmakedefine HAVE_PTHREAD_MUTEX_TIMEDLOCK
 
 #ifndef bswap64
 #define bswap64(val) \
@@ -149,10 +147,6 @@ char *strchrnul(const char *s, int c);
 
 #ifndef HAVE_GET_CURRENT_DIR_NAME
 char *get_current_dir_name(void);
-#endif
-
-#ifndef HAVE_PTHREAD_MUTEX_TIMEDLOCK
-int pthread_mutex_timedlock(pthread_mutex_t *mutex, const struct timespec *abstime);
 #endif
 
 #endif /* _COMPAT_H_ */


### PR DESCRIPTION
It looks like this has never been used in libyang2.