### PR TITLE
Sync the debian packaging into apkg format

### DIFF
--- a/distro/pkg/deb/control
+++ b/distro/pkg/deb/control
@@ -6,7 +6,8 @@ Priority: optional
 Standards-Version: 4.5.0
 Build-Depends: cmake,
                debhelper (>= 10),
-               libpcre2-dev (>= 10.21),
+               libcmocka-dev <!nocheck>,
+               libpcre2-dev,
                pkg-config
 Vcs-Browser: https://github.com/CESNET/libyang/tree/master
 Vcs-Git: https://github.com/CESNET/libyang.git
@@ -15,6 +16,7 @@ Package: libyang2
 Depends: ${misc:Depends},
          ${shlibs:Depends}
 Architecture: any
+Multi-Arch: same
 Description: parser toolkit for IETF YANG data modeling - runtime
  Libyang implements functions to process schemas expressed in the
  YANG data modeling language defined by the IETF in RFCs 6020/7950.
@@ -28,12 +30,13 @@ Description: parser toolkit for IETF YANG data modeling - runtime
  to use in processing configurations.
 
 Package: libyang2-dev
-Depends: libpcre2-dev (>= 10.21),
+Depends: libpcre2-dev,
          libyang2 (= ${binary:Version}),
          ${misc:Depends}
 Conflicts: libyang-dev
 Section: libdevel
 Architecture: any
+Multi-Arch: same
 Description: parser toolkit for IETF YANG data modeling - development files
  Libyang implements functions to process schemas expressed in the
  YANG data modeling language defined by the IETF in RFCs 6020/7950.
@@ -54,6 +57,7 @@ Breaks: libyang-tools (<< ${source:Version})
 Replaces: libyang-tools (<< ${source:Version})
 Section: devel
 Architecture: any
+Multi-Arch: foreign
 Description: parser toolkit for IETF YANG data modeling - executable tools
  This package provides the "yanglint" and "yangre" tools which can be used
  during the creation of IETF YANG schemas.  The tools are not generally
@@ -65,6 +69,7 @@ Depends: libyang2-tools (>= ${source:Version}),
          ${misc:Depends}
 Section: oldlibs
 Architecture: all
+Multi-Arch: foreign
 Description: parser toolkit for IETF YANG data modeling [dummy package]
  This is empty dependency package to pull the executable tools.  It's
  safe to remove.

--- a/distro/pkg/deb/copyright
+++ b/distro/pkg/deb/copyright
@@ -47,6 +47,11 @@ License: BSD-2-clause
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+Files: debian/*
+Copyright: 2018 by David Lamparter
+	   2020-2021 Ondřej Surý
+License: BSD-3-clause
+
 License: BSD-3-clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:

--- a/distro/pkg/deb/libyang2.symbols
+++ b/distro/pkg/deb/libyang2.symbols
@@ -84,6 +84,10 @@ libyang.so.2 libyang2 #MINVER#
  ly_set_rm@Base 2.0.0~
  ly_set_rm_index@Base 2.0.0~
  ly_stmt2str@Base 2.0.0~
+ ly_time_str2time@Base 2.0.7~
+ ly_time_str2ts@Base 2.0.7~
+ ly_time_time2str@Base 2.0.7~
+ ly_time_ts2str@Base 2.0.7~
  ly_vecode@Base 2.0.0~
  ly_write@Base 2.0.0~
  lyd_any_copy_value@Base 2.0.0~
@@ -107,12 +111,16 @@ libyang.so.2 libyang2 #MINVER#
  lyd_dup_meta_single@Base 2.0.0~
  lyd_dup_siblings@Base 2.0.0~
  lyd_dup_single@Base 2.0.0~
+ lyd_eval_xpath2@Base 2.0.112~
+ lyd_eval_xpath@Base 2.0.112~
  lyd_find_meta@Base 2.0.0~
  lyd_find_path@Base 2.0.0~
  lyd_find_sibling_dup_inst_set@Base 2.0.0~
  lyd_find_sibling_first@Base 2.0.0~
  lyd_find_sibling_opaq_next@Base 2.0.0~
  lyd_find_sibling_val@Base 2.0.0~
+ lyd_find_target@Base 2.0.112~
+ lyd_find_xpath2@Base 2.0.112~
  lyd_find_xpath@Base 2.0.0~
  lyd_first_sibling@Base 2.0.0~
  lyd_free_all@Base 2.0.0~
@@ -129,6 +137,7 @@ libyang.so.2 libyang2 #MINVER#
  lyd_is_default@Base 2.0.0~
  lyd_list_pos@Base 2.0.0~
  lyd_lyb_data_length@Base 2.0.0~
+ lyd_merge_module@Base 2.0.7~
  lyd_merge_siblings@Base 2.0.0~
  lyd_merge_tree@Base 2.0.0~
  lyd_new_any@Base 2.0.0~
@@ -145,6 +154,8 @@ libyang.so.2 libyang2 #MINVER#
  lyd_new_inner@Base 2.0.0~
  lyd_new_list2@Base 2.0.0~
  lyd_new_list@Base 2.0.0~
+ lyd_new_list_bin@Base 2.0.112~
+ lyd_new_list_canon@Base 2.0.112~
  lyd_new_meta2@Base 2.0.0~
  lyd_new_meta@Base 2.0.0~
  lyd_new_opaq2@Base 2.0.0~
@@ -171,6 +182,7 @@ libyang.so.2 libyang2 #MINVER#
  lyd_print_path@Base 2.0.0~
  lyd_print_tree@Base 2.0.0~
  lyd_target@Base 2.0.0~
+ lyd_unlink_siblings@Base 2.0.112~
  lyd_unlink_tree@Base 2.0.0~
  lyd_validate_all@Base 2.0.0~
  lyd_validate_module@Base 2.0.0~
@@ -184,28 +196,29 @@ libyang.so.2 libyang2 #MINVER#
  lyplg_add@Base 2.0.0~
  lyplg_ext_instance_substatements_free@Base 2.0.0~
  lyplg_ext_log@Base 2.0.0~
- lyplg_type_bits_bitmap_size@Base 2.0.0~
- lyplg_type_bits_is_bit_set@Base 2.0.0~
+ lyplg_type_bits_bitmap_size@Base 2.0.7~
+ lyplg_type_bits_is_bit_set@Base 2.0.7~
  lyplg_type_check_hints@Base 2.0.0~
- lyplg_type_compare_binary@Base 2.0.0~
- lyplg_type_compare_bits@Base 2.0.0~
- lyplg_type_compare_boolean@Base 2.0.0~
- lyplg_type_compare_decimal64@Base 2.0.0~
+ lyplg_type_check_status@Base 2.0.112~
+ lyplg_type_compare_binary@Base 2.0.7~
+ lyplg_type_compare_bits@Base 2.0.7~
+ lyplg_type_compare_boolean@Base 2.0.7~
+ lyplg_type_compare_decimal64@Base 2.0.7~
  lyplg_type_compare_identityref@Base 2.0.0~
  lyplg_type_compare_instanceid@Base 2.0.0~
- lyplg_type_compare_int@Base 2.0.0~
+ lyplg_type_compare_int@Base 2.0.7~
  lyplg_type_compare_leafref@Base 2.0.0~
  lyplg_type_compare_simple@Base 2.0.0~
- lyplg_type_compare_uint@Base 2.0.0~
+ lyplg_type_compare_uint@Base 2.0.7~
  lyplg_type_compare_union@Base 2.0.0~
- lyplg_type_dup_binary@Base 2.0.0~
+ lyplg_type_dup_binary@Base 2.0.7~
  lyplg_type_dup_bits@Base 2.0.0~
  lyplg_type_dup_instanceid@Base 2.0.0~
  lyplg_type_dup_leafref@Base 2.0.0~
  lyplg_type_dup_simple@Base 2.0.0~
  lyplg_type_dup_union@Base 2.0.0~
  lyplg_type_dup_xpath10@Base 2.0.0~
- lyplg_type_free_binary@Base 2.0.0~
+ lyplg_type_free_binary@Base 2.0.7~
  lyplg_type_free_bits@Base 2.0.0~
  lyplg_type_free_instanceid@Base 2.0.0~
  lyplg_type_free_leafref@Base 2.0.0~
@@ -215,6 +228,7 @@ libyang.so.2 libyang2 #MINVER#
  lyplg_type_get_prefix@Base 2.0.0~
  lyplg_type_identity_isderived@Base 2.0.0~
  lyplg_type_identity_module@Base 2.0.0~
+ lyplg_type_lypath_check_status@Base 2.0.112~
  lyplg_type_lypath_free@Base 2.0.0~
  lyplg_type_lypath_new@Base 2.0.0~
  lyplg_type_make_implemented@Base 2.0.0~
@@ -224,17 +238,17 @@ libyang.so.2 libyang2 #MINVER#
  lyplg_type_prefix_data_dup@Base 2.0.0~
  lyplg_type_prefix_data_free@Base 2.0.0~
  lyplg_type_prefix_data_new@Base 2.0.0~
- lyplg_type_print_binary@Base 2.0.0~
- lyplg_type_print_bits@Base 2.0.0~
- lyplg_type_print_boolean@Base 2.0.0~
- lyplg_type_print_decimal64@Base 2.0.0~
- lyplg_type_print_enum@Base 2.0.0~
+ lyplg_type_print_binary@Base 2.0.7~
+ lyplg_type_print_bits@Base 2.0.7~
+ lyplg_type_print_boolean@Base 2.0.7~
+ lyplg_type_print_decimal64@Base 2.0.7~
+ lyplg_type_print_enum@Base 2.0.7~
  lyplg_type_print_identityref@Base 2.0.0~
  lyplg_type_print_instanceid@Base 2.0.0~
- lyplg_type_print_int@Base 2.0.0~
+ lyplg_type_print_int@Base 2.0.7~
  lyplg_type_print_leafref@Base 2.0.0~
  lyplg_type_print_simple@Base 2.0.0~
- lyplg_type_print_uint@Base 2.0.0~
+ lyplg_type_print_uint@Base 2.0.7~
  lyplg_type_print_union@Base 2.0.0~
  lyplg_type_print_xpath10@Base 2.0.0~
  lyplg_type_resolve_leafref@Base 2.0.0~
@@ -267,6 +281,7 @@ libyang.so.2 libyang2 #MINVER#
  lys_find_xpath_atoms@Base 2.0.0~
  lys_getnext@Base 2.0.0~
  lys_getnext_ext@Base 2.0.0~
+ lys_identity_iffeature_value@Base 2.0.112~
  lys_nodetype2stmt@Base 2.0.0~
  lys_nodetype2str@Base 2.0.0~
  lys_parse@Base 2.0.0~
@@ -298,6 +313,7 @@ libyang.so.2 libyang2 #MINVER#
  lysc_node_musts@Base 2.0.0~
  lysc_node_notifs@Base 2.0.0~
  lysc_node_when@Base 2.0.0~
+ lysc_owner_module@Base 2.0.112~
  lysc_path@Base 2.0.0~
  lysc_tree_dfs_full@Base 2.0.0~
  lysp_feature_next@Base 2.0.0~
@@ -307,3 +323,5 @@ libyang.so.2 libyang2 #MINVER#
  lysp_node_notifs@Base 2.0.0~
  lysp_node_typedefs@Base 2.0.0~
  lyxp_get_expr@Base 2.0.0~
+ lyxp_vars_free@Base 2.0.112~
+ lyxp_vars_set@Base 2.0.112~

--- a/distro/pkg/deb/tests/yanglint
+++ b/distro/pkg/deb/tests/yanglint
@@ -1,9 +1,18 @@
 #!/bin/sh
 
 set -e
-if test -f /usr/share/doc/libyang-tools/examples/ietf-interfaces.yang.gz; then
-	gunzip -c < /usr/share/doc/libyang-tools/examples/ietf-interfaces.yang.gz > /tmp/ietf-interfaces.yang
+
+# Setup the test file
+trap 'rm -f "${TESTFILE}"; rmdir "${TESTDIR}"' EXIT
+TESTDIR=$(mktemp -d /tmp/yanglint.XXXXXX)
+TESTFILE="${TESTDIR}/ietf-interfaces.yang"
+
+# Unpack or copy the test file
+if test -f /usr/share/doc/libyang2-tools/examples/ietf-interfaces.yang.gz; then
+	gunzip -c < /usr/share/doc/libyang2-tools/examples/ietf-interfaces.yang.gz > "${TESTFILE}"
 else
-	cp /usr/share/doc/libyang-tools/examples/ietf-interfaces.yang /tmp/ietf-interfaces.yang
+	cp /usr/share/doc/libyang2-tools/examples/ietf-interfaces.yang "${TESTFILE}"
 fi
-yanglint /tmp/ietf-interfaces.yang
+
+# Lint the test file
+yanglint "${TESTFILE}"


### PR DESCRIPTION
- Drop the versioned dependency on pcre2 (the oldest still supported Debian has
  pcre2 10.22 and the oldest still supported Ubuntu has pcre2 10.31)
- Update the symbols file up to upstream 2.0.7 version
- Update the yanglint autopkgtest for libyang2 packaging