### PR TITLE
Windows: do not skip building `yangre`

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,10 +1,14 @@
 # config file for tools
 configure_file(${PROJECT_SOURCE_DIR}/tools/config.h.in ${PROJECT_BINARY_DIR}/tools/config.h @ONLY)
 
-add_subdirectory(lint)
-if(NOT WIN32)
-    add_subdirectory(re)
+if(WIN32)
+    find_library(GETOPT_LIBRARY NAMES getopt REQUIRED)
+    find_path(GETOPT_INCLUDE_DIR NAMES getopt.h REQUIRED)
+    message(STATUS "Found <getopt.h> at ${GETOPT_INCLUDE_DIR}, library at ${GETOPT_LIBRARY}")
 endif()
+
+add_subdirectory(lint)
+add_subdirectory(re)
 
 set(format_sources
     ${format_sources}

--- a/tools/lint/CMakeLists.txt
+++ b/tools/lint/CMakeLists.txt
@@ -43,9 +43,6 @@ install(FILES ${PROJECT_SOURCE_DIR}/tools/lint/yanglint.1 DESTINATION ${CMAKE_IN
 target_include_directories(yanglint BEFORE PRIVATE ${PROJECT_BINARY_DIR})
 
 if(WIN32)
-    find_library(GETOPT_LIBRARY NAMES getopt REQUIRED)
-    find_path(GETOPT_INCLUDE_DIR NAMES getopt.h REQUIRED)
-    message(STATUS "Found <getopt.h> at ${GETOPT_INCLUDE_DIR}, library at ${GETOPT_LIBRARY}")
     target_include_directories(yanglint PRIVATE ${GETOPT_INCLUDE_DIR})
     target_link_libraries(yanglint ${GETOPT_LIBRARY})
 endif()

--- a/tools/re/CMakeLists.txt
+++ b/tools/re/CMakeLists.txt
@@ -13,3 +13,8 @@ target_link_libraries(yangre yang)
 install(TARGETS yangre DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(FILES ${PROJECT_SOURCE_DIR}/tools/re/yangre.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 target_include_directories(yangre BEFORE PRIVATE ${PROJECT_BINARY_DIR})
+
+if(WIN32)
+    target_include_directories(yangre PRIVATE ${GETOPT_INCLUDE_DIR})
+    target_link_libraries(yangre ${GETOPT_LIBRARY})
+endif()


### PR DESCRIPTION
It looks like I excluded this by mistake; the `getopt` library is already used by `yanglint` anyway.