### PR TITLE
lyd_new_path: creating list key might return parent

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -2225,6 +2225,10 @@ lyd_new_path(struct lyd_node *data_tree, const struct ly_ctx *ctx, const char *p
                         lyd_free(ret);
                         return NULL;
                     }
+                    if (options & LYD_PATH_OPT_NOPARENTRET) {
+                        /* last created node */
+                        return node;
+                    }
                     return ret;
                 }
             }


### PR DESCRIPTION
Under certain conditions, when creating a list key node and when there
is no existing data_tree, any created root parent node might be
returned instead of the child, when LYD_PATH_OPT_NOPARENTRET has been
specified.

This causes unexpected application (sysrepo) behaviour. Suppose the
following calls are issued:

    sr_delete_item("/root/list[name='foo']", SR_EDIT_ISOLATE);
    sr_delete_item("/root/list[name='foo']/name", SR_EDIT_ISOLATE);

In the second call, sr_edit_add() is returned a node representing
"root" rather than "list". It expects the latter, since
LYD_PATH_OPT_NOPARENTRET is specified.

This causes the delete operation to be mistakenly applied to the
"root" node, thus causing the entire tree to be removed, rather
than the intended list entry.