### PR TITLE
Fix windows time handling

### DIFF
--- a/CMakeModules/UseCompat.cmake
+++ b/CMakeModules/UseCompat.cmake
@@ -53,6 +53,7 @@ macro(USE_COMPAT)
 
     check_symbol_exists(realpath "stdlib.h" HAVE_REALPATH)
     check_symbol_exists(localtime_r "time.h" HAVE_LOCALTIME_R)
+    check_symbol_exists(gmtime_r "time.h" HAVE_GMTIME_R)
     check_symbol_exists(strptime "time.h" HAVE_STRPTIME)
     check_symbol_exists(mmap "sys/mman.h" HAVE_MMAP)
     check_symbol_exists(dirname "libgen.h" HAVE_DIRNAME)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ the `distro` directory.
 * [`getopt-win32`](https://github.com/libimobiledevice-win32/getopt)
 
 The Windows version [does not support plugins](https://github.com/CESNET/libyang/commit/323c31221645052e13db83f7d0e6e51c3ce9d802), and the `yanglint` works in a [non-interactive mode](https://github.com/CESNET/libyang/commit/2e3f935ed6f4a47e65b31de5aeebcd8877d5a09b) only.
+On Windows, all YANG date-and-time values are first converted to UTC (if TZ offset was specified), and then returned with "unspecified timezone".
 
 ## Building
 

--- a/compat/compat.c
+++ b/compat/compat.c
@@ -290,6 +290,25 @@ localtime_r(const time_t *timep, struct tm *result)
 #endif
 #endif
 
+#ifndef HAVE_GMTIME_R
+#ifdef _WIN32
+struct tm *
+gmtime_r(const time_t *timep, struct tm *result)
+{
+    errno_t res = gmtime_s(result, timep);
+
+    if (res) {
+        return NULL;
+    } else {
+        return result;
+    }
+}
+
+#else
+#error No gmtime_r() implementation for this platform is available.
+#endif
+#endif
+
 #ifndef HAVE_DIRNAME
 #ifdef _WIN32
 #include <shlwapi.h>

--- a/compat/compat.h.in
+++ b/compat/compat.h.in
@@ -69,6 +69,7 @@
 #cmakedefine HAVE_TIME_H_TIMEZONE
 #cmakedefine HAVE_REALPATH
 #cmakedefine HAVE_LOCALTIME_R
+#cmakedefine HAVE_GMTIME_R
 #cmakedefine HAVE_STRPTIME
 #cmakedefine HAVE_MMAP
 #cmakedefine HAVE_DIRNAME

--- a/src/tree_data_helpers.c
+++ b/src/tree_data_helpers.c
@@ -930,12 +930,12 @@ ly_time_time2str(time_t time, const char *fractions_s, char **str)
     /* initialize the local timezone */
     tzset();
 
+#ifdef HAVE_TM_GMTOFF
     /* convert */
     if (!localtime_r(&time, &tm)) {
         return LY_ESYS;
     }
 
-#ifdef HAVE_TM_GMTOFF
     /* get timezone offset */
     if (tm.tm_gmtoff == 0) {
         /* time is Zulu (UTC) */
@@ -948,6 +948,11 @@ ly_time_time2str(time_t time, const char *fractions_s, char **str)
     }
     sprintf(zoneshift, "%+03d:%02d", zonediff_h, zonediff_m);
 #else
+    /* convert */
+    if (!gmtime_r(&time, &tm)) {
+        return LY_ESYS;
+    }
+
     (void)zonediff_h;
     (void)zonediff_m;
     sprintf(zoneshift, "-00:00");


### PR DESCRIPTION
## MSVC: preserve date-and-time with unspecified TZ
    
This compatibility code was not stable for datetime values with unknown TZ. I think that the old behavior was not in violation of the YANG standard, but it was silly anyway -- if there's a timestamp with "unknown TZ", adding the *local* TZ before storing it doesn't make a lot of sense.
    
After this commit, the date-and-time handling on Windows becomes saner. These timestamps still won't remember their original TZ, but at least the absolute time will remain unchanged if we interpret "unknown" as "UTC", *and* there's now roundtrip stability.
    
Also expand the test coverage a bit.
    
Fixes: e182a27c Allow building on platforms without `struct tm.tm_gmtoff`, `timezone`, `daylight`

## MSVC: compat: implement `gmtime_r()`
    
Technically, there's no need for `gmtime_r()` because Windows `gmtime()` is thread-safe already, but we're using these thread-safe versions almost everywhere already.