### PR TITLE
printer: do not add quotes around anyxml JSON values

### DIFF
--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -586,8 +586,8 @@ json_print_any_content(struct jsonpr_ctx *pctx, struct lyd_node_any *any)
     case LYD_ANYDATA_JSON:
         /* print without escaping special characters */
         if (any->schema->nodetype == LYS_ANYXML) {
-            /* print as a string */
-            ly_print_(pctx->out, "\"%s\"", any->value.str);
+            /* print as a raw JSON */
+            ly_print_(pctx->out, "%s", any->value.str);
         } else if (any->value.str[0]) {
             /* print with indent */
             ly_print_(pctx->out, "%*s%s", INDENT, any->value.str);


### PR DESCRIPTION
When an anyxml data node contains a JSON value, this JSON value should be printed directly into the JSON output buffer, bypassing any additional transformation. The RFC explicitly mention an example with a JSON array, but more JSON types are actually allowed.

This is not covered by the test suite. There's some code in `tests/utests/data/test_parser_json.c` which could probably be extended, but I am not sure on how to extend the matching parser. Here's what I tried:
```diff
diff --git a/tests/utests/data/test_parser_json.c b/tests/utests/data/test_parser_json.c
index e9fb7057..25410b45 100644
--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -37,6 +37,7 @@ setup(void **state)
             "}"
             "container cp {presence \"container switch\"; leaf y {type string;} leaf z {type int8;}}"
             "anydata any {config false;}"
+            "anyxml anyx {config false;}"
             "leaf-list ll1 { type uint8; }"
             "leaf foo2 { type string; default \"default-val\"; }"
             "leaf foo3 { type uint32; }"
```
...along with basically a copy-paste of `test_anydata` along with `s/anydata/anyxml/g`, but that gets rejected by the matching parser:
```
ERROR: LY_SUCCESS != 0x7; MSG: The anyxml "anyx" is expected to be represented as JSON name/value, but input data contains name/object.
```
And indeed, the parser looks like something which checks for just one possible JSON type. This should be fixed, but I don't know what your preference for `anyxml` parsing are, whether to turn them into a tree of (opaque?) nodes, or something else, so I would like to leave this to you :).

Still, even this patch is an improvement for us. Granted, it will produce data that libyang cannot load, but at least we can return `anyxml` in a JSON format in a standard-compliant way, which is currently not possible (so this currently looks like tha last blocker for migrating to ly2 for us).