### PR TITLE
lys_getnext: Clarify iteration order

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -239,6 +239,8 @@ lys_getnext_into_case(const struct lysc_node_case *first_case, const struct lysc
  * data nodes in a data tree. By setting some \p options the behavior can be modified to the extent that
  * all the schema nodes are iteratively returned.
  *
+ * The order of iteration is schema order.
+ *
  * @param[in] last Previously returned schema tree node, or NULL in case of the first call.
  * @param[in] parent Parent of the subtree where the function starts processing.
  * @param[in] module In case of iterating on top level elements, the \p parent is NULL and

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -2410,6 +2410,8 @@ LIBYANG_API_DECL LY_ERR lys_feature_value(const struct lys_module *module, const
  * data nodes in a data tree. By setting some \p options the behavior can be modified to the extent that
  * all the schema nodes are iteratively returned.
  *
+ * The order of iteration is schema order.
+ *
  * @param[in] last Previously returned schema tree node, or NULL in case of the first call.
  * @param[in] parent Parent of the subtree where the function starts processing.
  * @param[in] module In case of iterating on top level elements, the \p parent is NULL and
@@ -2435,6 +2437,8 @@ LIBYANG_API_DECL const struct lysc_node *lys_getnext(const struct lysc_node *las
  * Without options, the function is used to traverse only the schema nodes that can be paired with corresponding
  * data nodes in a data tree. By setting some \p options the behavior can be modified to the extent that
  * all the schema nodes are iteratively returned.
+ *
+ * The order of iteration is schema order.
  *
  * @param[in] last Previously returned schema tree node, or NULL in case of the first call.
  * @param[in] parent Parent of the subtree where the function starts processing.


### PR DESCRIPTION
The doc hints that the order is schema order, but the order is not specifically written.
Also, I am not aware exactly how this function works:
>[lys_getnext()](https://github.com/CESNET/libyang/compare/group__schematree.html#gaeb9fc3101ead041d1e34e657c4cfb498) is supposed to be called sequentially. In the first call, the last parameter is usually NULL and function starts returning i) the first parent's child or ii) the first top level element of the module. Consequent calls suppose to provide the previously returned node as the last parameter and still the same parent and module parameters.

What happens if I specify both module and parent? 🤔 I think the "i)" and "ii)" should be changed, but I'm no exactly sure how.