### PR TITLE
lyd_diff: check LYS_USERORDERED is valid for the node type

### DIFF
--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3779,7 +3779,7 @@ lyd_diff(struct lyd_node *first, struct lyd_node *second, int options)
                 goto error;
             }
 
-            if (elem1 && (elem2->schema->flags & LYS_USERORDERED)) {
+            if (elem1 && ((elem2->schema->nodetype & (LYS_LIST | LYS_LEAFLIST)) && elem2->schema->flags & LYS_USERORDERED)) {
                 /* store the correct place where the node is supposed to be moved after creation */
                 /* if elem1 does not exist, all nodes were created and they will be created in
                  * correct order, so it is not needed to detect moves */


### PR DESCRIPTION
A LYD_DIFF_MOVEDAFTER2 diff was incorrectly being generated for a
leaf node which was a unique child of a list, since LYS_USERORDERED
and LYS_UNIQUE overload the same value (0x100).