### PR TITLE
windows: fix path handling in the schema mount

### DIFF
--- a/src/plugins_exts/schema_mount.c
+++ b/src/plugins_exts/schema_mount.c
@@ -297,7 +297,7 @@ schema_mount_create_ctx(const struct lysc_ext_instance *ext, const struct lyd_no
     if (searchdirs) {
         /* append them all into a single string */
         for (i = 0; searchdirs[i]; ++i) {
-            if ((rc = ly_strcat(&sdirs, "%s:", searchdirs[i]))) {
+            if ((rc = ly_strcat(&sdirs, "%s" PATH_SEPARATOR, searchdirs[i]))) {
                 goto cleanup;
             }
         }


### PR DESCRIPTION
On Windows, libyang uses semicolon as path separator.

Fixes: 0fca45cf schema mount UPDATE use all the searchdirs
See-also: a3ea193c Use semicolon as a directory delimiter on Windows