### PR TITLE
Fix compilation for FreeBSD/NetBSD

### DIFF
--- a/compat/compat.c
+++ b/compat/compat.c
@@ -265,7 +265,18 @@ realpath(const char *path, char *resolved_path)
     }
     return resolved;
 }
+#elif defined (__NetBSD__)
+char *
+realpath(const char *path, char *resolved_path)
+{
+    ssize_t nbytes;
 
+    nbytes = readlink(path, resolved_path, PATH_MAX);
+    if (nbytes == -1)
+        return NULL;
+
+    return resolved_path;
+}
 #else
 #error No realpath() implementation for this platform is available.
 #endif

--- a/compat/strptime.c
+++ b/compat/strptime.c
@@ -166,7 +166,7 @@ numeric_range:
             for (i = 1; i <= min + range && isdigit(*s); i *= 10) {
                 *dest = *dest * 10 + *s++ - '0';
             }
-            if (*dest - min >= (unsigned)range) {
+            if (*dest - min >= range) {
                 return 0;
             }
             *dest -= adj;


### PR DESCRIPTION
```
libyang-source/src/plugins_types/date_and_time.c:122:19: warning: arithmetic on a pointer to the function type 'char *(int, int)' is a GNU extension [-Wpointer-arith]
 	        val->time += timezone;
 	                  ^  ~~~~~~~~
libyang-source/src/plugins_types/date_and_time.c:122:19: warning: incompatible pointer to integer conversion assigning to 'time_t' (aka 'long') from 'char *(*)(int, int)' [-Wint-conversion]
 	        val->time += timezone;
 	                  ^  ~~~~~~~~
 	/usr/home/ci/cibuild.167/libyang-source/src/plugins_types/date_and_time.c:125:13: error: use of undeclared identifier 'daylight'
 	        if (daylight) {
 	            ^
2 warnings and 1 error generated.
```

* localtime_r() tells about DST already. In FreeBSD `daylight` variable
is not exposed. I believe we can use DST from tm?

Signed-off-by: Donatas Abraitis <donatas@opensourcerouting.org>