### PR TITLE
Do not include POSIX-specific bits from public headers

### DIFF
--- a/compat/posix-shims/unistd.h
+++ b/compat/posix-shims/unistd.h
@@ -39,11 +39,7 @@
 #define timegm _mkgmtime
 /* read, write, and close are NOT being #defined here, because while there are file handle specific versions for Windows, they probably don't work for sockets. You need to look at your app and consider whether to call e.g. closesocket(). */
 
-#ifdef _WIN64
-#define ssize_t __int64
-#else
-#define ssize_t long
-#endif
+#define ssize_t SSIZE_T
 
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1

--- a/src/out.h
+++ b/src/out.h
@@ -16,7 +16,10 @@
 #define LY_OUT_H_
 
 #include <stdio.h>
-#include <unistd.h>
+#include <sys/types.h>
+#ifdef _MSC_VER
+#  define ssize_t SSIZE_T
+#endif
 
 #include "log.h"
 


### PR DESCRIPTION
On MSVC, there's no `<unistd.h>`. The only relevant types used directly via this header is `size_t` (which is already available via other headers, so let's use one of these instead), and `ssize_t`. The latter appears to be a POSIX extension. We already have a workaround in our compattibility, faux `unistd.h`, but it's problematic to install that one "publicly" -- and we should not use private bits from a public interface, anyway.

Fix this via using a MSVC `typedef`, and adjust the compat header as well. This means that there's now an `#ifdef` in a public header, but hey, it's just one thing, and there's no way around that.