### PR TITLE
CI: test ASAN/UBSAN with a newer clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,10 @@ jobs:
             make-target: ""
           }
           - {
-            name: "ASAN and UBSAN",
-            os: "ubuntu-18.04",
+            name: "ASAN and UBSAN, clang 14",
+            os: "ubuntu-22.04",
             build-type: "Debug",
-            cc: "clang",
+            cc: "clang-14",
             options: "-DCMAKE_C_FLAGS=-fsanitize=address,undefined -DENABLE_TESTS=ON -DENABLE_VALGRIND_TESTS=OFF",
             packager: "sudo apt-get",
             packages: "libcmocka-dev",


### PR DESCRIPTION
There's no point in not using the latest & greatest when it comes to diagnostics. The other builds are still on Ubuntu 18.04 for compatibility reasons, I suppose, but for this one we want to latest fixes from upstream.