### PR TITLE
Printing features in a new format in yanglint 

### DIFF
--- a/tools/lint/CMakeLists.txt
+++ b/tools/lint/CMakeLists.txt
@@ -56,6 +56,7 @@ function(add_yanglint_test)
 
     add_test(NAME ${TEST_NAME} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/${ADDTEST_SCRIPT})
     set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "YANGLINT=${PROJECT_BINARY_DIR}/yanglint")
+    set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "YANG_MODULES_DIR=${PROJECT_SOURCE_DIR}/tests/modules/yang")
 endfunction(add_yanglint_test)
 
 if(ENABLE_TESTS)
@@ -65,6 +66,7 @@ if(ENABLE_TESTS)
         message(WARNING "'shunit2' not found! The yanglint(1) non-interactive tests will not be available.")
     else()
         add_yanglint_test(NAME ni_list SCRIPT shunit2/list.sh)
+        add_yanglint_test(NAME ni_feature SCRIPT shunit2/feature.sh)
     endif()
 
     # tests of interactive mode using expect
@@ -73,5 +75,6 @@ if(ENABLE_TESTS)
         message(WARNING "'expect' not found! The yanglint(1) interactive tests will not be available.")
     elseif(YANGLINT_INTERACTIVE)
         add_yanglint_test(NAME in_list SCRIPT expect/list.exp)
+        add_yanglint_test(NAME in_feature SCRIPT expect/feature.exp)
     endif()
 endif()

--- a/tools/lint/cmd_add.c
+++ b/tools/lint/cmd_add.c
@@ -39,6 +39,7 @@ cmd_add_help(void)
             "                  explicitly specified).\n"
             "  -F FEATURES, --features=FEATURES\n"
             "                  Features to support, default all in all implemented modules.\n"
+            "                  Specify separately for each module.\n"
             "                  <modname>:[<feature>,]*\n"
             "  -i, --make-implemented\n"
             "                  Make the imported modules \"referenced\" from any loaded\n"

--- a/tools/lint/cmd_feature.c
+++ b/tools/lint/cmd_feature.c
@@ -27,25 +27,14 @@
 void
 cmd_feature_help(void)
 {
-    printf("Usage: feature [-h] <module> [<module>]*\n"
-            "                  Print features of all the module with state of each one.\n");
-}
-
-int
-collect_features(const struct lys_module *mod, struct ly_set *set)
-{
-    struct lysp_feature *f = NULL;
-    uint32_t idx = 0;
-
-    while ((f = lysp_feature_next(f, mod->parsed, &idx))) {
-        if (ly_set_add(set, (void *)f->name, 1, NULL)) {
-            YLMSG_E("Memory allocation failed.\n");
-            ly_set_erase(set, NULL);
-            return 1;
-        }
-    }
-
-    return 0;
+    printf("Usage: feature [-f] <module> [<module>]*\n"
+            "       feature -a [-f]\n"
+            "                  Print features of all the modules with state of each one.\n\n"
+            "  -f <module1, module2, ...>, --feature-param <module1, module2, ...>\n"
+            "                  Generate features parameter for the command \"add\" \n"
+            "                  in the form of -F <module-name>:<features>\n"
+            "  -a, --all \n"
+            "                  Print features of all implemented modules.\n");
 }
 
 void
@@ -53,29 +42,54 @@ cmd_feature(struct ly_ctx **ctx, const char *cmdline)
 {
     int argc = 0;
     char **argv = NULL;
+    char *features_output = NULL;
     int opt, opt_index, i;
+    ly_bool generate_features = 0, print_all = 0;
+    struct ly_set set = {0};
+    const struct lys_module *mod;
+    struct ly_out *out = NULL;
     struct option options[] = {
         {"help", no_argument, NULL, 'h'},
+        {"all", no_argument, NULL, 'a'},
+        {"feature-param", no_argument, NULL, 'f'},
         {NULL, 0, NULL, 0}
     };
-    struct ly_set set = {0};
-    size_t max_len;
-    uint32_t j;
-    const char *name;
 
     if (parse_cmdline(cmdline, &argc, &argv)) {
         goto cleanup;
     }
 
-    while ((opt = getopt_long(argc, argv, "h", options, &opt_index)) != -1) {
+    while ((opt = getopt_long(argc, argv, "haf", options, &opt_index)) != -1) {
         switch (opt) {
         case 'h':
             cmd_feature_help();
             goto cleanup;
+        case 'a':
+            print_all = 1;
+            break;
+        case 'f':
+            generate_features = 1;
+            break;
         default:
             YLMSG_E("Unknown option.\n");
             goto cleanup;
         }
+    }
+
+    if (ly_out_new_file(stdout, &out)) {
+        YLMSG_E("Unable to print to the standard output.\n");
+        goto cleanup;
+    }
+
+    if (print_all) {
+        if (print_all_features(out, *ctx, generate_features, &features_output)) {
+            YLMSG_E("Printing all features failed.\n");
+            goto cleanup;
+        }
+        if (generate_features) {
+            printf("%s\n", features_output);
+        }
+        goto cleanup;
     }
 
     if (argc == optind) {
@@ -84,8 +98,10 @@ cmd_feature(struct ly_ctx **ctx, const char *cmdline)
     }
 
     for (i = 0; i < argc - optind; i++) {
-        const struct lys_module *mod = ly_ctx_get_module_latest(*ctx, argv[optind + i]);
+        /* always erase the set, so the previous module's features don't carry over to the next module's features */
+        ly_set_erase(&set, NULL);
 
+        mod = ly_ctx_get_module_latest(*ctx, argv[optind + i]);
         if (!mod) {
             YLMSG_E("Module \"%s\" not found.\n", argv[optind + i]);
             goto cleanup;
@@ -96,31 +112,24 @@ cmd_feature(struct ly_ctx **ctx, const char *cmdline)
             goto cleanup;
         }
 
-        /* header */
-        printf("%s features:\n", mod->name);
-
-        if (set.count) {
-            /* get max len */
-            max_len = 0;
-            for (j = 0; j < set.count; ++j) {
-                name = set.objs[j];
-                if (strlen(name) > max_len) {
-                    max_len = strlen(name);
-                }
+        if (generate_features) {
+            if (generate_features_output(mod, &set, &features_output)) {
+                goto cleanup;
             }
-
-            /* print features */
-            for (j = 0; j < set.count; ++j) {
-                name = set.objs[j];
-                printf("\t%-*s (%s)\n", (int)max_len, name, lys_feature_value(mod, name) ? "off" : "on");
-            }
-
-            ly_set_erase(&set, NULL);
-        } else {
-            printf("\t(none)\n");
+            /* don't print features and their state of each module if generating features parameter */
+            continue;
         }
+
+        print_features(out, mod, &set);
+    }
+
+    if (generate_features) {
+        printf("%s\n", features_output);
     }
 
 cleanup:
     free_cmdline(argv);
+    ly_out_free(out, NULL, 0);
+    ly_set_erase(&set, NULL);
+    free(features_output);
 }

--- a/tools/lint/common.c
+++ b/tools/lint/common.c
@@ -209,6 +209,146 @@ fill_cmdline_file(struct ly_set *set, struct ly_in *in, const char *path, LYD_FO
     return rec;
 }
 
+int
+collect_features(const struct lys_module *mod, struct ly_set *set)
+{
+    struct lysp_feature *f = NULL;
+    uint32_t idx = 0;
+
+    while ((f = lysp_feature_next(f, mod->parsed, &idx))) {
+        if (ly_set_add(set, (void *)f->name, 1, NULL)) {
+            YLMSG_E("Memory allocation failed.\n");
+            ly_set_erase(set, NULL);
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+void
+print_features(struct ly_out *out, const struct lys_module *mod, const struct ly_set *set)
+{
+    size_t max_len;
+    uint32_t j;
+    const char *name;
+
+    /* header */
+    ly_print(out, "%s:\n", mod->name);
+
+    /* no features */
+    if (!set->count) {
+        ly_print(out, "\t(none)\n");
+        return;
+    }
+
+    /* get max len, so the statuses of all the features will be aligned */
+    max_len = 0;
+    for (j = 0; j < set->count; ++j) {
+        name = set->objs[j];
+        if (strlen(name) > max_len) {
+            max_len = strlen(name);
+        }
+    }
+
+    /* print features */
+    for (j = 0; j < set->count; ++j) {
+        name = set->objs[j];
+        ly_print(out, "\t%-*s (%s)\n", (int)max_len, name, lys_feature_value(mod, name) ? "off" : "on");
+    }
+
+    ly_print(out, "\n");
+}
+
+int
+generate_features_output(const struct lys_module *mod, const struct ly_set *set, char **features_param)
+{
+    uint32_t j;
+    /*
+     * features_len - length of all the features in the current module
+     * added_len - length of a string to be added, = features_len + extra necessary length
+     * param_len - length of the parameter before appending new string
+    */
+    size_t features_len, added_len, param_len;
+    char *tmp;
+
+    features_len = 0;
+    for (j = 0; j < set->count; j++) {
+        features_len += strlen(set->objs[j]);
+    }
+
+    if (j == 0) {
+        /* no features */
+        added_len = strlen("-F ") + strlen(mod->name) + strlen(":");
+    } else {
+        /* j = comma count, -1 because of trailing comma */
+        added_len = strlen("-F ") + strlen(mod->name) + strlen(":") + features_len + j - 1;
+    }
+
+    /* to avoid strlen(NULL) if this is the first call */
+    param_len = 0;
+    if (*features_param) {
+        param_len = strlen(*features_param);
+    }
+
+    /* +1 because of white space at the beginning */
+    tmp = realloc(*features_param, param_len + added_len + 1 + 1);
+    if (!tmp) {
+        goto error;
+    } else {
+        *features_param = tmp;
+    }
+    sprintf(*features_param + param_len, " -F %s:", mod->name);
+
+    for (j = 0; j < set->count; j++) {
+        strcat(*features_param, set->objs[j]);
+        /* no trailing comma */
+        if (j != (set->count - 1)) {
+            strcat(*features_param, ",");
+        }
+    }
+
+    return 0;
+
+error:
+    YLMSG_E("Memory allocation failed (%s:%d, %s).\n", __FILE__, __LINE__, strerror(errno));
+    return 1;
+}
+
+int
+print_all_features(struct ly_out *out, const struct ly_ctx *ctx, ly_bool generate_features, char **features_param)
+{
+    int ret = 0;
+    uint32_t i = 0;
+    struct lys_module *mod;
+    struct ly_set set = {0};
+
+    while ((mod = ly_ctx_get_module_iter(ctx, &i)) != NULL) {
+        /* only care about implemented modules */
+        if (!mod->implemented) {
+            continue;
+        }
+
+        /* always erase the set, so the previous module's features don't carry over to the next module's features */
+        ly_set_erase(&set, NULL);
+
+        if (collect_features(mod, &set)) {
+            ret = 1;
+            goto cleanup;
+        }
+
+        if (generate_features && generate_features_output(mod, &set, features_param)) {
+            ret = 1;
+            goto cleanup;
+        }
+        print_features(out, mod, &set);
+    }
+
+cleanup:
+    ly_set_erase(&set, NULL);
+    return ret;
+}
+
 void
 free_cmdline_file(void *cmdline_file)
 {

--- a/tools/lint/common.h
+++ b/tools/lint/common.h
@@ -88,6 +88,48 @@ void get_features(struct ly_set *fset, const char *module, const char ***feature
 int parse_features(const char *fstring, struct ly_set *fset);
 
 /**
+ * @brief Collect all features of a module.
+ *
+ * @param[in] mod Module to be searched for features.
+ * @param[out] set Set in which the features will be stored.
+ * @return 0 on success.
+ * @return 1 on error.
+ */
+int collect_features(const struct lys_module *mod, struct ly_set *set);
+
+/**
+ * @brief Print all features of a single module.
+ *
+ * @param[in] out The output handler for printing.
+ * @param[in] mod Module which contains the features.
+ * @param[in] set Set which holds the features.
+ */
+void print_features(struct ly_out *out, const struct lys_module *mod, const struct ly_set *set);
+
+/**
+ * @brief Generate a string, which will contain features paramater.
+ *
+ * @param[in] mod Module, for which the string will be generated.
+ * @param[in] set Set containing the features.
+ * @param[out] features_param String which will contain the output.
+ * @return 0 on success.
+ * @return 1 on error.
+ */
+int generate_features_output(const struct lys_module *mod, const struct ly_set *set, char **features_param);
+
+/**
+ * @brief Print all features of all implemented modules.
+ *
+ * @param[in] out The output handler for printing.
+ * @param[in] ctx Libyang context.
+ * @param[in] generate_features Flag expressing whether to generate features parameter.
+ * @param[out] features_param String, which will contain the output if the above flag is set.
+ * @return 0 on success.
+ * @return 1 on error.
+ */
+int print_all_features(struct ly_out *out, const struct ly_ctx *ctx, ly_bool generate_features, char **features_param);
+
+/**
  * @brief Parse path of a schema module file into the directory and module name.
  *
  * @param[in] path Schema module file path to be parsed.

--- a/tools/lint/tests/expect/feature.exp
+++ b/tools/lint/tests/expect/feature.exp
@@ -1,0 +1,18 @@
+#!/usr/bin/expect -f
+
+set timeout 1
+
+spawn $env(YANGLINT)
+expect -exact "> "
+send -- "feature -a\r"
+expect {
+    "feature -a\r
+yang:\r
+\t(none)\r
+ietf-yang-schema-mount:\r
+\t(none)\r
+> " { }
+    timeout { exit 1 }
+}
+send -- "exit\r"
+expect eof

--- a/tools/lint/tests/shunit2/feature.sh
+++ b/tools/lint/tests/shunit2/feature.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+testFeature() {
+	models=( "iana-if-type@2014-05-08.yang" "ietf-netconf@2011-06-01.yang" "ietf-netconf-with-defaults@2011-06-01.yang"
+	 		"sm.yang" "ietf-interfaces@2014-05-08.yang" "ietf-netconf-acm@2018-02-14.yang" "ietf-origin@2018-02-14.yang"
+	 		"ietf-ip@2014-06-16.yang" "ietf-restconf@2017-01-26.yang" )
+	features=( " -F iana-if-type:"
+			  " -F ietf-netconf:writable-running,candidate,confirmed-commit,rollback-on-error,validate,startup,url,xpath"
+			  " -F ietf-netconf-with-defaults:" " -F sm:" " -F ietf-interfaces:arbitrary-names,pre-provisioning,if-mib"
+			  " -F ietf-netconf-acm:" " -F ietf-origin:" " -F ietf-ip:ipv4-non-contiguous-netmasks,ipv6-privacy-autoconf"
+			  " -F ietf-restconf:" )
+
+	for i in ${!models[@]}; do
+		output=`${YANGLINT} -f feature-param ${YANG_MODULES_DIR}/${models[$i]}`
+		assertEquals "Unexpected features of module ${models[$i]}." "${features[$i]}" "${output}"
+	done
+}
+
+. shunit2

--- a/tools/lint/tests/shunit2/list.sh
+++ b/tools/lint/tests/shunit2/list.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/env bash
 
 LIST_BASE="List of the loaded models:
     i ietf-yang-metadata@2016-08-05


### PR DESCRIPTION
Added the ability to print all features in a format, which can later be used to specify, which features a model should use, for both interactive and non-interactive versions of yanglint. Interactive version also supports doing this for all implemented modules at once.