### PR TITLE
yanglint: fix race around `mkdir()`

### DIFF
--- a/tools/lint/configuration.c
+++ b/tools/lint/configuration.c
@@ -55,9 +55,12 @@ get_yanglint_dir(void)
             /* directory does not exist */
             YLMSG_W("Configuration directory \"%s\" does not exist, creating it.\n", yl_dir);
             if (mkdir(yl_dir, 00700)) {
-                YLMSG_E("Configuration directory \"%s\" cannot be created (%s).\n", yl_dir, strerror(errno));
-                free(yl_dir);
-                return NULL;
+                if (errno != EEXIST) {
+                    /* parallel execution, yay */
+                    YLMSG_E("Configuration directory \"%s\" cannot be created (%s).\n", yl_dir, strerror(errno));
+                    free(yl_dir);
+                    return NULL;
+                }
             }
         } else {
             YLMSG_E("Configuration directory \"%s\" exists but cannot be accessed (%s).\n", yl_dir, strerror(errno));


### PR DESCRIPTION
I've actually [seen this](https://github.com/Telecominfraproject/oopt-gnpy-libyang/runs/7956994609?check_suite_focus=true#step:24:142) via CI on Mac OS:

```
      Start 60: yanglint_in_list
58/61 Test #57: regress_fuzz_lys_parse_mem ........   Passed    0.85 sec
      Start 61: yanglint_in_feature
59/61 Test #56: headers ...........................   Passed    2.65 sec
60/61 Test #60: yanglint_in_list ..................***Failed    2.41 sec
spawn /Users/runner/work/oopt-gnpy-libyang/build-libyang/yanglint
YANGLINT[W]: Configuration directory "/Users/runner/.yanglint" does not exist, creating it.
YANGLINT[E]: Configuration directory "/Users/runner/.yanglint" cannot be created (File exists).

61/61 Test #61: yanglint_in_feature ...............***Failed    2.40 sec
spawn /Users/runner/work/oopt-gnpy-libyang/build-libyang/yanglint
YANGLINT[W]: Configuration directory "/Users/runner/.yanglint" does not exist, creating it.
YANGLINT[W]: No saved history.
```