### PR TITLE
tests: include missing stdint.h

### DIFF
--- a/tests/utests/utests.h
+++ b/tests/utests/utests.h
@@ -21,6 +21,7 @@
 #include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 #include <cmocka.h>


### PR DESCRIPTION
see:
https://git.cryptomilk.org/projects/cmocka.git/tree/include/cmocka.h#n44

'These headers or their equivalents MUST be included prior to including this header file.'

stdint.h is listed there but not included in libyang's utests.h which breaks, for example,
cross compilation for aarch64 with:
"error: unknown type name 'uintmax_t'"