### PR TITLE
Printer tree and mount-point

### DIFF
--- a/src/plugins_exts/schema_mount.c
+++ b/src/plugins_exts/schema_mount.c
@@ -690,24 +690,24 @@ cleanup:
 LY_ERR
 lyplg_ext_schema_mount_get_parent_ref(const struct lysc_ext_instance *ext, struct ly_set **refs)
 {
-    LY_ERR res;
+    LY_ERR rc;
     struct ly_set *pref_set = NULL;
-    struct ly_set *snode_set;
+    struct ly_set *snode_set = NULL;
     struct ly_set *results_set = NULL;
     struct lyd_node *ext_data;
     ly_bool ext_data_free;
 
     /* get operational data with ietf-yang-library and ietf-yang-schema-mount data */
-    if ((res = lyplg_ext_get_data(ext->module->ctx, ext, (void **)&ext_data, &ext_data_free))) {
-        return res;
+    if ((rc = lyplg_ext_get_data(ext->module->ctx, ext, (void **)&ext_data, &ext_data_free))) {
+        return rc;
     }
 
-    LY_CHECK_GOTO(res = schema_mount_get_parent_ref(ext, ext_data, &pref_set), out);
+    LY_CHECK_GOTO(rc = schema_mount_get_parent_ref(ext, ext_data, &pref_set), cleanup);
     if (pref_set->count == 0) {
-        goto out;
+        goto cleanup;
     }
 
-    LY_CHECK_GOTO(res = ly_set_new(&results_set), out);
+    LY_CHECK_GOTO(rc = ly_set_new(&results_set), cleanup);
 
     for (uint32_t i = 0; i < pref_set->count; ++i) {
         struct lyd_node_term *term;
@@ -717,29 +717,29 @@ lyplg_ext_schema_mount_get_parent_ref(const struct lysc_ext_instance *ext, struc
 
         term = (struct lyd_node_term *)pref_set->dnodes[i];
         LYD_VALUE_GET(&term->value, xp_val);
-        LY_CHECK_GOTO(res = lyplg_type_print_xpath10_value(xp_val, LY_VALUE_JSON, NULL, &value, &err), out);
-        LY_CHECK_ERR_GOTO(res = lys_find_xpath(ext->module->ctx, NULL, value, 0, &snode_set), free(value), out);
+        LY_CHECK_GOTO(rc = lyplg_type_print_xpath10_value(xp_val, LY_VALUE_JSON, NULL, &value, &err), cleanup);
+        LY_CHECK_ERR_GOTO(rc = lys_find_xpath(ext->module->ctx, NULL, value, 0, &snode_set), free(value), cleanup);
         free(value);
         for (uint32_t sn = 0; sn < snode_set->count; sn++) {
-            struct lysc_node *snode = snode_set->snodes[sn];
-
-            if ((res = ly_set_add(results_set, snode, 0, NULL))) {
-                ly_set_free(snode_set, NULL);
-                ly_set_free(results_set, NULL);
-                goto out;
-            }
+            LY_CHECK_GOTO(rc = ly_set_add(results_set, snode_set->snodes[sn], 0, NULL), cleanup);
         }
         ly_set_free(snode_set, NULL);
+        snode_set = NULL;
     }
 
     *refs = results_set;
 
-out:
+cleanup:
+    if (rc) {
+        ly_set_free(results_set, NULL);
+    }
+    ly_set_free(snode_set, NULL);
     if (ext_data_free) {
         lyd_free_all(ext_data);
     }
     ly_set_free(pref_set, NULL);
-    return res;
+
+    return rc;
 }
 
 /**

--- a/src/printer_tree.c
+++ b/src/printer_tree.c
@@ -4558,7 +4558,7 @@ trb_print_mount_point(const struct lysc_ext_instance *ext, const struct trt_wrap
             trm_lysp_tree_ctx(mod, pc->out, pc->max_line_length, 1, refs, &tmppc, &tmptc);
         }
         /* Decide whether to print the symbol '|'. */
-        tmpwr = (mod == last_mod) ? wr : trp_wrapper_set_mark_top(wr);
+        tmpwr = (mod == last_mod) && !refs ? wr : trp_wrapper_set_mark_top(wr);
         /* Print top-level nodes of mounted module which are denoted by the symbol '/'. */
         trb_print_family_tree(tmpwr, &tmppc, &tmptc);
     }
@@ -4566,6 +4566,7 @@ trb_print_mount_point(const struct lysc_ext_instance *ext, const struct trt_wrap
     /* Print parent-referenced nodes which are denoted by the symbol '@'. */
     for (i = 0; refs && i < refs->count; i++) {
         trm_lysc_tree_ctx(refs->snodes[i]->module, pc->out, pc->max_line_length, 1, refs, &tmppc, &tmptc);
+        tmpwr = ((i + 1) == refs->count) ? wr : trp_wrapper_set_mark_top(wr);
         trb_print_parents(refs->snodes[i], &tmpwr, pc, &tmptc);
     }
 

--- a/src/printer_tree.c
+++ b/src/printer_tree.c
@@ -2566,6 +2566,7 @@ tro_create_implicit_case_node(struct trt_node node)
     ret.type = TRP_EMPTY_TRT_TYPE;
     ret.iffeatures = 0;
     ret.last_one = node.last_one;
+    ret.mount = NULL;
 
     return ret;
 }

--- a/tests/modules/yang/sm-extension.yang
+++ b/tests/modules/yang/sm-extension.yang
@@ -1,0 +1,17 @@
+module sm-extension {
+  yang-version 1.1;
+  namespace "urn:sm-ext";
+  prefix "sm-ext";
+
+  list tlist {
+    key "name";
+    leaf name {
+      type uint32;
+    }
+  }
+  container tcont {
+    leaf tleaf {
+      type uint32;
+    }
+  }
+}

--- a/tests/modules/yang/sm-mod.yang
+++ b/tests/modules/yang/sm-mod.yang
@@ -1,0 +1,9 @@
+module sm-mod {
+  yang-version 1.1;
+  namespace "urn:sm-mod";
+  prefix "sm-mod";
+
+  import sm-modp {
+    prefix smp;
+  }
+}

--- a/tests/modules/yang/sm-modp.yang
+++ b/tests/modules/yang/sm-modp.yang
@@ -1,0 +1,24 @@
+module sm-modp {
+  yang-version 1.1;
+  namespace "urn:sm-modp";
+  prefix "sm-modp";
+
+  import ietf-yang-schema-mount {
+    prefix yangmnt;
+  }
+
+  revision 2017-01-26;
+
+  container ncmp {
+    yangmnt:mount-point "root";
+  }
+
+  container not-compiled {
+    leaf first {
+      type string;
+    }
+    leaf second {
+      type string;
+    }
+  }
+}

--- a/tests/modules/yang/sm-rpcnotif.yang
+++ b/tests/modules/yang/sm-rpcnotif.yang
@@ -1,0 +1,25 @@
+module sm-rpcnotif {
+  yang-version 1.1;
+  namespace "urn:rpcnotif";
+  prefix "smrn";
+
+  container cont {
+    notification cn;
+    action cr {
+      input {
+        leaf in {
+          type string;
+        }
+      }
+      output {
+        leaf out {
+          type string;
+        }
+      }
+    }
+  }
+  rpc r1;
+  rpc r2;
+  notification n1;
+  notification n2;
+}

--- a/tests/utests/schema/test_printer_tree.c
+++ b/tests/utests/schema/test_printer_tree.c
@@ -2188,6 +2188,68 @@ mount_point(void **state)
     assert_string_equal(printed, expect);
     ly_out_reset(UTEST_OUT);
 
+    /*
+     * parent-ref composes the '@' subtree
+     */
+    orig = SM_MOD_MAIN("a37",
+            "container pr {\n"
+            "  leaf ignored_node {\n"
+            "    type string;\n"
+            "  }\n"
+            "  container cont {\n"
+            "    leaf ignored_lf {\n"
+            "      type uint32;\n"
+            "    }\n"
+            "  }\n"
+            "  container ignored_subtree {\n"
+            "    leaf ignored_lf {\n"
+            "      type uint32;\n"
+            "    }\n"
+            "  }\n"
+            "  container cont_sibl {\n"
+            "    leaf slf {\n"
+            "      type string;\n"
+            "    }\n"
+            "  }\n"
+            "  leaf lf {\n"
+            "    type uint32;\n"
+            "  }\n"
+            "}\n"
+            "container cont_mount {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n");
+    expect =
+            "module: a37\n"
+            "  +--rw pr\n"
+            "  |  +--rw ignored_node?      string\n"
+            "  |  +--rw cont\n"
+            "  |  |  +--rw ignored_lf?   uint32\n"
+            "  |  +--rw ignored_subtree\n"
+            "  |  |  +--rw ignored_lf?   uint32\n"
+            "  |  +--rw cont_sibl\n"
+            "  |  |  +--rw slf?   string\n"
+            "  |  +--rw lf?                uint32\n"
+            "  +--mp cont_mount\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--rw pr@\n"
+            "        +--rw cont\n"
+            "        +--rw cont_sibl\n"
+            "        |  +--rw slf?   string\n"
+            "        +--rw lf?          uint32\n";
+    data = EXT_DATA("a37", "", SCHEMA_REF_SHARED(
+            "<parent-reference>/"SM_PREF ":pr/"SM_PREF ":cont_sibl/slf</parent-reference>\n"
+            "<parent-reference>/"SM_PREF ":pr/"SM_PREF ":cont</parent-reference>\n"
+            "<parent-reference>/"SM_PREF ":pr/"SM_PREF ":lf</parent-reference>\n"));
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
     ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
     TEST_LOCAL_TEARDOWN;
 }

--- a/tests/utests/schema/test_printer_tree.c
+++ b/tests/utests/schema/test_printer_tree.c
@@ -1841,51 +1841,316 @@ yang_data(void **state)
     TEST_LOCAL_TEARDOWN;
 }
 
+static LY_ERR
+getter(const struct lysc_ext_instance *ext, void *user_data, void **ext_data, ly_bool *ext_data_free)
+{
+    struct ly_ctx *ctx;
+    struct lyd_node *data = NULL;
+
+    ctx = ext->module->ctx;
+    if (user_data) {
+        assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(ctx, user_data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &data));
+    }
+
+    *ext_data = data;
+    *ext_data_free = 1;
+    return LY_SUCCESS;
+}
+
+#define SM_MODNAME_EXT "sm-extension"
+#define SM_MOD_EXT_NAMESPACE "urn:sm-ext"
+#define SM_PREF "sm"
+#define SCHEMA_REF_INLINE "<inline></inline>"
+#define SCHEMA_REF_SHARED(REF) "<shared-schema>"REF"</shared-schema>"
+
+#define EXT_DATA(MPMOD_NAME, MODULES, SCHEMA_REF) \
+    "<yang-library xmlns=\"urn:ietf:params:xml:ns:yang:ietf-yang-library\"\n" \
+    "   xmlns:ds=\"urn:ietf:params:xml:ns:yang:ietf-datastores\">\n" \
+    "<module-set>\n" \
+    "   <name>test-set</name>\n" \
+    "   <module>\n" \
+    "      <name>"SM_MODNAME_EXT"</name>\n" \
+    "      <namespace>"SM_MOD_EXT_NAMESPACE"</namespace>\n" \
+    "   </module>\n" \
+    MODULES \
+    "</module-set>\n" \
+    "<content-id>1</content-id>\n" \
+    "</yang-library>\n" \
+    "<modules-state xmlns=\"urn:ietf:params:xml:ns:yang:ietf-yang-library\">\n" \
+    "<module-set-id>1</module-set-id>\n" \
+    "</modules-state>\n" \
+    "<schema-mounts xmlns=\"urn:ietf:params:xml:ns:yang:ietf-yang-schema-mount\">\n" \
+    "<namespace>\n" \
+    "   <prefix>"SM_PREF"</prefix>\n" \
+    "   <uri>x:"MPMOD_NAME"</uri>\n" \
+    "</namespace>\n" \
+    "<mount-point>\n" \
+    "   <module>"MPMOD_NAME"</module>\n" \
+    "   <label>mnt-root</label>\n" \
+    SCHEMA_REF \
+    "</mount-point>\n" \
+    "</schema-mounts>"
+
+#define SM_MOD_MAIN(NAME, BODY) \
+    "module "NAME" {\n" \
+    "  yang-version 1.1;\n" \
+    "  namespace \"x:"NAME"\";\n" \
+    "  prefix \"x\";\n" \
+    "  import ietf-yang-schema-mount {\n" \
+    "    prefix yangmnt;\n" \
+    "  }\n" \
+    BODY \
+    "}"
+
 static void
 mount_point(void **state)
 {
+    char *data;
+
     TEST_LOCAL_SETUP;
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
 
-    orig =
-            "module a29 {\n"
-            "  yang-version 1.1;\n"
-            "  namespace \"x:y\";\n"
-            "  prefix x;\n"
-            "  import ietf-yang-schema-mount {\n"
-            "prefix yangmnt;\n"
-            "  }\n"
-            "  list my-list {\n"
-            "    key name;\n"
-            "    leaf name {\n"
-            "      type string;\n"
-            "    }\n"
-            "    yangmnt:mount-point \"mnt-root\";\n"
-            "  }\n"
-            "  container my-cont {\n"
-            "    yangmnt:mount-point \"mnt-root\";\n"
-            "  }\n"
-            "}\n";
+    /* interested in sm-extension.yang and sm-mod.yang */
+    assert_int_equal(LY_SUCCESS, ly_ctx_set_searchdir(UTEST_LYCTX, TESTS_DIR_MODULES_YANG));
 
+    /*
+     * 'mp' flag for list and container
+     */
+    orig = SM_MOD_MAIN("a29",
+            "list lt {\n"
+            "  key \"name\";\n"
+            "  leaf name {\n"
+            "    type string;\n"
+            "  }\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n"
+            "container cont {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n");
     expect =
             "module: a29\n"
-            "  +--mp my-list* [name]\n"
+            "  +--mp lt* [name]\n"
             "  |  +--rw name    string\n"
-            "  +--mp my-cont\n";
-
+            "  +--mp cont\n";
     UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
-
     ly_out_reset(UTEST_OUT);
 
-    /* using lysc tree */
-    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    /*
+     * mount schema by 'inline' schema-ref
+     */
+    orig = SM_MOD_MAIN("a30",
+            "list lt {\n"
+            "  key \"name\";\n"
+            "  leaf name {\n"
+            "    type string;\n"
+            "  }\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n");
+    expect =
+            "module: a30\n"
+            "  +--mp lt* [name]\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--rw name    string\n";
+    data = EXT_DATA("a30", "", SCHEMA_REF_INLINE);
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
     TEST_LOCAL_PRINT(mod, 72);
     assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
     assert_string_equal(printed, expect);
-    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
+    ly_out_reset(UTEST_OUT);
 
+    /*
+     * mount schema into empty container
+     */
+    orig = SM_MOD_MAIN("a31",
+            "container cont {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n"
+            "leaf lf {\n"
+            "  type string;\n"
+            "}\n");
+    expect =
+            "module: a31\n"
+            "  +--mp cont\n"
+            "  |  +--rw tlist/ [name]\n"
+            "  |  |  +--rw name    uint32\n"
+            "  |  +--rw tcont/\n"
+            "  |     +--rw tleaf?   uint32\n"
+            "  +--rw lf?     string\n";
+    data = EXT_DATA("a31", "", SCHEMA_REF_INLINE);
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
+    /*
+     * mount schema into non-empty container
+     */
+    orig = SM_MOD_MAIN("a32",
+            "container cont {\n"
+            "  leaf lf1 {\n"
+            "    type string;\n"
+            "  }\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "  leaf lf2 {\n"
+            "    type string;\n"
+            "  }\n"
+            "}\n");
+    expect =
+            "module: a32\n"
+            "  +--mp cont\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--rw lf1?   string\n"
+            "     +--rw lf2?   string\n";
+    data = EXT_DATA("a32", "", SCHEMA_REF_INLINE);
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
+    /*
+     * mounting with parent-reference
+     */
+    orig = SM_MOD_MAIN("a33",
+            "list pr {\n"
+            "  key \"name\";\n"
+            "  leaf name {\n"
+            "    type string;\n"
+            "  }\n"
+            "  leaf prlf {\n"
+            "    type string;\n"
+            "  }\n"
+            "}\n"
+            "leaf lf {\n"
+            "  type string;\n"
+            "}\n"
+            "container cont {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "  list lt {\n"
+            "    key \"name\";\n"
+            "    leaf name {\n"
+            "      type string;\n"
+            "    }\n"
+            "  }\n"
+            "}\n");
+    expect =
+            "module: a33\n"
+            "  +--rw pr* [name]\n"
+            "  |  +--rw name    string\n"
+            "  |  +--rw prlf?   string\n"
+            "  +--rw lf?     string\n"
+            "  +--mp cont\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--rw pr@ [name]\n"
+            "     |  +--rw prlf?   string\n"
+            "     +--rw lf@   string\n"
+            "     +--rw lt* [name]\n"
+            "        +--rw name    string\n";
+    data = EXT_DATA("a33", "", SCHEMA_REF_SHARED(
+            "<parent-reference>/"SM_PREF ":pr/"SM_PREF ":prlf</parent-reference>\n"
+            "<parent-reference>/"SM_PREF ":lf</parent-reference>\n"));
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
+    /*
+     * mounting with parent-reference into empty container
+     */
+    orig = SM_MOD_MAIN("a34",
+            "container cont {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n"
+            "leaf lf {\n"
+            "  type string;\n"
+            "}\n");
+    expect =
+            "module: a34\n"
+            "  +--mp cont\n"
+            "  |  +--rw tlist/ [name]\n"
+            "  |  |  +--rw name    uint32\n"
+            "  |  +--rw tcont/\n"
+            "  |  |  +--rw tleaf?   uint32\n"
+            "  |  +--rw lf@   string\n"
+            "  +--rw lf?     string\n";
+    data = EXT_DATA("a34", "",
+            SCHEMA_REF_SHARED(
+            "<parent-reference>/"SM_PREF ":lf</parent-reference>\n"));
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
+    /*
+     * mounting module which is only parsed
+     */
+    orig = SM_MOD_MAIN("a35",
+            "import sm-mod {\n"
+            "  prefix smm;\n"
+            "}\n"
+            "container pr {\n"
+            "  leaf prlf {\n"
+            "    type uint32;\n"
+            "  }\n"
+            "}\n"
+            "list lt {\n"
+            "  key \"name\";\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "  leaf name {\n"
+            "    type string;\n"
+            "  }\n"
+            "}\n");
+    expect =
+            "module: a35\n"
+            "  +--rw pr\n"
+            "  |  +--rw prlf?   uint32\n"
+            "  +--mp lt* [name]\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--mp ncmp/\n"
+            "     +--rw not-compiled/\n"
+            "     |  +--rw first?    string\n"
+            "     |  +--rw second?   string\n"
+            "     +--rw pr@\n"
+            "     |  +--rw prlf?   uint32\n"
+            "     +--rw name    string\n";
+    data = EXT_DATA("a35",
+            "<module>\n"
+            "   <name>sm-mod</name>\n"
+            "   <namespace>urn:sm-mod</namespace>\n"
+            "</module>\n",
+            SCHEMA_REF_SHARED(
+            "<parent-reference>/"SM_PREF ":pr/"SM_PREF ":prlf</parent-reference>\n"));
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
+    ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
     TEST_LOCAL_TEARDOWN;
 }
 
@@ -1921,7 +2186,7 @@ main(void)
         UTEST(print_compiled_node),
         UTEST(print_parsed_submodule),
         UTEST(yang_data),
-        UTEST(mount_point),
+        UTEST(mount_point)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/utests/schema/test_printer_tree.c
+++ b/tests/utests/schema/test_printer_tree.c
@@ -2150,6 +2150,44 @@ mount_point(void **state)
     assert_string_equal(printed, expect);
     ly_out_reset(UTEST_OUT);
 
+    /*
+     * notifications and rpcs in mounted module
+     */
+    orig = SM_MOD_MAIN("a36",
+            "container cont {\n"
+            "  yangmnt:mount-point \"mnt-root\";\n"
+            "}\n");
+    expect =
+            "module: a36\n"
+            "  +--mp cont\n"
+            "     +--rw tlist/ [name]\n"
+            "     |  +--rw name    uint32\n"
+            "     +--rw tcont/\n"
+            "     |  +--rw tleaf?   uint32\n"
+            "     +--rw cont/\n"
+            "     |  +---x cr\n"
+            "     |  |  +---w input\n"
+            "     |  |  |  +---w in?   string\n"
+            "     |  |  +--ro output\n"
+            "     |  |     +--ro out?   string\n"
+            "     |  +---n cn\n"
+            "     +---x r1/\n"
+            "     +---x r2/\n"
+            "     +---n n1/\n"
+            "     +---n n2/\n";
+    data = EXT_DATA("a36",
+            "<module>\n"
+            "   <name>sm-rpcnotif</name>\n"
+            "   <namespace>urn:rpcnotif</namespace>\n"
+            "</module>\n",
+            SCHEMA_REF_INLINE);
+    ly_ctx_set_ext_data_clb(UTEST_LYCTX, getter, data);
+    UTEST_ADD_MODULE(orig, LYS_IN_YANG, NULL, &mod);
+    TEST_LOCAL_PRINT(mod, 72);
+    assert_int_equal(strlen(expect), ly_out_printed(UTEST_OUT));
+    assert_string_equal(printed, expect);
+    ly_out_reset(UTEST_OUT);
+
     ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_SET_PRIV_PARSED);
     TEST_LOCAL_TEARDOWN;
 }

--- a/tools/lint/common.h
+++ b/tools/lint/common.h
@@ -44,6 +44,12 @@
 #define YLMSG_W(...) \
         fprintf(stderr, "YANGLINT[W]: " __VA_ARGS__)
 
+#ifndef _WIN32
+# define PATH_SEPARATOR ":"
+#else
+# define PATH_SEPARATOR ";"
+#endif
+
 /**
  * @brief Storage for the list of the features (their names) in a specific YANG module.
  */


### PR DESCRIPTION
This pull request partly refactored PR #1901.
Printer tree and mount-point tests have also been added.
The biggest change concerns the printing of the shared-schema tree based on parent-references. Individual paths to parent-reference nodes are not printed, but instead are combined into a single tree if they have a common parents.