### PR TITLE
resolve Segmentation fault when get extensions plugin

### DIFF
--- a/src/plugins.c
+++ b/src/plugins.c
@@ -458,7 +458,7 @@ ext_get_plugin(const char *name, const char *module, const char *revision)
 
     for (u = 0; u < ext_plugins_count; u++) {
         if (!strcmp(name, ext_plugins[u].name) && !strcmp(module, ext_plugins[u].module) &&
-                ((!revision && !ext_plugins[u].revision) || (revision && !strcmp(revision, ext_plugins[u].revision)))) {
+                (!ext_plugins[u].revision || (revision && !strcmp(revision, ext_plugins[u].revision)))) {
             /* we have the match */
             return ext_plugins[u].plugin;
         }


### PR DESCRIPTION
If ext_plugins[u].revision is NULL, revision is not NULL, resulting in a Segmentation fault