### PR TITLE
docs: `lyd_path()` on disconnected nodes

### DIFF
--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -2302,6 +2302,10 @@ typedef enum {
 /**
  * @brief Generate path of the given node in the requested format.
  *
+ * The path is constructed based on the parent node(s) of this node. When run on a node which is disconnected
+ * from its parent(s), this function might yield unexpected results such as `/example:b` instead of the expected
+ * `/example:a/b`.
+ *
  * @param[in] node Data path of this node will be generated.
  * @param[in] pathtype Format of the path to generate.
  * @param[in,out] buffer Prepared buffer of the @p buflen length to store the generated path.


### PR DESCRIPTION
sysrepo's `sr_get_node()` returns a single `lyd_node` which is disconnected from its parents. If that node is not a top-level one in a module, this means that calling `lyd_path()` on it will be different compared to what would be returned from a node tree which includes the parents.

We caught this when working on C++ bindings for `sr_get_node()`, and on Slack it was agreed that this function is probably the best candidate for a doc tweak. The whole concept of "disconnected nodes" is not properly defined anywhere, but I think it's OK to consider this an edge case, and just document what exactly is going on.