### PR TITLE
Replaced pthread_key_create() by a memory pointer because the number …

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -327,7 +327,7 @@ struct ly_ctx {
 
     ly_ext_data_clb ext_clb;          /**< optional callback for providing extension-specific run-time data for extensions */
     void *ext_clb_data;               /**< optional private data for ::ly_ctx.ext_clb */
-    pthread_key_t errlist_key;        /**< key for the thread-specific list of errors related to the context */
+    struct ly_err_item *errlist;
     pthread_mutex_t lyb_hash_lock;    /**< lock for storing LYB schema hashes in schema nodes */
 };
 

--- a/src/context.c
+++ b/src/context.c
@@ -251,9 +251,6 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
     /* plugins */
     LY_CHECK_ERR_GOTO(lyplg_init(), LOGINT(NULL); rc = LY_EINT, cleanup);
 
-    /* initialize thread-specific keys */
-    while ((pthread_key_create(&ctx->errlist_key, ly_err_free)) == EAGAIN) {}
-
     /* init LYB hash lock */
     pthread_mutex_init(&ctx->lyb_hash_lock, NULL);
 
@@ -1281,7 +1278,6 @@ ly_ctx_destroy(struct ly_ctx *ctx)
 
     /* clean the error list */
     ly_err_clean(ctx, 0);
-    pthread_key_delete(ctx->errlist_key);
 
     /* dictionary */
     lydict_clean(&ctx->dict);


### PR DESCRIPTION
…of pthread keys is limited by PTHREAD_KEY_MAX which is 1024. As such, the number of ly_ctx is also limited to 1024. This value can only be changed by re-building libc. This change works for my case but I'm not sure that it is safe or not for general use.