### PR TITLE
tests: expect: increase timeout

### DIFF
--- a/tools/lint/tests/interactive/ly.tcl
+++ b/tools/lint/tests/interactive/ly.tcl
@@ -2,8 +2,8 @@ package require Expect
 
 source [expr {[info exists ::env(TESTS_DIR)] ? "$env(TESTS_DIR)/common.tcl" : "../common.tcl"}]
 
-# set the timeout to 1 second
-set timeout 1
+# set the timeout to 5 seconds
+set timeout 5
 # prompt of yanglint
 set prompt "> "
 # turn off dialog between expect and yanglint


### PR DESCRIPTION
I'm usually running these tests in a highly parallel manner, and I was getting an annoying high rate of failures in the `yanglint_interactive` test.

Bug: https://github.com/CESNET/libyang/issues/2047