### PR TITLE
Windows: accept backslashes in file names

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1749,8 +1749,6 @@ lys_parse_in(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format,
     struct lysp_yin_ctx *yinctx = NULL;
     struct lysp_ctx *pctx = NULL;
     struct lysf_ctx fctx = {.ctx = ctx};
-    char *filename, *rev, *dot;
-    size_t len;
     ly_bool module_created = 0;
 
     assert(ctx && in && new_mods);
@@ -1831,30 +1829,7 @@ lys_parse_in(struct ly_ctx *ctx, struct ly_in *in, LYS_INFORMAT format,
 
     switch (in->type) {
     case LY_IN_FILEPATH:
-        /* check that name and revision match filename */
-        filename = strrchr(in->method.fpath.filepath, '/');
-        if (!filename) {
-            filename = in->method.fpath.filepath;
-        } else {
-            filename++;
-        }
-        rev = strchr(filename, '@');
-        dot = strrchr(filename, '.');
-
-        /* name */
-        len = strlen(mod->name);
-        if (strncmp(filename, mod->name, len) ||
-                ((rev && (rev != &filename[len])) || (!rev && (dot != &filename[len])))) {
-            LOGWRN(ctx, "File name \"%s\" does not match module name \"%s\".", filename, mod->name);
-        }
-        if (rev) {
-            len = dot - ++rev;
-            if (!mod->parsed->revs || (len != LY_REV_SIZE - 1) || strncmp(mod->parsed->revs[0].date, rev, len)) {
-                LOGWRN(ctx, "File name \"%s\" does not match module revision \"%s\".", filename,
-                        mod->parsed->revs ? mod->parsed->revs[0].date : "none");
-            }
-        }
-
+        ly_check_module_filename(ctx, mod->name, mod->parsed->revs ? mod->parsed->revs[0].date : NULL, in->method.fpath.filepath);
         break;
     case LY_IN_FD:
     case LY_IN_FILE:

--- a/src/tree_schema_common.c
+++ b/src/tree_schema_common.c
@@ -2599,6 +2599,13 @@ ly_check_module_filename(const struct ly_ctx *ctx, const char *name, const char 
 
     /* check that name and revision match filename */
     basename = strrchr(filename, '/');
+#ifdef _WIN32
+    const char *backslash = strrchr(filename, '\\');
+
+    if (!basename || (basename && backslash && (backslash > basename))) {
+        basename = backslash;
+    }
+#endif
     if (!basename) {
         basename = filename;
     } else {

--- a/src/tree_schema_internal.h
+++ b/src/tree_schema_internal.h
@@ -732,4 +732,14 @@ uint8_t lys_stmt_flags(enum ly_stmt stmt);
  */
 LY_ERR lyplg_ext_get_storage_p(const struct lysc_ext_instance *ext, int stmt, const void ***storage_p);
 
+/**
+ * @brief Warning if the filename does not match the expected module name and version
+ *
+ * @param[in] ctx Context for logging
+ * @param[in] name Expected module name
+ * @param[in] revision Expected module revision, or NULL if not to be checked
+ * @param[in] filename File path to be checked
+ */
+void ly_check_module_filename(const struct ly_ctx *ctx, const char *name, const char *revision, const char *filename);
+
 #endif /* LY_TREE_SCHEMA_INTERNAL_H_ */

--- a/tools/lint/common.c
+++ b/tools/lint/common.c
@@ -54,6 +54,7 @@ parse_schema_path(const char *path, char **dir, char **module)
 
     /* split the path to dirname and basename for further work */
     *dir = strdup(path);
+    /* FIXME: this is broken on Windows */
     *module = strrchr(*dir, '/');
     if (!(*module)) {
         *module = *dir;


### PR DESCRIPTION
Without this patch, a warning gets printed for any .yang files that are read using native path names:
```
libyang[1]: File name "D:\a\oopt-gnpy-libyang\oopt-gnpy-libyang\tests\yang\ietf-network@2018-02-26.yang" does not match module name "ietf-network".
```