### PR TITLE
printer json BUGFIX nested union value print

### DIFF
--- a/src/printer_json.c
+++ b/src/printer_json.c
@@ -363,7 +363,8 @@ print_val:
     switch (basetype) {
     case LY_TYPE_UNION:
         /* use the resolved type */
-        basetype = val->subvalue->value.realtype->basetype;
+        val = &val->subvalue->value;
+        basetype = val->realtype->basetype;
         goto print_val;
 
     case LY_TYPE_BINARY:


### PR DESCRIPTION
Fix an infinite loop in json_print_value() when
resolved type of a union member is also union.

Fixes: 183b911ec920 ("printer json BUGFIX union realtype value print")