### PR TITLE
Optimize hash table insertion

### DIFF
--- a/src/dict.c
+++ b/src/dict.c
@@ -70,25 +70,23 @@ lydict_clean(struct ly_dict *dict)
 {
     struct ly_dict_rec *dict_rec = NULL;
     struct ly_ht_rec *rec = NULL;
+    uint32_t hlist_idx;
+    uint32_t rec_idx;
 
     LY_CHECK_ARG_RET(NULL, dict, );
 
-    for (uint32_t i = 0; i < dict->hash_tab->size; i++) {
-        /* get ith record */
-        rec = (struct ly_ht_rec *)&dict->hash_tab->recs[i * dict->hash_tab->rec_size];
-        if (rec->hits == 1) {
-            /*
-             * this should not happen, all records inserted into
-             * dictionary are supposed to be removed using lydict_remove()
-             * before calling lydict_clean()
-             */
-            dict_rec = (struct ly_dict_rec *)rec->val;
-            LOGWRN(NULL, "String \"%s\" not freed from the dictionary, refcount %d", dict_rec->value, dict_rec->refcount);
-            /* if record wasn't removed before free string allocated for that record */
+    LYHT_ITER_ALL_RECS(dict->hash_tab, hlist_idx, rec_idx, rec) {
+        /*
+         * this should not happen, all records inserted into
+         * dictionary are supposed to be removed using lydict_remove()
+         * before calling lydict_clean()
+         */
+        dict_rec = (struct ly_dict_rec *)rec->val;
+        LOGWRN(NULL, "String \"%s\" not freed from the dictionary, refcount %d", dict_rec->value, dict_rec->refcount);
+        /* if record wasn't removed before free string allocated for that record */
 #ifdef NDEBUG
-            free(dict_rec->value);
+        free(dict_rec->value);
 #endif
-        }
     }
 
     /* free table and destroy mutex */

--- a/src/hash_table.c
+++ b/src/hash_table.c
@@ -65,10 +65,11 @@ lyht_init_hlists_and_records(struct ly_ht *ht)
     LY_CHECK_ERR_RET(!ht->recs, LOGMEM(NULL), LY_EMEM);
     for (i = 0; i < ht->size; i++) {
         rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        if (i != ht->size)
+        if (i != ht->size) {
             rec->next = i + 1;
-        else
+        } else {
             rec->next = LYHT_NO_RECORD;
+        }
     }
 
     ht->hlists = malloc(sizeof(ht->hlists[0]) * ht->size);
@@ -164,8 +165,9 @@ lyht_free(struct ly_ht *ht, void (*val_free)(void *val_p))
     }
 
     if (val_free) {
-        LYHT_ITER_ALL_RECS(ht, hlist_idx, rec_idx, rec)
+        LYHT_ITER_ALL_RECS(ht, hlist_idx, rec_idx, rec) {
             val_free(&rec->val);
+        }
     }
     free(ht->hlists);
     free(ht->recs);
@@ -216,14 +218,15 @@ lyht_resize(struct ly_ht *ht, int operation, int check)
     /* add all the old records into the new records array */
     for (i = 0; i < old_size; i++) {
         for (rec_idx = old_hlists[i].first, rec = lyht_get_rec(old_recs, ht->rec_size, rec_idx);
-             rec_idx != LYHT_NO_RECORD;
-             rec_idx = rec->next, rec = lyht_get_rec(old_recs, ht->rec_size, rec_idx)) {
+                rec_idx != LYHT_NO_RECORD;
+                rec_idx = rec->next, rec = lyht_get_rec(old_recs, ht->rec_size, rec_idx)) {
             LY_ERR ret;
 
-            if (check)
+            if (check) {
                 ret = lyht_insert(ht, rec->val, rec->hash, NULL);
-            else
+            } else {
                 ret = lyht_insert_no_check(ht, rec->val, rec->hash, NULL);
+            }
 
             assert(!ret);
             (void)ret;
@@ -311,8 +314,8 @@ lyht_find_next_with_collision_cb(struct ly_ht *ht, void *val_p, uint32_t hash,
     }
 
     for (rec_idx = rec->next, rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);
-         rec_idx != LYHT_NO_RECORD;
-         rec_idx = rec->next, rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx)) {
+            rec_idx != LYHT_NO_RECORD;
+            rec_idx = rec->next, rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx)) {
 
         if (rec->hash != hash) {
             continue;
@@ -442,24 +445,27 @@ lyht_remove_with_resize_cb(struct ly_ht *ht, void *val_p, uint32_t hash, lyht_va
     uint32_t rec_idx;
 
     LY_CHECK_ERR_RET(lyht_find_rec(ht, val_p, hash, 1, NULL, NULL, &found_rec),
-                     LOGARG(NULL, hash), LY_ENOTFOUND); /* hash not found */
+            LOGARG(NULL, hash), LY_ENOTFOUND);          /* hash not found */
 
     prev_rec_idx = LYHT_NO_RECORD;
     LYHT_ITER_HLIST_RECS(ht, hlist_idx, rec_idx, rec) {
-        if (rec == found_rec)
+        if (rec == found_rec) {
             break;
+        }
         prev_rec_idx = rec_idx;
     }
 
     if (prev_rec_idx == LYHT_NO_RECORD) {
         ht->hlists[hlist_idx].first = rec->next;
-        if (rec->next == LYHT_NO_RECORD)
+        if (rec->next == LYHT_NO_RECORD) {
             ht->hlists[hlist_idx].last = LYHT_NO_RECORD;
+        }
     } else {
         prev_rec = lyht_get_rec(ht->recs, ht->rec_size, prev_rec_idx);
         prev_rec->next = rec->next;
-        if (rec->next == LYHT_NO_RECORD)
+        if (rec->next == LYHT_NO_RECORD) {
             ht->hlists[hlist_idx].last = prev_rec_idx;
+        }
     }
 
     rec->next = ht->first_free_rec;
@@ -495,8 +501,9 @@ lyht_remove(struct ly_ht *ht, void *val_p, uint32_t hash)
 LIBYANG_API_DEF uint32_t
 lyht_get_fixed_size(uint32_t item_count)
 {
-    if (item_count == 0)
+    if (item_count == 0) {
         return 1;
+    }
 
     /* return next power of 2 (greater or equal) */
     item_count--;

--- a/src/hash_table.h
+++ b/src/hash_table.h
@@ -172,6 +172,19 @@ LIBYANG_API_DECL LY_ERR lyht_find_next_with_collision_cb(struct ly_ht *ht, void 
 LIBYANG_API_DECL LY_ERR lyht_insert(struct ly_ht *ht, void *val_p, uint32_t hash, void **match_p);
 
 /**
+ * @brief Insert a value into a hash table, without checking whether the value has already been inserted.
+ *
+ * @param[in] ht Hash table to insert into.
+ * @param[in] val_p Pointer to the value to insert. Be careful, if the values stored in the hash table
+ * are pointers, @p val_p must be a pointer to a pointer.
+ * @param[in] hash Hash of the stored value.
+ * @param[out] match_p Pointer to the stored value, optional
+ * @return LY_SUCCESS on success,
+ * @return LY_EMEM in case of memory allocation failure.
+ */
+LIBYANG_API_DECL LY_ERR lyht_insert_no_check(struct ly_ht *ht, void *val_p, uint32_t hash, void **match_p);
+
+/**
  * @brief Insert a value into hash table. Same functionality as ::lyht_insert()
  * but allows to specify a temporary val equal callback to be used in case the hash table
  * will be resized after successful insertion.

--- a/src/hash_table_internal.h
+++ b/src/hash_table_internal.h
@@ -50,6 +50,11 @@ struct ly_ht_rec {
 /* real size, without taking the val[1] in account */
 #define SIZEOF_LY_HT_REC (sizeof(struct ly_ht_rec) - 1)
 
+struct ly_ht_hlist {
+    uint32_t first;
+    uint32_t last;
+};
+
 /**
  * @brief (Very) generic hash table.
  *
@@ -81,7 +86,7 @@ struct ly_ht {
                            * 2 - both shrinking and enlarging is enabled */
     uint16_t rec_size;    /* real size (in bytes) of one record for accessing recs array */
     uint32_t first_free_rec; /* index of the first free record */
-    uint32_t *hlists;     /* pointer to the hlists table */
+    struct ly_ht_hlist *hlists; /* pointer to the hlists table */
     unsigned char *recs;  /* pointer to the hash table itself (array of struct ht_rec) */
 };
 
@@ -97,7 +102,7 @@ lyht_get_rec(unsigned char *recs, uint16_t rec_size, uint32_t idx)
 
 /* Iterate all records in a hlist */
 #define LYHT_ITER_HLIST_RECS(ht, hlist_idx, rec_idx, rec)               \
-    for (rec_idx = ht->hlists[hlist_idx],                               \
+    for (rec_idx = ht->hlists[hlist_idx].first,                         \
              rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);       \
          rec_idx != LYHT_NO_RECORD;                                     \
          rec_idx = rec->next,                                           \

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -128,7 +128,7 @@ lyd_insert_hash_add(struct ly_ht *ht, struct lyd_node *node, ly_bool empty_ht)
     assert(ht && node && node->schema);
 
     /* add node itself */
-    if (lyht_insert(ht, &node, node->hash, NULL)) {
+    if (lyht_insert_no_check(ht, &node, node->hash, NULL)) {
         LOGINT_RET(LYD_CTX(node));
     }
 

--- a/src/tree_data_hash.c
+++ b/src/tree_data_hash.c
@@ -182,8 +182,7 @@ lyd_insert_hash(struct lyd_node *node)
             }
         }
         if (u >= LYD_HT_MIN_ITEMS) {
-            /* create hash table, insert all the children */
-            node->parent->children_ht = lyht_new(1, sizeof(struct lyd_node *), lyd_hash_table_val_equal, NULL, 1);
+            node->parent->children_ht = lyht_new(lyht_get_fixed_size(u), sizeof(struct lyd_node *), lyd_hash_table_val_equal, NULL, 1);
             LY_LIST_FOR(node->parent->child, iter) {
                 if (iter->schema) {
                     LY_CHECK_RET(lyd_insert_hash_add(node->parent->children_ht, iter, 1));

--- a/tests/utests/basic/test_hash_table.c
+++ b/tests/utests/basic/test_hash_table.c
@@ -19,8 +19,6 @@
 #include "common.h"
 #include "hash_table.h"
 
-struct ly_ht_rec *lyht_get_rec(unsigned char *recs, uint16_t rec_size, uint32_t idx);
-
 static void
 test_invalid_arguments(void **state)
 {
@@ -103,7 +101,6 @@ static void
 test_ht_resize(void **state)
 {
     uint32_t i;
-    struct ly_ht_rec *rec;
     struct ly_ht *ht;
 
     assert_non_null(ht = lyht_new(8, sizeof(int), ht_equal_clb, NULL, 1));
@@ -120,13 +117,12 @@ test_ht_resize(void **state)
     for (i = 0; i < 16; ++i) {
         if ((i >= 2) && (i < 8)) {
             /* inserted data on indexes 2-7 */
-            rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-            assert_int_equal(1, rec->hits);
-            assert_int_equal(i, rec->hash);
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, i, NULL));
         } else {
             /* nothing otherwise */
-            rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-            assert_int_equal(0, rec->hits);
+            assert_int_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, i, NULL));
         }
     }
 
@@ -164,6 +160,8 @@ test_ht_collisions(void **UNUSED(state))
     uint32_t i;
     struct ly_ht_rec *rec;
     struct ly_ht *ht;
+    uint32_t rec_idx;
+    int count;
 
     assert_non_null(ht = lyht_new(8, sizeof(int), ht_equal_clb, NULL, 1));
 
@@ -172,66 +170,64 @@ test_ht_collisions(void **UNUSED(state))
     }
 
     /* check all records */
-    for (i = 0; i < 2; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
+    for (i = 0; i < 8; ++i) {
+        if (i == 2)
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+        else
+            assert_int_equal(UINT32_MAX, ht->hlists[i]);
     }
-    rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-    assert_int_equal(rec->hits, 4);
-    assert_int_equal(GET_REC_INT(rec), i);
-    ++i;
-    for ( ; i < 6; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 1);
-        assert_int_equal(GET_REC_INT(rec), i);
+    for (i = 0; i < 8; ++i) {
+        if (i >= 2 && i < 6)
+            assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, 2, NULL));
+        else
+            assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
     }
-    for ( ; i < 8; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
+    rec_idx = ht->hlists[2];
+    count = 0;
+    while (rec_idx != UINT32_MAX) {
+        rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);
+        rec_idx = rec->next;
+        assert_int_equal(rec->hash, 2);
+        count++;
     }
+    assert_int_equal(count, 4);
 
     i = 4;
     assert_int_equal(lyht_remove(ht, &i, 2), 0);
 
     rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-    assert_int_equal(rec->hits, -1);
 
     i = 2;
     assert_int_equal(lyht_remove(ht, &i, 2), 0);
 
     /* check all records */
-    for (i = 0; i < 2; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
+    for (i = 0; i < 8; ++i) {
+        if (i == 2)
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+        else
+            assert_int_equal(UINT32_MAX, ht->hlists[i]);
     }
-    rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-    assert_int_equal(rec->hits, 2);
-    assert_int_equal(GET_REC_INT(rec), 5);
-    ++i;
-    rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-    assert_int_equal(rec->hits, 1);
-    assert_int_equal(GET_REC_INT(rec), 3);
-    ++i;
-    for ( ; i < 6; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, -1);
+    for (i = 0; i < 8; ++i) {
+        if (i == 3 || i == 5)
+            assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, 2, NULL));
+        else
+            assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
     }
-    for ( ; i < 8; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
+    rec_idx = ht->hlists[2];
+    count = 0;
+    while (rec_idx != UINT32_MAX) {
+        rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);
+        rec_idx = rec->next;
+        assert_int_equal(rec->hash, 2);
+        count++;
     }
+    assert_int_equal(count, 2);
 
-    for (i = 0; i < 3; ++i) {
-        assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_ENOTFOUND);
-    }
-    assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_SUCCESS);
-    ++i;
-    assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_ENOTFOUND);
-    ++i;
-    assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_SUCCESS);
-    ++i;
-    for ( ; i < 8; ++i) {
-        assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_ENOTFOUND);
+    for (i = 0; i < 8; ++i) {
+        if (i == 3 || i == 5)
+            assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_SUCCESS);
+        else
+            assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_ENOTFOUND);
     }
 
     i = 3;
@@ -240,17 +236,8 @@ test_ht_collisions(void **UNUSED(state))
     assert_int_equal(lyht_remove(ht, &i, 2), 0);
 
     /* check all records */
-    for (i = 0; i < 2; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
-    }
-    for ( ; i < 6; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, -1);
-    }
-    for ( ; i < 8; ++i) {
-        rec = lyht_get_rec(ht->recs, ht->rec_size, i);
-        assert_int_equal(rec->hits, 0);
+    for (i = 0; i < 8; ++i) {
+        assert_int_equal(UINT32_MAX, ht->hlists[i]);
     }
 
     lyht_free(ht, NULL);

--- a/tests/utests/basic/test_hash_table.c
+++ b/tests/utests/basic/test_hash_table.c
@@ -117,11 +117,11 @@ test_ht_resize(void **state)
     for (i = 0; i < 16; ++i) {
         if ((i >= 2) && (i < 8)) {
             /* inserted data on indexes 2-7 */
-            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i].first);
             assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, i, NULL));
         } else {
             /* nothing otherwise */
-            assert_int_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_equal(UINT32_MAX, ht->hlists[i].first);
             assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, i, NULL));
         }
     }
@@ -172,9 +172,9 @@ test_ht_collisions(void **UNUSED(state))
     /* check all records */
     for (i = 0; i < 8; ++i) {
         if (i == 2)
-            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i].first);
         else
-            assert_int_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_equal(UINT32_MAX, ht->hlists[i].first);
     }
     for (i = 0; i < 8; ++i) {
         if (i >= 2 && i < 6)
@@ -182,7 +182,7 @@ test_ht_collisions(void **UNUSED(state))
         else
             assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
     }
-    rec_idx = ht->hlists[2];
+    rec_idx = ht->hlists[2].first;
     count = 0;
     while (rec_idx != UINT32_MAX) {
         rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);
@@ -203,9 +203,9 @@ test_ht_collisions(void **UNUSED(state))
     /* check all records */
     for (i = 0; i < 8; ++i) {
         if (i == 2)
-            assert_int_not_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_not_equal(UINT32_MAX, ht->hlists[i].first);
         else
-            assert_int_equal(UINT32_MAX, ht->hlists[i]);
+            assert_int_equal(UINT32_MAX, ht->hlists[i].first);
     }
     for (i = 0; i < 8; ++i) {
         if (i == 3 || i == 5)
@@ -213,7 +213,7 @@ test_ht_collisions(void **UNUSED(state))
         else
             assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
     }
-    rec_idx = ht->hlists[2];
+    rec_idx = ht->hlists[2].first;
     count = 0;
     while (rec_idx != UINT32_MAX) {
         rec = lyht_get_rec(ht->recs, ht->rec_size, rec_idx);
@@ -237,7 +237,7 @@ test_ht_collisions(void **UNUSED(state))
 
     /* check all records */
     for (i = 0; i < 8; ++i) {
-        assert_int_equal(UINT32_MAX, ht->hlists[i]);
+        assert_int_equal(UINT32_MAX, ht->hlists[i].first);
     }
 
     lyht_free(ht, NULL);

--- a/tests/utests/basic/test_hash_table.c
+++ b/tests/utests/basic/test_hash_table.c
@@ -171,16 +171,18 @@ test_ht_collisions(void **UNUSED(state))
 
     /* check all records */
     for (i = 0; i < 8; ++i) {
-        if (i == 2)
+        if (i == 2) {
             assert_int_not_equal(UINT32_MAX, ht->hlists[i].first);
-        else
+        } else {
             assert_int_equal(UINT32_MAX, ht->hlists[i].first);
+        }
     }
     for (i = 0; i < 8; ++i) {
-        if (i >= 2 && i < 6)
+        if ((i >= 2) && (i < 6)) {
             assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, 2, NULL));
-        else
+        } else {
             assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
+        }
     }
     rec_idx = ht->hlists[2].first;
     count = 0;
@@ -202,16 +204,18 @@ test_ht_collisions(void **UNUSED(state))
 
     /* check all records */
     for (i = 0; i < 8; ++i) {
-        if (i == 2)
+        if (i == 2) {
             assert_int_not_equal(UINT32_MAX, ht->hlists[i].first);
-        else
+        } else {
             assert_int_equal(UINT32_MAX, ht->hlists[i].first);
+        }
     }
     for (i = 0; i < 8; ++i) {
-        if (i == 3 || i == 5)
+        if ((i == 3) || (i == 5)) {
             assert_int_equal(LY_SUCCESS, lyht_find(ht, &i, 2, NULL));
-        else
+        } else {
             assert_int_equal(LY_ENOTFOUND, lyht_find(ht, &i, 2, NULL));
+        }
     }
     rec_idx = ht->hlists[2].first;
     count = 0;
@@ -224,10 +228,11 @@ test_ht_collisions(void **UNUSED(state))
     assert_int_equal(count, 2);
 
     for (i = 0; i < 8; ++i) {
-        if (i == 3 || i == 5)
+        if ((i == 3) || (i == 5)) {
             assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_SUCCESS);
-        else
+        } else {
             assert_int_equal(lyht_find(ht, &i, 2, NULL), LY_ENOTFOUND);
+        }
     }
 
     i = 3;


### PR DESCRIPTION
Hello,

This is a draft pull request that solves the issue #2106 

The idea is to allow to insert elements in the hash table in O(1), even in case of collisions. First, the hash table is reworked to avoid browsing records to find a free one. Then, a new API is added to allow an insertion without checking for duplicates.

Feedback is of course welcome!

Note: the first patch breaks the validation test, but it is fixed by the second. From what I understand, it is expected that the browsing order is the same than the insert order, but I think this was not always guaranteed by the previous implementation.
