### PR TITLE
lyd_new_path handle json encoded string leaves

### DIFF
--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -1529,6 +1529,12 @@ LIBYANG_API_DECL LY_ERR lyd_new_attr2(struct lyd_node *parent, const char *modul
                                             to unexpected behavior. */
 #define LYD_NEW_PATH_WITH_OPAQ 0x20 /**< Consider opaque nodes normally when searching for existing nodes. */
 
+#define LYD_NEW_PATH_JSON_VALUE  0x40   /**< Interpret the provided leaf/leaf-list @p value as being in the JSON format.
+                                             Specifically, strings are quoted as per IETF rfc 8259
+                                                `string = quotation-mark *char quotation-mark`
+                                            Example, `const char * data = "\"Great View\"";` should be processed as
+                                            `const value = "Great View";` */
+
 /** @} pathoptions */
 
 /**

--- a/src/tree_data_new.c
+++ b/src/tree_data_new.c
@@ -1616,6 +1616,7 @@ lyd_new_path_(struct lyd_node *parent, const struct ly_ctx *ctx, const struct ly
     const struct lyd_value *val = NULL;
     LY_ARRAY_COUNT_TYPE path_idx = 0, orig_count = 0;
     LY_VALUE_FORMAT format;
+    const char *str_value = value;
 
     assert(parent || ctx);
     assert(path && ((path[0] == '/') || parent));
@@ -1627,6 +1628,16 @@ lyd_new_path_(struct lyd_node *parent, const struct ly_ctx *ctx, const struct ly
     if (value && !value_len) {
         value_len = strlen(value);
     }
+    if (options & LYD_NEW_PATH_JSON_VALUE) {
+        /* if it starts and ends in double-quotes, it can only be a string value */
+        if ((value_len > 1) && str_value &&
+                ('"' == str_value[0]) && ('"' == str_value[value_len - 1])) {
+            /* remove the quotes */
+            value = ++str_value;
+            value_len -= 2;
+        }
+    }
+
     if (options & LYD_NEW_PATH_BIN_VALUE) {
         format = LY_VALUE_LYB;
     } else if (options & LYD_NEW_PATH_CANON_VALUE) {


### PR DESCRIPTION
 According to ietf rfc 8259, strings are always surrounded by double
 quotes. This means, for storing within libyang, we must strip input
 data of these, and take the value as the stripped portion.

 Example: const char * data = "\"Great View\""; should yield
 const char *value = "Great View";

 For this, a new option is used `LYD_NEW_PATH_JSON_VALUE`