### PR TITLE
Support for printing and parsing bare json values for sysrepo-gnmi

### DIFF
--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -172,6 +172,9 @@ struct ly_in;
                                                  when parsing validated data to skip some validation tasks and modify
                                                  some validation behavior (auto-deletion of cases). */
 
+#define LYD_PARSE_BARETOPLEAF 0x2000000     /**< Fragments for top-level leaf values are expected to be bare and not
+                                                 have a top-level object or node name. */
+
 #define LYD_PARSE_OPTS_MASK 0xFFFF0000      /**< Mask for all the LYD_PARSE_ options. */
 
 /** @} dataparseroptions */

--- a/src/printer_data.h
+++ b/src/printer_data.h
@@ -96,6 +96,11 @@ struct ly_out;
                                                       are not explicitly present in the original data tree despite their
                                                       value is equal to their default value.  There is the same limitation regarding
                                                       the presence of ietf-netconf-with-defaults module in libyang context. */
+#define LYD_PRINT_FRAGMENT 0x100 /**< Print the data tree as a fragment. For
+                                      JSON this means that apparent
+                                      top-level nodes do not have their
+                                      namespace added. */
+#define LYD_PRINT_BARETOPLEAF 0x200 /**< Print top-level leaf node as a bare value (JSON-only). */
 /**
  * @}
  */


### PR DESCRIPTION
- Support for parsing JSON  bare leaf values

    Add support for parsing bare values for top-level (from the
    parser's point of view) leaf nodes, using a new LYD_OPT_BARETOPLEAF
    flag. The parsing of leaf nodes is too tied in with the allocation of
    a new node and parsing of the node name and namespace to easily
    trigger it from that case, so instead the case is check and handled
    explicitly in the top-level parser loop.

- Support for printing JSON bare values

    Add support for printing top-level leaf nodes as bare values, which is
    triggered through the use of a new LYD_BARETOPLEAF flag.