### PR TITLE
Adding leafref references and API to lyd_node_term

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -373,6 +373,7 @@ struct ly_ctx {
     void *ext_clb_data;               /**< optional private data for ::ly_ctx.ext_clb */
     struct ly_ht *err_ht;             /**< hash table of thread-specific list of errors related to the context */
     pthread_mutex_t lyb_hash_lock;    /**< lock for storing LYB schema hashes in schema nodes */
+    struct ly_ht *term_nodes_ext_ht;  /**< hash table of term data nodes extension */
 };
 
 /**

--- a/src/common.h
+++ b/src/common.h
@@ -373,7 +373,7 @@ struct ly_ctx {
     void *ext_clb_data;               /**< optional private data for ::ly_ctx.ext_clb */
     struct ly_ht *err_ht;             /**< hash table of thread-specific list of errors related to the context */
     pthread_mutex_t lyb_hash_lock;    /**< lock for storing LYB schema hashes in schema nodes */
-    struct ly_ht *term_nodes_ext_ht;  /**< hash table of term data nodes extension */
+    struct ly_ht *leafref_links_ht;   /**< hash table of leafref links between term data nodes */
 };
 
 /**

--- a/src/context.c
+++ b/src/context.c
@@ -240,7 +240,7 @@ ly_ctx_ht_err_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UN
 }
 
 /**
- * @brief Hash table value-equal callback for comparing term data node extension hash table record.
+ * @brief Hash table value-equal callback for comparing leafref links hash table record.
  */
 static ly_bool
 ly_ctx_ht_leafref_links_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UNUSED(cb_data))
@@ -251,9 +251,9 @@ ly_ctx_ht_leafref_links_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod)
 }
 
 /**
- * @brief Callback for freeing term data node extension hash table values.
+ * @brief Callback for freeing leafref links hash table values.
  *
- * @param[in] val_p Pointer to a pointer to a term data node extension item to free with all the siblings.
+ * @param[in] val_p Pointer to a pointer to a leafref links item to free with all the siblings.
  */
 static void
 ly_ctx_ht_leafref_links_rec_free(void *val_p)

--- a/src/context.c
+++ b/src/context.c
@@ -620,8 +620,6 @@ ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option)
     if (!(ctx->flags & LY_CTX_LEAFREF_LINKING) && (option & LY_CTX_LEAFREF_LINKING)) {
         ctx->term_nodes_ext_ht = lyht_new(1, sizeof(struct lyd_term_nodes_ext_rec), ly_ctx_ht_term_node_ext_equal_cb, NULL, 1);
         LY_CHECK_ERR_RET(!ctx->term_nodes_ext_ht, LOGARG(ctx, option), LY_EMEM);
-    } else if ((ctx->flags & LY_CTX_LEAFREF_LINKING) && !(option & LY_CTX_LEAFREF_LINKING)) {
-        lyht_free(ctx->term_nodes_ext_ht, ly_ctx_ht_term_node_ext_rec_free);
     }
 
     if (!(ctx->flags & LY_CTX_SET_PRIV_PARSED) && (option & LY_CTX_SET_PRIV_PARSED)) {
@@ -663,6 +661,11 @@ ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option)
 
     LY_CHECK_ARG_RET(ctx, ctx, LY_EINVAL);
     LY_CHECK_ERR_RET(option & LY_CTX_NO_YANGLIBRARY, LOGARG(ctx, option), LY_EINVAL);
+
+    if ((ctx->flags & LY_CTX_LEAFREF_LINKING) && (option & LY_CTX_LEAFREF_LINKING)) {
+        lyht_free(ctx->term_nodes_ext_ht, ly_ctx_ht_term_node_ext_rec_free);
+	ctx->term_nodes_ext_ht = NULL;
+    }
 
     if ((ctx->flags & LY_CTX_SET_PRIV_PARSED) && (option & LY_CTX_SET_PRIV_PARSED)) {
         struct lys_module *mod;

--- a/src/context.c
+++ b/src/context.c
@@ -243,9 +243,9 @@ ly_ctx_ht_err_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UN
  * @brief Hash table value-equal callback for comparing term data node extension hash table record.
  */
 static ly_bool
-ly_ctx_ht_term_node_ext_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UNUSED(cb_data))
+ly_ctx_ht_leafref_links_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod), void *UNUSED(cb_data))
 {
-    struct lyd_term_nodes_ext_rec *rec1 = val1_p, *rec2 = val2_p;
+    struct lyd_leafref_links_rec *rec1 = val1_p, *rec2 = val2_p;
 
     return rec1->node == rec2->node;
 }
@@ -256,11 +256,11 @@ ly_ctx_ht_term_node_ext_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod)
  * @param[in] val_p Pointer to a pointer to a term data node extension item to free with all the siblings.
  */
 static void
-ly_ctx_ht_term_node_ext_rec_free(void *val_p)
+ly_ctx_ht_leafref_links_rec_free(void *val_p)
 {
-    struct lyd_term_nodes_ext_rec *rec = val_p;
+    struct lyd_leafref_links_rec *rec = val_p;
 
-    lyd_free_term_node_ext_rec(rec);
+    lyd_free_leafref_links_rec(rec);
 }
 
 LIBYANG_API_DEF LY_ERR
@@ -287,8 +287,8 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
     LY_CHECK_ERR_GOTO(lyplg_init(), LOGINT(NULL); rc = LY_EINT, cleanup);
 
     if (options & LY_CTX_LEAFREF_LINKING) {
-        ctx->term_nodes_ext_ht = lyht_new(1, sizeof(struct lyd_term_nodes_ext_rec), ly_ctx_ht_term_node_ext_equal_cb, NULL, 1);
-        LY_CHECK_ERR_GOTO(!ctx->term_nodes_ext_ht, rc = LY_EMEM, cleanup);
+        ctx->leafref_links_ht = lyht_new(1, sizeof(struct lyd_leafref_links_rec), ly_ctx_ht_leafref_links_equal_cb, NULL, 1);
+        LY_CHECK_ERR_GOTO(!ctx->leafref_links_ht, rc = LY_EMEM, cleanup);
     }
 
     /* initialize thread-specific error hash table */
@@ -618,8 +618,8 @@ ly_ctx_set_options(struct ly_ctx *ctx, uint16_t option)
             LOGARG(ctx, option), LY_EINVAL);
 
     if (!(ctx->flags & LY_CTX_LEAFREF_LINKING) && (option & LY_CTX_LEAFREF_LINKING)) {
-        ctx->term_nodes_ext_ht = lyht_new(1, sizeof(struct lyd_term_nodes_ext_rec), ly_ctx_ht_term_node_ext_equal_cb, NULL, 1);
-        LY_CHECK_ERR_RET(!ctx->term_nodes_ext_ht, LOGARG(ctx, option), LY_EMEM);
+        ctx->leafref_links_ht = lyht_new(1, sizeof(struct lyd_leafref_links_rec), ly_ctx_ht_leafref_links_equal_cb, NULL, 1);
+        LY_CHECK_ERR_RET(!ctx->leafref_links_ht, LOGARG(ctx, option), LY_EMEM);
     }
 
     if (!(ctx->flags & LY_CTX_SET_PRIV_PARSED) && (option & LY_CTX_SET_PRIV_PARSED)) {
@@ -663,8 +663,8 @@ ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option)
     LY_CHECK_ERR_RET(option & LY_CTX_NO_YANGLIBRARY, LOGARG(ctx, option), LY_EINVAL);
 
     if ((ctx->flags & LY_CTX_LEAFREF_LINKING) && (option & LY_CTX_LEAFREF_LINKING)) {
-        lyht_free(ctx->term_nodes_ext_ht, ly_ctx_ht_term_node_ext_rec_free);
-        ctx->term_nodes_ext_ht = NULL;
+        lyht_free(ctx->leafref_links_ht, ly_ctx_ht_leafref_links_rec_free);
+        ctx->leafref_links_ht = NULL;
     }
 
     if ((ctx->flags & LY_CTX_SET_PRIV_PARSED) && (option & LY_CTX_SET_PRIV_PARSED)) {
@@ -1357,9 +1357,9 @@ ly_ctx_destroy(struct ly_ctx *ctx)
     /* leftover unres */
     lys_unres_glob_erase(&ctx->unres);
 
-    /* clean the term data node extension hash table */
-    if (ctx->term_nodes_ext_ht) {
-        lyht_free(ctx->term_nodes_ext_ht, ly_ctx_ht_term_node_ext_rec_free);
+    /* clean the leafref links hash table */
+    if (ctx->leafref_links_ht) {
+        lyht_free(ctx->leafref_links_ht, ly_ctx_ht_leafref_links_rec_free);
     }
 
     /* clean the error hash table */

--- a/src/context.c
+++ b/src/context.c
@@ -251,9 +251,9 @@ ly_ctx_ht_leafref_links_equal_cb(void *val1_p, void *val2_p, ly_bool UNUSED(mod)
 }
 
 /**
- * @brief Callback for freeing leafref links hash table values.
+ * @brief Callback for freeing leafref links recorcd internal resources.
  *
- * @param[in] val_p Pointer to a pointer to a leafref links item to free with all the siblings.
+ * @param[in] val_p Pointer to leafref links record
  */
 static void
 ly_ctx_ht_leafref_links_rec_free(void *val_p)

--- a/src/context.c
+++ b/src/context.c
@@ -664,7 +664,7 @@ ly_ctx_unset_options(struct ly_ctx *ctx, uint16_t option)
 
     if ((ctx->flags & LY_CTX_LEAFREF_LINKING) && (option & LY_CTX_LEAFREF_LINKING)) {
         lyht_free(ctx->term_nodes_ext_ht, ly_ctx_ht_term_node_ext_rec_free);
-	ctx->term_nodes_ext_ht = NULL;
+        ctx->term_nodes_ext_ht = NULL;
     }
 
     if ((ctx->flags & LY_CTX_SET_PRIV_PARSED) && (option & LY_CTX_SET_PRIV_PARSED)) {

--- a/src/context.h
+++ b/src/context.h
@@ -200,8 +200,8 @@ struct ly_ctx;
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
 #define LY_CTX_LEAFREF_LINKING 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
-                                        [link](@ref lyd_link_leafref_node), [unlink](@ref lyd_unlink_leafref_node) and
-                                        [link_all](@ref lyd_link_leafref_node_all) APIs. */
+                                        [get_record](@ref lyd_get_term_nodes_ext_record) and
+                                        [link_tree](@ref lyd_link_leafref_node_tree) APIs. */
 
 /** @} contextoptions */
 

--- a/src/context.h
+++ b/src/context.h
@@ -200,8 +200,8 @@ struct ly_ctx;
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
 #define LY_CTX_LEAFREF_LINKING 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
-                                        [get_record](@ref lyd_get_term_nodes_ext_record) and
-                                        [link_tree](@ref lyd_link_leafref_node_tree) APIs. */
+                                        [lyd_leafref_get_links](@ref lyd_leafref_get_links) and
+                                        [lyd_leafref_link_node_tree](@ref lyd_leafref_link_node_tree) APIs. */
 
 /** @} contextoptions */
 

--- a/src/context.h
+++ b/src/context.h
@@ -199,7 +199,8 @@ struct ly_ctx;
                                         enabled. */
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
-#define LY_CTX_LEAFREF_LINKING 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
+#define LY_CTX_LEAFREF_LINKING 0x0400 /**< Link valid leafref nodes with its target during validation if leafref node is not using
+                                        'require-instance false;'. It also enables usage of
                                         [lyd_leafref_get_links](@ref lyd_leafref_get_links) and
                                         [lyd_leafref_link_node_tree](@ref lyd_leafref_link_node_tree) APIs. */
 

--- a/src/context.h
+++ b/src/context.h
@@ -199,6 +199,9 @@ struct ly_ctx;
                                         enabled. */
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
+#define LY_CTX_LEAFREF_LINKING_ENABLED 0x0400 /**< Link leafref nodes with its target during validation. It also enabled usage of
+                                        usage of [link](@ref lyd_link_leafref_node), [unlink](@ref lyd_unlink_leafref_node) and
+                                        [link_all](@ref lyd_link_leafref_node_all). */
 
 /** @} contextoptions */
 

--- a/src/context.h
+++ b/src/context.h
@@ -199,7 +199,7 @@ struct ly_ctx;
                                         enabled. */
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
-#define LY_CTX_LEAFREF_LINKING_ENABLED 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
+#define LY_CTX_LEAFREF_LINKING 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
                                         [link](@ref lyd_link_leafref_node), [unlink](@ref lyd_unlink_leafref_node) and
                                         [link_all](@ref lyd_link_leafref_node_all) APIs. */
 

--- a/src/context.h
+++ b/src/context.h
@@ -199,9 +199,9 @@ struct ly_ctx;
                                         enabled. */
 #define LY_CTX_LEAFREF_EXTENDED 0x0200 /**< By default, path attribute of leafref accepts only path as defined in RFC 7950.
                                         By using this option, the path attribute will also allow using XPath functions as deref() */
-#define LY_CTX_LEAFREF_LINKING_ENABLED 0x0400 /**< Link leafref nodes with its target during validation. It also enabled usage of
-                                        usage of [link](@ref lyd_link_leafref_node), [unlink](@ref lyd_unlink_leafref_node) and
-                                        [link_all](@ref lyd_link_leafref_node_all). */
+#define LY_CTX_LEAFREF_LINKING_ENABLED 0x0400 /**< Link leafref nodes with its target during validation. It also enables usage of
+                                        [link](@ref lyd_link_leafref_node), [unlink](@ref lyd_unlink_leafref_node) and
+                                        [link_all](@ref lyd_link_leafref_node_all) APIs. */
 
 /** @} contextoptions */
 

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -196,7 +196,7 @@ struct ly_in;
  * already a case and another one was added, the previous one is silently auto-deleted. Otherwise (if data from 2 or
  * more cases were created) a validation error is raised,
  * - default values are added.
- *
+ * - target data nodes are not linked with leafref data nodes by default
  * @{
  */
 #define LYD_VALIDATE_NO_STATE   0x0001      /**< Consider state data not allowed and raise an error if they are found.

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -196,6 +196,7 @@ struct ly_in;
  * already a case and another one was added, the previous one is silently auto-deleted. Otherwise (if data from 2 or
  * more cases were created) a validation error is raised,
  * - default values are added.
+ *
  * @{
  */
 #define LYD_VALIDATE_NO_STATE   0x0001      /**< Consider state data not allowed and raise an error if they are found.

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -196,7 +196,6 @@ struct ly_in;
  * already a case and another one was added, the previous one is silently auto-deleted. Otherwise (if data from 2 or
  * more cases were created) a validation error is raised,
  * - default values are added.
- * - target data nodes are not linked with leafref data nodes by default
  * @{
  */
 #define LYD_VALIDATE_NO_STATE   0x0001      /**< Consider state data not allowed and raise an error if they are found.

--- a/src/plugins_types/leafref.c
+++ b/src/plugins_types/leafref.c
@@ -25,6 +25,7 @@
 #include "common.h"
 #include "compat.h"
 #include "plugins_internal.h" /* LY_TYPE_*_STR */
+#include "tree_data_internal.h" /* lyd_link_leafref_node */
 
 /**
  * @page howtoDataLYB LYB Binary Format
@@ -86,7 +87,7 @@ lyplg_type_validate_leafref(const struct ly_ctx *ctx, const struct lysc_type *ty
         return ret;
     }
 
-    if (ly_ctx_get_options(ctx) & LY_CTX_LEAFREF_LINKING_ENABLED) {
+    if (ly_ctx_get_options(ctx) & LY_CTX_LEAFREF_LINKING) {
         return lyd_link_leafref_node((struct lyd_node_term *)target, (struct lyd_node_term *)ctx_node);
     }
 

--- a/src/plugins_types/leafref.c
+++ b/src/plugins_types/leafref.c
@@ -63,7 +63,7 @@ lyplg_type_store_leafref(const struct ly_ctx *ctx, const struct lysc_type *type,
 }
 
 LIBYANG_API_DEF LY_ERR
-lyplg_type_validate_leafref(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *ctx_node,
+lyplg_type_validate_leafref(const struct ly_ctx *ctx, const struct lysc_type *type, const struct lyd_node *ctx_node,
         const struct lyd_node *tree, struct lyd_value *storage, struct ly_err_item **err)
 {
     LY_ERR ret;
@@ -86,7 +86,11 @@ lyplg_type_validate_leafref(const struct ly_ctx *UNUSED(ctx), const struct lysc_
         return ret;
     }
 
-    return lyd_link_leafref_node((struct lyd_node_term *)target, (struct lyd_node_term *)ctx_node);
+    if (ly_ctx_get_options(ctx) & LY_CTX_LEAFREF_LINKING_ENABLED) {
+        return lyd_link_leafref_node((struct lyd_node_term *)target, (struct lyd_node_term *)ctx_node);
+    }
+
+    return LY_SUCCESS;
 }
 
 LIBYANG_API_DEF LY_ERR

--- a/src/plugins_types/leafref.c
+++ b/src/plugins_types/leafref.c
@@ -69,6 +69,7 @@ lyplg_type_validate_leafref(const struct ly_ctx *UNUSED(ctx), const struct lysc_
     LY_ERR ret;
     struct lysc_type_leafref *type_lr = (struct lysc_type_leafref *)type;
     char *errmsg = NULL, *path;
+    struct lyd_node *target = NULL;
 
     *err = NULL;
 
@@ -78,14 +79,14 @@ lyplg_type_validate_leafref(const struct ly_ctx *UNUSED(ctx), const struct lysc_
     }
 
     /* check leafref target existence */
-    if (lyplg_type_resolve_leafref(type_lr, ctx_node, storage, tree, NULL, &errmsg)) {
+    if (lyplg_type_resolve_leafref(type_lr, ctx_node, storage, tree, &target, &errmsg)) {
         path = lyd_path(ctx_node, LYD_PATH_STD, NULL, 0);
         ret = ly_err_new(err, LY_EVALID, LYVE_DATA, path, strdup("instance-required"), "%s", errmsg);
         free(errmsg);
         return ret;
     }
 
-    return LY_SUCCESS;
+    return lyd_link_leafref_node((struct lyd_node_term *)target, (struct lyd_node_term *)ctx_node);
 }
 
 LIBYANG_API_DEF LY_ERR

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -911,6 +911,11 @@ lyd_unlink(struct lyd_node *node)
     /* update hashes while still linked into the tree */
     lyd_unlink_hash(node);
 
+    /* unlink leafref nodes */
+    if (node->schema && (node->schema->nodetype & LYD_NODE_TERM)) {
+        lyd_free_leafref_nodes((struct lyd_node_term *)node);
+    }
+
     /* unlink from siblings */
     if (node->prev->next) {
         node->prev->next = node->next;
@@ -3279,7 +3284,7 @@ lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_
     assert(node);
     assert(leafref_node);
 
-    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING)) {
         return LY_EDENIED;
     }
 
@@ -3307,7 +3312,7 @@ lyd_link_leafref_node_tree(struct lyd_node *tree)
 
     assert(tree);
 
-    if (!(ly_ctx_get_options(LYD_CTX(tree)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+    if (!(ly_ctx_get_options(LYD_CTX(tree)) & LY_CTX_LEAFREF_LINKING)) {
         return LY_EDENIED;
     }
 
@@ -3340,7 +3345,7 @@ lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafre
     assert(node);
     assert(leafref_node);
 
-    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING)) {
         return LY_EDENIED;
     }
 

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3309,14 +3309,9 @@ lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct 
 LIBYANG_API_DEF LY_ERR
 lyd_leafref_get_links(const struct lyd_node_term *node, const struct lyd_leafref_links_rec **record)
 {
-    struct lyd_leafref_links_rec *record2 = NULL;
-    LY_ERR ret;
-
-    assert(record);
-
-    ret = lyd_get_or_create_leafref_links_record(node, &record2, 0);
-    *record = record2;
-    return ret;
+    LY_CHECK_ARG_RET(NULL, node, LY_EINVAL);
+    LY_CHECK_ARG_RET(NULL, record, LY_EINVAL);
+    return lyd_get_or_create_leafref_links_record(node, (struct lyd_leafref_links_rec **)record, 0);
 }
 
 LY_ERR
@@ -3358,7 +3353,7 @@ lyd_leafref_link_node_tree(const struct lyd_node *tree)
     struct lysc_type_leafref *lref;
     LY_ERR ret;
 
-    assert(tree);
+    LY_CHECK_ARG_RET(NULL, tree, LY_EINVAL);
 
     if (!(ly_ctx_get_options(LYD_CTX(tree)) & LY_CTX_LEAFREF_LINKING)) {
         return LY_EDENIED;

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3279,6 +3279,10 @@ lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_
     assert(node);
     assert(leafref_node);
 
+    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+        return LY_EDENIED;
+    }
+
     LY_ARRAY_FOR(node->leafref_nodes, u) {
         if (node->leafref_nodes[u] == leafref_node) {
             return LY_SUCCESS;
@@ -3303,6 +3307,10 @@ lyd_link_leafref_node_tree(struct lyd_node *tree)
 
     assert(tree);
 
+    if (!(ly_ctx_get_options(LYD_CTX(tree)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+        return LY_EDENIED;
+    }
+
     LY_LIST_FOR(tree, sibling) {
         LYD_TREE_DFS_BEGIN(sibling, elem) {
             if (elem->schema->nodetype & LYD_NODE_TERM) {
@@ -3326,11 +3334,17 @@ lyd_link_leafref_node_tree(struct lyd_node *tree)
     return LY_SUCCESS;
 }
 
-LIBYANG_API_DEF void
+LIBYANG_API_DEF LY_ERR
 lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node)
 {
     assert(node);
     assert(leafref_node);
+
+    if (!(ly_ctx_get_options(LYD_CTX(node)) & LY_CTX_LEAFREF_LINKING_ENABLED)) {
+        return LY_EDENIED;
+    }
+
     leafref_node->target_node = NULL;
     LY_ARRAY_REMOVE_VALUE(node->leafref_nodes, leafref_node);
+    return LY_SUCCESS;
 }

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3309,8 +3309,8 @@ lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct 
 LIBYANG_API_DEF LY_ERR
 lyd_leafref_get_links(const struct lyd_node_term *node, const struct lyd_leafref_links_rec **record)
 {
-    LY_CHECK_ARG_RET(NULL, node, LY_EINVAL);
-    LY_CHECK_ARG_RET(NULL, record, LY_EINVAL);
+    LY_CHECK_ARG_RET(NULL, node, record, LY_EINVAL);
+
     return lyd_get_or_create_leafref_links_record(node, (struct lyd_leafref_links_rec **)record, 0);
 }
 

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3273,16 +3273,7 @@ lyd_get_value(const struct lyd_node *node)
     return NULL;
 }
 
-/**
- * @brief Gets or creates the leafref links record.
- *
- * @param[in] node The term data node.
- * @param[out] record The leafref links record.
- * @param[in] create Whether to create record if not exists.
- * @return LY_SUCCESS on success.
- * @return LY_ERR value on error.
- */
-static LY_ERR
+LY_ERR
 lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record, ly_bool create)
 {
     struct ly_ht *ht;
@@ -3316,9 +3307,16 @@ lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct 
 }
 
 LIBYANG_API_DEF LY_ERR
-lyd_get_leafref_links(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record)
+lyd_leafref_get_links(const struct lyd_node_term *node, const struct lyd_leafref_links_rec **record)
 {
-    return lyd_get_or_create_leafref_links_record(node, record, 0);
+    struct lyd_leafref_links_rec *record2 = NULL;
+    LY_ERR ret;
+
+    assert(record);
+
+    ret = lyd_get_or_create_leafref_links_record(node, &record2, 0);
+    *record = record2;
+    return ret;
 }
 
 LY_ERR
@@ -3350,7 +3348,7 @@ lyd_link_leafref_node(const struct lyd_node_term *node, const struct lyd_node_te
 }
 
 LIBYANG_API_DEF LY_ERR
-lyd_link_leafref_node_tree(const struct lyd_node *tree)
+lyd_leafref_link_node_tree(const struct lyd_node *tree)
 {
     const struct lyd_node *sibling, *elem;
     struct lyd_node *target;
@@ -3402,7 +3400,7 @@ lyd_unlink_leafref_node(const struct lyd_node_term *node, const struct lyd_node_
         return LY_EDENIED;
     }
 
-    ret = lyd_get_leafref_links(node, &rec);
+    ret = lyd_get_or_create_leafref_links_record(node, &rec, 0);
     if (ret == LY_SUCCESS) {
         LY_ARRAY_REMOVE_VALUE(rec->leafref_nodes, leafref_node);
         if ((LY_ARRAY_COUNT(rec->leafref_nodes) == 0) && (rec->target_node == NULL)) {
@@ -3412,7 +3410,7 @@ lyd_unlink_leafref_node(const struct lyd_node_term *node, const struct lyd_node_
         return ret;
     }
 
-    ret = lyd_get_leafref_links(leafref_node, &rec);
+    ret = lyd_get_or_create_leafref_links_record(leafref_node, &rec, 0);
     if (ret == LY_SUCCESS) {
         rec->target_node = NULL;
         if ((LY_ARRAY_COUNT(rec->leafref_nodes) == 0) && (rec->target_node == NULL)) {

--- a/src/tree_data.c
+++ b/src/tree_data.c
@@ -3316,7 +3316,7 @@ lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct 
 }
 
 LIBYANG_API_DEF LY_ERR
-lyd_get_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record)
+lyd_get_leafref_links(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record)
 {
     return lyd_get_or_create_leafref_links_record(node, record, 0);
 }
@@ -3402,7 +3402,7 @@ lyd_unlink_leafref_node(const struct lyd_node_term *node, const struct lyd_node_
         return LY_EDENIED;
     }
 
-    ret = lyd_get_term_nodes_ext_record(node, &rec);
+    ret = lyd_get_leafref_links(node, &rec);
     if (ret == LY_SUCCESS) {
         LY_ARRAY_REMOVE_VALUE(rec->leafref_nodes, leafref_node);
         if ((LY_ARRAY_COUNT(rec->leafref_nodes) == 0) && (rec->target_node == NULL)) {
@@ -3412,7 +3412,7 @@ lyd_unlink_leafref_node(const struct lyd_node_term *node, const struct lyd_node_
         return ret;
     }
 
-    ret = lyd_get_term_nodes_ext_record(leafref_node, &rec);
+    ret = lyd_get_leafref_links(leafref_node, &rec);
     if (ret == LY_SUCCESS) {
         rec->target_node = NULL;
         if ((LY_ARRAY_COUNT(rec->leafref_nodes) == 0) && (rec->target_node == NULL)) {

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -854,14 +854,6 @@ struct lyd_node_term {
     };                                      /**< common part corresponding to ::lyd_node */
 
     struct lyd_value value;          /**< node's value representation */
-    struct lyd_node_term **leafref_nodes;   /**< list of the leafref data nodes [sized array](@ref sizedarrays)).
-                                                 By default it is empty. It is filled automatically by validation
-                                                 function of leafref nodes. It can also be manipulated manually by
-                                                 using [link api](@ref lyd_link_leafref_node),
-                                                 [unlink](@ref lyd_unlink_leafref_node). Freeing of the resources is
-                                                 automatic. */
-    struct lyd_node_term *target_node;      /**< pointer to leafref target data node, by default is NULL. The logic
-                                                 is the same as for [leafref_nodes](@ref leafref_nodes). */
 };
 
 /**
@@ -1003,6 +995,20 @@ struct lyd_node_opaq {
 
     struct lyd_attr *attr;          /**< pointer to the list of generic attributes of this node */
     const struct ly_ctx *ctx;       /**< libyang context */
+};
+
+/**
+ * @brief Context term data node record.
+ */
+struct lyd_term_nodes_ext_rec {
+    const struct lyd_node_term *node;           /** pointer to the node itself */
+    const struct lyd_node_term **leafref_nodes; /** list of the leafref data nodes [sized array](@ref sizedarrays)).
+                                                    By default it is empty. It is filled automatically by validation
+                                                    function of leafref nodes. It can also be populated based on manual request
+                                                    using [link api](@ref lyd_link_leafref_node_tree). Freeing of the resources
+                                                    is automatic. */
+    const struct lyd_node_term *target_node;    /** pointer to leafref target data node, by default is NULL. The logic
+                                                    is the same as for [leafref_nodes](@ref leafref_nodes). */
 };
 
 /**
@@ -2711,7 +2717,19 @@ LIBYANG_API_DECL LY_ERR ly_time_str2ts(const char *value, struct timespec *ts);
 LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
 
 /**
- * @brief Traverse through data tree including root node siblings and adds leafref data node to the given nodes
+ * @brief Gets the term data node extension record for given node
+ *
+ * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
+ *
+ * @param[in] node The term data node.
+ * @param[out] record The term data node extension record
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LIBYANG_API_DECL LY_ERR lyd_get_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_term_nodes_ext_rec **record);
+
+/**
+ * @brief Gets the term node extension record for given nodeTraverse through data tree including root node siblings and adds leafref data node to the given nodes
  *
  * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *
@@ -2719,7 +2737,7 @@ LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(struct lyd_node *tree);
+LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(const struct lyd_node *tree);
 
 #ifdef __cplusplus
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -998,17 +998,18 @@ struct lyd_node_opaq {
 };
 
 /**
- * @brief Context term data node record.
+ * @brief Structure of leafref links record.
  */
-struct lyd_term_nodes_ext_rec {
-    const struct lyd_node_term *node;           /** pointer to the node itself */
-    const struct lyd_node_term **leafref_nodes; /** list of the leafref data nodes [sized array](@ref sizedarrays)).
+struct lyd_leafref_links_rec {
+    const struct lyd_node_term *node;           /** pointer to the data node itself */
+    const struct lyd_node_term **leafref_nodes; /** list of the leafref pointing to this data node [sized array](@ref sizedarrays)),
                                                     By default it is empty. It is filled automatically by validation
                                                     function of leafref nodes. It can also be populated based on manual request
                                                     using [link api](@ref lyd_link_leafref_node_tree). Freeing of the resources
                                                     is automatic. */
     const struct lyd_node_term *target_node;    /** pointer to leafref target data node, by default is NULL. The logic
-                                                    is the same as for [leafref_nodes](@ref leafref_nodes). */
+                                                    is the same as for [leafref_nodes](@ref leafref_nodes) and is filled only
+                                                    for leafrefs */
 };
 
 /**
@@ -2726,10 +2727,10 @@ LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL LY_ERR lyd_get_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_term_nodes_ext_rec **record);
+LIBYANG_API_DECL LY_ERR lyd_get_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record);
 
 /**
- * @brief Gets the term node extension record for given nodeTraverse through data tree including root node siblings and adds leafref data node to the given nodes
+ * @brief Traverse through data tree including root node siblings and adds leafrefs links to the given nodes
  *
  * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -1003,10 +1003,11 @@ struct lyd_node_opaq {
 struct lyd_leafref_links_rec {
     const struct lyd_node_term *node;           /** pointer to the data node itself */
     const struct lyd_node_term **leafref_nodes; /** list of the leafref pointing to this data node [sized array](@ref sizedarrays)),
-                                                    By default it is empty. It is filled automatically by validation
-                                                    function of leafref nodes. It can also be populated based on manual request
-                                                    using [link api](@ref lyd_link_leafref_node_tree). Freeing of the resources
-                                                    is automatic. */
+                                                    By default it is empty. It is filled automatically by validation function of
+                                                    leafref nodes, which are valid and are not using 'require-instance false'.
+                                                    It can also be populated based on manual request using
+                                                    [link api](@ref lyd_leafref_link_node_tree). Freeing of the resources is
+                                                    automatic. */
     const struct lyd_node_term *target_node;    /** pointer to leafref target data node, by default is NULL. The logic
                                                     is the same as for [leafref_nodes](@ref leafref_nodes) and is filled only
                                                     for leafrefs */
@@ -2727,7 +2728,7 @@ LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL LY_ERR lyd_get_leafref_links(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record);
+LIBYANG_API_DECL LY_ERR lyd_leafref_get_links(const struct lyd_node_term *node, const struct lyd_leafref_links_rec **record);
 
 /**
  * @brief Traverse through data tree including root node siblings and adds leafrefs links to the given nodes
@@ -2738,7 +2739,7 @@ LIBYANG_API_DECL LY_ERR lyd_get_leafref_links(const struct lyd_node_term *node, 
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(const struct lyd_node *tree);
+LIBYANG_API_DECL LY_ERR lyd_leafref_link_node_tree(const struct lyd_node *tree);
 
 #ifdef __cplusplus
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -2711,41 +2711,15 @@ LIBYANG_API_DECL LY_ERR ly_time_str2ts(const char *value, struct timespec *ts);
 LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
 
 /**
- * @brief Adds leafref data node to the given node.
- *
- * If the leafref data node was already added, it will not be added again.
- * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
- *
- * @param[in] node Data node to which the leafref data node will be added.
- * @param[in] leafref_node The leafref data node, which points to given node.
- * @return LY_SUCCESS on success.
- * @return LY_ERR value on error.
- */
-LIBYANG_API_DECL LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
-
-/**
  * @brief Traverse through data tree including root node siblings and adds leafref data node to the given nodes
  *
- * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
+ * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *
  * @param[in] tree The data tree root node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
 LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(struct lyd_node *tree);
-
-/**
- * @brief Removes leafref data node to the given node
- *
- * If the leafref data node was not added, it will be silently ignored.
- * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
- *
- * @param[in] node Data node from which the leafref data node will be removed.
- * @param[in] leafref_node The leafref data node, which points to given node.
- * @return LY_SUCCESS on success.
- * @return LY_ERR value on error.
- */
-LIBYANG_API_DECL LY_ERR lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
 
 #ifdef __cplusplus
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -2718,16 +2718,16 @@ LIBYANG_API_DECL LY_ERR ly_time_str2ts(const char *value, struct timespec *ts);
 LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
 
 /**
- * @brief Gets the term data node extension record for given node
+ * @brief Gets the leafref links record for given node
  *
  * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *
  * @param[in] node The term data node.
- * @param[out] record The term data node extension record
+ * @param[out] record The leafref links record
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL LY_ERR lyd_get_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record);
+LIBYANG_API_DECL LY_ERR lyd_get_leafref_links(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record);
 
 /**
  * @brief Traverse through data tree including root node siblings and adds leafrefs links to the given nodes

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -1004,7 +1004,7 @@ struct lyd_leafref_links_rec {
     const struct lyd_node_term *node;           /** pointer to the data node itself */
     const struct lyd_node_term **leafref_nodes; /** list of the leafref pointing to this data node [sized array](@ref sizedarrays)),
                                                     By default it is empty. It is filled automatically by validation function of
-                                                    leafref nodes, which are valid and are not using 'require-instance false'.
+                                                    leafref nodes, which are valid and are not using 'require-instance false;'.
                                                     It can also be populated based on manual request using
                                                     [link api](@ref lyd_leafref_link_node_tree). Freeing of the resources is
                                                     automatic. */

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -2714,6 +2714,7 @@ LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
  * @brief Adds leafref data node to the given node.
  *
  * If the leafref data node was already added, it will not be added again.
+ * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
  *
  * @param[in] node Data node to which the leafref data node will be added.
  * @param[in] leafref_node The leafref data node, which points to given node.
@@ -2725,7 +2726,9 @@ LIBYANG_API_DECL LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct
 /**
  * @brief Traverse through data tree including root node siblings and adds leafref data node to the given nodes
  *
- * @param[in] tree The data tree root node
+ * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
+ *
+ * @param[in] tree The data tree root node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
@@ -2734,14 +2737,15 @@ LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(struct lyd_node *tree);
 /**
  * @brief Removes leafref data node to the given node
  *
- * If the leafref data node was not added, it will be silently ignored
+ * If the leafref data node was not added, it will be silently ignored.
+ * This API requires usage of LY_CTX_LEAFREF_LINKING_ENABLED context flag.
  *
- * @param[in] node Data node from which the leafref data node will be removed
+ * @param[in] node Data node from which the leafref data node will be removed.
  * @param[in] leafref_node The leafref data node, which points to given node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LIBYANG_API_DECL void lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+LIBYANG_API_DECL LY_ERR lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
 
 #ifdef __cplusplus
 }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -854,6 +854,14 @@ struct lyd_node_term {
     };                                      /**< common part corresponding to ::lyd_node */
 
     struct lyd_value value;          /**< node's value representation */
+    struct lyd_node_term **leafref_nodes;   /**< list of the leafref data nodes [sized array](@ref sizedarrays)).
+                                                 By default it is empty. It is filled automatically by validation
+                                                 function of leafref nodes. It can also be manipulated manually by
+                                                 using [link api](@ref lyd_link_leafref_node),
+                                                 [unlink](@ref lyd_unlink_leafref_node). Freeing of the resources is
+                                                 automatic. */
+    struct lyd_node_term *target_node;      /**< pointer to leafref target data node, by default is NULL. The logic
+                                                 is the same as for [leafref_nodes](@ref leafref_nodes). */
 };
 
 /**
@@ -2701,6 +2709,39 @@ LIBYANG_API_DECL LY_ERR ly_time_str2ts(const char *value, struct timespec *ts);
  * @return LY_ERR value.
  */
 LIBYANG_API_DECL LY_ERR ly_time_ts2str(const struct timespec *ts, char **str);
+
+/**
+ * @brief Adds leafref data node to the given node.
+ *
+ * If the leafref data node was already added, it will not be added again.
+ *
+ * @param[in] node Data node to which the leafref data node will be added.
+ * @param[in] leafref_node The leafref data node, which points to given node.
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LIBYANG_API_DECL LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+
+/**
+ * @brief Traverse through data tree including root node siblings and adds leafref data node to the given nodes
+ *
+ * @param[in] tree The data tree root node
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LIBYANG_API_DECL LY_ERR lyd_link_leafref_node_tree(struct lyd_node *tree);
+
+/**
+ * @brief Removes leafref data node to the given node
+ *
+ * If the leafref data node was not added, it will be silently ignored
+ *
+ * @param[in] node Data node from which the leafref data node will be removed
+ * @param[in] leafref_node The leafref data node, which points to given node.
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LIBYANG_API_DECL void lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
 
 #ifdef __cplusplus
 }

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -148,7 +148,7 @@ lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec)
 
     /* remove stored leafref nodes */
     LY_ARRAY_FOR(rec->leafref_nodes, u) {
-        if (lyd_get_leafref_links(rec->leafref_nodes[u], &leafref_rec) == LY_SUCCESS) {
+        if (lyd_get_or_create_leafref_links_record(rec->leafref_nodes[u], &leafref_rec, 0) == LY_SUCCESS) {
             leafref_rec->target_node = NULL;
             if ((LY_ARRAY_COUNT(leafref_rec->leafref_nodes) == 0) && (leafref_rec->target_node == NULL)) {
                 lyd_free_leafref_nodes(rec->leafref_nodes[u]);
@@ -172,7 +172,7 @@ lyd_free_leafref_nodes(const struct lyd_node_term *node)
 
     assert(node);
 
-    if (lyd_get_leafref_links(node, &rec) != LY_SUCCESS) {
+    if (lyd_get_or_create_leafref_links_record(node, &rec, 0) != LY_SUCCESS) {
         return;
     }
 

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -148,7 +148,7 @@ lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec)
 
     /* remove stored leafref nodes */
     LY_ARRAY_FOR(rec->leafref_nodes, u) {
-        if (lyd_get_term_nodes_ext_record(rec->leafref_nodes[u], &leafref_rec) == LY_SUCCESS) {
+        if (lyd_get_leafref_links(rec->leafref_nodes[u], &leafref_rec) == LY_SUCCESS) {
             leafref_rec->target_node = NULL;
             if ((LY_ARRAY_COUNT(leafref_rec->leafref_nodes) == 0) && (leafref_rec->target_node == NULL)) {
                 lyd_free_leafref_nodes(rec->leafref_nodes[u]);
@@ -172,7 +172,7 @@ lyd_free_leafref_nodes(const struct lyd_node_term *node)
 
     assert(node);
 
-    if (lyd_get_term_nodes_ext_record(node, &rec) != LY_SUCCESS) {
+    if (lyd_get_leafref_links(node, &rec) != LY_SUCCESS) {
         return;
     }
 

--- a/src/tree_data_free.c
+++ b/src/tree_data_free.c
@@ -139,10 +139,10 @@ lyd_free_attr_siblings(const struct ly_ctx *ctx, struct lyd_attr *attr)
 }
 
 void
-lyd_free_term_node_ext_rec(struct lyd_term_nodes_ext_rec *rec)
+lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec)
 {
     LY_ARRAY_COUNT_TYPE u;
-    struct lyd_term_nodes_ext_rec *leafref_rec;
+    struct lyd_leafref_links_rec *leafref_rec;
 
     assert(rec);
 
@@ -168,7 +168,7 @@ lyd_free_leafref_nodes(const struct lyd_node_term *node)
 {
     struct ly_ht *ht;
     uint32_t hash;
-    struct lyd_term_nodes_ext_rec *rec;
+    struct lyd_leafref_links_rec *rec;
 
     assert(node);
 
@@ -177,10 +177,10 @@ lyd_free_leafref_nodes(const struct lyd_node_term *node)
     }
 
     /* free entry content */
-    lyd_free_term_node_ext_rec(rec);
+    lyd_free_leafref_links_rec(rec);
 
     /* free entry itself from hash table */
-    ht = LYD_CTX(node)->term_nodes_ext_ht;
+    ht = LYD_CTX(node)->leafref_links_ht;
     hash = lyht_hash((const char *)&node, sizeof & node);
     lyht_remove(ht, rec, hash);
 }

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -592,11 +592,29 @@ char *lyd_path_set(const struct ly_set *dnodes, LYD_PATH_TYPE pathtype);
 LY_ERR ly_set_rm_index_ordered(struct ly_set *set, uint32_t index, void (*destructor)(void *obj));
 
 /**
+ * @brief Gets or creates the term data node extension record for given node
+ *
+ * @param[in] node The term data node.
+ * @param[out] record The term data node extension record
+ * @param[in] create Whether to create record if not exists
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LY_ERR lyd_get_or_create_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_term_nodes_ext_rec **record, ly_bool create);
+
+/**
+ * @brief Frees data within term data node extension record
+ *
+ * @param[in] rec The term data node extension record
+ */
+void lyd_free_term_node_ext_rec(struct lyd_term_nodes_ext_rec *rec);
+
+/**
  * @brief Frees all leafref nodes and target node of given data node
  *
  * @param[in] node The data node, which leafref nodes and/or target node should be cleared.
  */
-void lyd_free_leafref_nodes(struct lyd_node_term *node);
+void lyd_free_leafref_nodes(const struct lyd_node_term *node);
 
 /**
  * @brief Adds leafref data node to the given node.
@@ -609,7 +627,7 @@ void lyd_free_leafref_nodes(struct lyd_node_term *node);
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+LY_ERR lyd_link_leafref_node(const struct lyd_node_term *node, const struct lyd_node_term *leafref_node);
 
 /**
  * @brief Removes leafref data node to the given node
@@ -622,6 +640,6 @@ LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *l
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
-LY_ERR lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+LY_ERR lyd_unlink_leafref_node(const struct lyd_node_term *node, const struct lyd_node_term *leafref_node);
 
 #endif /* LY_TREE_DATA_INTERNAL_H_ */

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -592,22 +592,11 @@ char *lyd_path_set(const struct ly_set *dnodes, LYD_PATH_TYPE pathtype);
 LY_ERR ly_set_rm_index_ordered(struct ly_set *set, uint32_t index, void (*destructor)(void *obj));
 
 /**
- * @brief Gets or creates the term data node extension record for given node
- *
- * @param[in] node The term data node.
- * @param[out] record The term data node extension record
- * @param[in] create Whether to create record if not exists
- * @return LY_SUCCESS on success.
- * @return LY_ERR value on error.
- */
-LY_ERR lyd_get_or_create_term_nodes_ext_record(const struct lyd_node_term *node, struct lyd_term_nodes_ext_rec **record, ly_bool create);
-
-/**
  * @brief Frees data within term data node extension record
  *
  * @param[in] rec The term data node extension record
  */
-void lyd_free_term_node_ext_rec(struct lyd_term_nodes_ext_rec *rec);
+void lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec);
 
 /**
  * @brief Frees all leafref nodes and target node of given data node
@@ -617,26 +606,26 @@ void lyd_free_term_node_ext_rec(struct lyd_term_nodes_ext_rec *rec);
 void lyd_free_leafref_nodes(const struct lyd_node_term *node);
 
 /**
- * @brief Adds leafref data node to the given node.
+ * @brief Adds links between leafref adn data node.
  *
- * If the leafref data node was already added, it will not be added again.
+ * If the links were already added, it will not be added again.
  * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *
- * @param[in] node Data node to which the leafref data node will be added.
- * @param[in] leafref_node The leafref data node, which points to given node.
+ * @param[in] node Data node to which, the leafref is pointing to.
+ * @param[in] leafref_node The leafref, which points to given node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */
 LY_ERR lyd_link_leafref_node(const struct lyd_node_term *node, const struct lyd_node_term *leafref_node);
 
 /**
- * @brief Removes leafref data node to the given node
+ * @brief Removes links between leafref adn data node.
  *
- * If the leafref data node was not added, it will be silently ignored.
+ * If the links were never added, it will be silently ignored.
  * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
  *
- * @param[in] node Data node from which the leafref data node will be removed.
- * @param[in] leafref_node The leafref data node, which points to given node.
+ * @param[in] node Data node to which, the leafref is pointing to.
+ * @param[in] leafref_node The leafref, which points to given node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value on error.
  */

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -591,4 +591,11 @@ char *lyd_path_set(const struct ly_set *dnodes, LYD_PATH_TYPE pathtype);
  */
 LY_ERR ly_set_rm_index_ordered(struct ly_set *set, uint32_t index, void (*destructor)(void *obj));
 
+/**
+ * @brief Frees all leafref nodes and target node of given data node
+ *
+ * @param[in] node The data node, which leafref nodes and/or target node should be cleared.
+ */
+void lyd_free_leafref_nodes(struct lyd_node_term *node);
+
 #endif /* LY_TREE_DATA_INTERNAL_H_ */

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -598,4 +598,30 @@ LY_ERR ly_set_rm_index_ordered(struct ly_set *set, uint32_t index, void (*destru
  */
 void lyd_free_leafref_nodes(struct lyd_node_term *node);
 
+/**
+ * @brief Adds leafref data node to the given node.
+ *
+ * If the leafref data node was already added, it will not be added again.
+ * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
+ *
+ * @param[in] node Data node to which the leafref data node will be added.
+ * @param[in] leafref_node The leafref data node, which points to given node.
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LY_ERR lyd_link_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+
+/**
+ * @brief Removes leafref data node to the given node
+ *
+ * If the leafref data node was not added, it will be silently ignored.
+ * This API requires usage of LY_CTX_LEAFREF_LINKING context flag.
+ *
+ * @param[in] node Data node from which the leafref data node will be removed.
+ * @param[in] leafref_node The leafref data node, which points to given node.
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LY_ERR lyd_unlink_leafref_node(struct lyd_node_term *node, struct lyd_node_term *leafref_node);
+
 #endif /* LY_TREE_DATA_INTERNAL_H_ */

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -606,6 +606,17 @@ void lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec);
 void lyd_free_leafref_nodes(const struct lyd_node_term *node);
 
 /**
+ * @brief Gets or creates the leafref links record.
+ *
+ * @param[in] node The term data node.
+ * @param[out] record The leafref links record.
+ * @param[in] create Whether to create record if not exists.
+ * @return LY_SUCCESS on success.
+ * @return LY_ERR value on error.
+ */
+LY_ERR lyd_get_or_create_leafref_links_record(const struct lyd_node_term *node, struct lyd_leafref_links_rec **record, ly_bool create);
+
+/**
  * @brief Adds links between leafref adn data node.
  *
  * If the links were already added, it will not be added again.

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -592,9 +592,9 @@ char *lyd_path_set(const struct ly_set *dnodes, LYD_PATH_TYPE pathtype);
 LY_ERR ly_set_rm_index_ordered(struct ly_set *set, uint32_t index, void (*destructor)(void *obj));
 
 /**
- * @brief Frees data within term data node extension record
+ * @brief Frees data within leafref links record
  *
- * @param[in] rec The term data node extension record
+ * @param[in] rec The leafref links record
  */
 void lyd_free_leafref_links_rec(struct lyd_leafref_links_rec *rec);
 

--- a/src/tree_data_new.c
+++ b/src/tree_data_new.c
@@ -1315,6 +1315,11 @@ _lyd_change_term(struct lyd_node *term, const void *value, size_t value_len, LY_
         val_change = 0;
     }
 
+    /* clear links to leafref nodes */
+    if (ly_ctx_get_options(LYD_CTX(term)) & LY_CTX_LEAFREF_LINKING_ENABLED) {
+        lyd_free_leafref_nodes(t);
+    }
+
     /* always clear the default flag */
     if (term->flags & LYD_DEFAULT) {
         for (parent = term; parent; parent = lyd_parent(parent)) {

--- a/src/tree_data_new.c
+++ b/src/tree_data_new.c
@@ -1316,7 +1316,7 @@ _lyd_change_term(struct lyd_node *term, const void *value, size_t value_len, LY_
     }
 
     /* clear links to leafref nodes */
-    if (ly_ctx_get_options(LYD_CTX(term)) & LY_CTX_LEAFREF_LINKING_ENABLED) {
+    if (ly_ctx_get_options(LYD_CTX(term)) & LY_CTX_LEAFREF_LINKING) {
         lyd_free_leafref_nodes(t);
     }
 

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -244,8 +244,8 @@ void *ly_realloc(void *ptr, size_t size);
         LY_ARRAY_FOR(ARRAY, index__) { \
             if (ARRAY[index__] == VALUE) { \
                 if (index__ != LY_ARRAY_COUNT(ARRAY) - 1) { \
-		    memmove(&(ARRAY[index__]), &(ARRAY[LY_ARRAY_COUNT(ARRAY) - 1]), sizeof *(ARRAY)); \
-		} \
+                    memmove(&(ARRAY[index__]), &(ARRAY[LY_ARRAY_COUNT(ARRAY) - 1]), sizeof *(ARRAY)); \
+                } \
                 remove__ = 1; \
             } \
         } \

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -235,23 +235,19 @@ void *ly_realloc(void *ptr, size_t size);
  * @brief Remove item from array based on value
  *
  * @param[in, out] ARRAY A ([sized array](@ref sizedarrays)) to be modified.
- * @param[in] INDEX The item position to be removed.
+ * @param[in] VALUE The item value to be removed. Only the first occurence will be removed.
  */
 #define LY_ARRAY_REMOVE_VALUE(ARRAY, VALUE) \
     { \
         LY_ARRAY_COUNT_TYPE index__; \
-        ly_bool remove__ = 0; \
         LY_ARRAY_FOR(ARRAY, index__) { \
             if (ARRAY[index__] == VALUE) { \
                 if (index__ != LY_ARRAY_COUNT(ARRAY) - 1) { \
                     memmove(&(ARRAY[index__]), &(ARRAY[LY_ARRAY_COUNT(ARRAY) - 1]), sizeof *(ARRAY)); \
                 } \
-                remove__ = 1; \
+                LY_ARRAY_DECREMENT(ARRAY); \
                 break; \
             } \
-        } \
-        if (remove__) { \
-            LY_ARRAY_DECREMENT(ARRAY); \
         } \
     }
 

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -206,7 +206,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] ARRAY Pointer to the array to affect.
  */
 #define LY_ARRAY_DECREMENT(ARRAY) \
-        --(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
+        --(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1))
 
 /**
  * @brief Decrement the items counter in a ([sized array](@ref sizedarrays)) and free the whole array
@@ -243,9 +243,10 @@ void *ly_realloc(void *ptr, size_t size);
         ly_bool remove__ = 0; \
         LY_ARRAY_FOR(ARRAY, index__) { \
             if (ARRAY[index__] == VALUE) { \
+                if (index__ != LY_ARRAY_COUNT(ARRAY) - 1) { \
+		    memmove(&(ARRAY[index__]), &(ARRAY[LY_ARRAY_COUNT(ARRAY) - 1]), sizeof *(ARRAY)); \
+		} \
                 remove__ = 1; \
-            } else if (remove__) { \
-                ARRAY[index__ - 1] = ARRAY[index__]; \
             } \
         } \
         if (remove__) { \

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -247,6 +247,7 @@ void *ly_realloc(void *ptr, size_t size);
                     memmove(&(ARRAY[index__]), &(ARRAY[LY_ARRAY_COUNT(ARRAY) - 1]), sizeof *(ARRAY)); \
                 } \
                 remove__ = 1; \
+                break; \
             } \
         } \
         if (remove__) { \

--- a/src/tree_edit.h
+++ b/src/tree_edit.h
@@ -206,7 +206,7 @@ void *ly_realloc(void *ptr, size_t size);
  * @param[in] ARRAY Pointer to the array to affect.
  */
 #define LY_ARRAY_DECREMENT(ARRAY) \
-        --(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1))
+        --(*((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1)); \
 
 /**
  * @brief Decrement the items counter in a ([sized array](@ref sizedarrays)) and free the whole array
@@ -230,6 +230,28 @@ void *ly_realloc(void *ptr, size_t size);
  */
 #define LY_ARRAY_FREE(ARRAY) \
         if (ARRAY){free((LY_ARRAY_COUNT_TYPE*)(ARRAY) - 1);}
+
+/**
+ * @brief Remove item from array based on value
+ *
+ * @param[in, out] ARRAY A ([sized array](@ref sizedarrays)) to be modified.
+ * @param[in] INDEX The item position to be removed.
+ */
+#define LY_ARRAY_REMOVE_VALUE(ARRAY, VALUE) \
+    { \
+        LY_ARRAY_COUNT_TYPE index__; \
+        ly_bool remove__ = 0; \
+        LY_ARRAY_FOR(ARRAY, index__) { \
+            if (ARRAY[index__] == VALUE) { \
+                remove__ = 1; \
+            } else if (remove__) { \
+                ARRAY[index__ - 1] = ARRAY[index__]; \
+            } \
+        } \
+        if (remove__) { \
+            LY_ARRAY_DECREMENT(ARRAY); \
+        } \
+    }
 
 /**
  * @brief Insert item into linked list.

--- a/tests/utests/basic/test_context.c
+++ b/tests/utests/basic/test_context.c
@@ -220,6 +220,11 @@ test_options(void **state)
     assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_PREFER_SEARCHDIRS));
     assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_PREFER_SEARCHDIRS);
 
+    /* LY_CTX_LEAFREF_LINKING */
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
+    assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING));
+    assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
+
     assert_int_equal(UTEST_LYCTX->flags, ly_ctx_get_options(UTEST_LYCTX));
 
     /* set back */
@@ -242,6 +247,10 @@ test_options(void **state)
     /* LY_CTX_PREFER_SEARCHDIRS */
     assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_PREFER_SEARCHDIRS));
     assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_PREFER_SEARCHDIRS);
+
+    /* LY_CTX_LEAFREF_LINKING */
+    assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING));
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
 
     assert_int_equal(UTEST_LYCTX->flags, ly_ctx_get_options(UTEST_LYCTX));
 }

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -649,36 +649,36 @@ test_data_leafref_nodes(void **state)
     }
 
     /* verify state after leafref plugin validation */
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* value modification of target */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "ASD"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
     /* change back to original value */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "asd"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
     /* linking the whole tree again */
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* value modification of leafref */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "qwe"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "asd"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
     /* linking the whole tree again */
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* freeing whole tree */
     lyd_free_all(tree);

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -598,7 +598,7 @@ test_data_leafref_nodes(void **state)
 {
     struct lyd_node *tree, *iter;
     struct lyd_node_term *target_node, *leafref_node;
-    struct lyd_leafref_links_rec *rec;
+    const struct lyd_leafref_links_rec *rec;
     const char *schema, *data, *value;
 
     ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING);
@@ -649,36 +649,36 @@ test_data_leafref_nodes(void **state)
     }
 
     /* verify state after leafref plugin validation */
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* value modification of target */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "ASD"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(leafref_node, &rec));
     /* change back to original value */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "asd"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(leafref_node, &rec));
     /* linking the whole tree again */
-    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_link_node_tree(tree));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* value modification of leafref */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "qwe"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(leafref_node, &rec));
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "asd"));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(target_node, &rec));
-    assert_int_equal(LY_ENOTFOUND, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_leafref_get_links(leafref_node, &rec));
     /* linking the whole tree again */
-    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(target_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_link_node_tree(tree));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(target_node, &rec));
     assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
-    assert_int_equal(LY_SUCCESS, lyd_get_leafref_links(leafref_node, &rec));
+    assert_int_equal(LY_SUCCESS, lyd_leafref_get_links(leafref_node, &rec));
     assert_ptr_equal(rec->target_node, target_node);
     /* freeing whole tree */
     lyd_free_all(tree);

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -600,6 +600,8 @@ test_data_leafref_nodes(void **state)
     struct lyd_node_term *target_node, *leafref_node, *wrong_node;
     const char *schema, *data, *value;
 
+    ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING_ENABLED);
+
     schema =
             "module test-data-hash {"
             "  yang-version 1.1;"
@@ -653,18 +655,18 @@ test_data_leafref_nodes(void **state)
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node(target_node, leafref_node));
     assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* wrong link */
-    lyd_link_leafref_node(target_node, wrong_node);
+    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node(target_node, wrong_node));
     assert_int_equal(2, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* wrong unlink */
-    lyd_unlink_leafref_node(target_node, wrong_node);
+    assert_int_equal(LY_SUCCESS, lyd_unlink_leafref_node(target_node, wrong_node));
     assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* correct unlink */
-    lyd_unlink_leafref_node(target_node, leafref_node);
+    assert_int_equal(LY_SUCCESS, lyd_unlink_leafref_node(target_node, leafref_node));
     assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* duplicate unlink */
-    lyd_unlink_leafref_node(target_node, leafref_node);
+    assert_int_equal(LY_SUCCESS, lyd_unlink_leafref_node(target_node, leafref_node));
     /* linking the whole tree */
-    lyd_link_leafref_node_tree(tree);
+    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
     assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* freeing whole tree */
     lyd_free_all(tree);

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -598,6 +598,7 @@ test_data_leafref_nodes(void **state)
 {
     struct lyd_node *tree, *iter;
     struct lyd_node_term *target_node, *leafref_node;
+    struct lyd_term_nodes_ext_rec *rec;
     const char *schema, *data, *value;
 
     ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING);
@@ -648,31 +649,37 @@ test_data_leafref_nodes(void **state)
     }
 
     /* verify state after leafref plugin validation */
-    assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_ptr_equal(leafref_node->target_node, target_node);
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_ptr_equal(rec->target_node, target_node);
     /* value modification of target */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "ASD"));
-    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_null(leafref_node->target_node);
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
     /* change back to original value */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "asd"));
-    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_null(leafref_node->target_node);
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
     /* linking the whole tree again */
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_ptr_equal(leafref_node->target_node, target_node);
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_ptr_equal(rec->target_node, target_node);
     /* value modification of leafref */
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "qwe"));
-    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_null(leafref_node->target_node);
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
     assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "asd"));
-    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_null(leafref_node->target_node);
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(LY_ENOTFOUND, lyd_get_term_nodes_ext_record(leafref_node, &rec));
     /* linking the whole tree again */
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
-    assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
-    assert_ptr_equal(leafref_node->target_node, target_node);
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(target_node, &rec));
+    assert_int_equal(1, LY_ARRAY_COUNT(rec->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_get_term_nodes_ext_record(leafref_node, &rec));
+    assert_ptr_equal(rec->target_node, target_node);
     /* freeing whole tree */
     lyd_free_all(tree);
 }

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -665,6 +665,20 @@ test_data_leafref_nodes(void **state)
     assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* duplicate unlink */
     assert_int_equal(LY_SUCCESS, lyd_unlink_leafref_node(target_node, leafref_node));
+    /* add + value modification of target */
+    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node(target_node, leafref_node));
+    assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "ASD"));
+    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
+    /* change back to original value + value modification of leafref */
+    assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)target_node, "asd"));
+    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_link_leafref_node(target_node, leafref_node));
+    assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "qwe"));
+    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
+    assert_int_equal(LY_SUCCESS, lyd_change_term((struct lyd_node *)leafref_node, "asd"));
+    assert_int_equal(0, LY_ARRAY_COUNT(target_node->leafref_nodes));
     /* linking the whole tree */
     assert_int_equal(LY_SUCCESS, lyd_link_leafref_node_tree(tree));
     assert_int_equal(1, LY_ARRAY_COUNT(target_node->leafref_nodes));

--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -598,7 +598,7 @@ test_data_leafref_nodes(void **state)
 {
     struct lyd_node *tree, *iter;
     struct lyd_node_term *target_node, *leafref_node;
-    struct lyd_term_nodes_ext_rec *rec;
+    struct lyd_leafref_links_rec *rec;
     const char *schema, *data, *value;
 
     ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING);


### PR DESCRIPTION
This patch introduces ability to store references between lyd_node_terms, when it comes to leafrefs. This can be used by higher layers to prevent removals of lyd_nodes, which are being referenced or to say, from which place the given data node is being referenced from.