### PR TITLE
Avoid compilation warning - empty C file

### DIFF
--- a/tools/lint/cmd_debug.c
+++ b/tools/lint/cmd_debug.c
@@ -132,3 +132,9 @@ cmd_debug_setlog(struct ly_ctx *ctx, struct yl_opt *yo)
 }
 
 #endif
+
+__attribute__((unused)) static void
+__cmd_debug_void(void)
+{
+    return ;
+}


### PR DESCRIPTION
Fix:
  warning: ISO C forbids an empty translation unit

Because of NDEBUG, cmd_debug.c is an empty C file so let's set at least 1 function for this C file that shall be used.