### PR TITLE
Introducing LY_CTX_BASIC_PLUGINS_ONLY & LYPLG_TYPE_STORE_ONLY

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -283,6 +283,7 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
     struct ly_in *in = NULL;
     LY_ERR rc = LY_SUCCESS;
     struct lys_glob_unres unres = {0};
+    ly_bool builtin_plugins_only;
 
     LY_CHECK_ARG_RET(NULL, new_ctx, LY_EINVAL);
 
@@ -293,7 +294,8 @@ ly_ctx_new(const char *search_dir, uint16_t options, struct ly_ctx **new_ctx)
     lydict_init(&ctx->dict);
 
     /* plugins */
-    LY_CHECK_ERR_GOTO(lyplg_init(), LOGINT(NULL); rc = LY_EINT, cleanup);
+    builtin_plugins_only = (options & LY_CTX_BUILTIN_PLUGINS_ONLY) ? 1 : 0;
+    LY_CHECK_ERR_GOTO(lyplg_init(builtin_plugins_only), LOGINT(NULL); rc = LY_EINT, cleanup);
 
     if (options & LY_CTX_LEAFREF_LINKING) {
         ctx->leafref_links_ht = lyht_new(1, sizeof(struct lyd_leafref_links_rec), ly_ctx_ht_leafref_links_equal_cb, NULL, 1);
@@ -1234,8 +1236,7 @@ ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root_p, cons
         LY_CHECK_GOTO(ret = ylib_deviation(cont, mod, 0), error);
 
         /* conformance-type */
-        LY_CHECK_GOTO(ret = lyd_new_term(cont, NULL, "conformance-type", mod->implemented ? "implement" : "import", 0,
-                NULL), error);
+        LY_CHECK_GOTO(ret = lyd_new_term(cont, NULL, "conformance-type", mod->implemented ? "implement" : "import", 0, NULL), error);
 
         /* submodule list */
         LY_CHECK_GOTO(ret = ylib_submodules(cont, mod->parsed, 0), error);

--- a/src/context.h
+++ b/src/context.h
@@ -202,6 +202,13 @@ struct ly_ctx;
                                         'require-instance false;'. It also enables usage of
                                         [lyd_leafref_get_links](@ref lyd_leafref_get_links) and
                                         [lyd_leafref_link_node_tree](@ref lyd_leafref_link_node_tree) APIs. */
+#define LY_CTX_BUILTIN_PLUGINS_ONLY 0x0800 /**< By default, context loads all available built-in plugins and extensions. This
+                                        options prohibits loading of built-in non-YANG plugin types and extensions (ipv4-address,
+                                        ipv6-address, etc.). Instead the value is processed by built-in YANG plugins (usually string)
+                                        with all its behavioral implications as hex-string comparison becoming case-sensitive.
+                                        Change of this flag during the lifetime of context is not fully supported. Once the non-YANG
+                                        plugins or extensions are loaded during context creation, they will be used regardless of this
+                                        flag. Therefore it is recommended to set this flag during the first context creation. */
 
 /** @} contextoptions */
 

--- a/src/diff.c
+++ b/src/diff.c
@@ -154,7 +154,7 @@ lyd_diff_add_create_nested_userord(struct lyd_node *node)
     }
 
     /* create the metadata */
-    LY_CHECK_GOTO(rc = lyd_new_meta(NULL, node, NULL, meta_name, meta_val, 0, NULL), cleanup);
+    LY_CHECK_GOTO(rc = lyd_new_meta(NULL, node, NULL, meta_name, meta_val, LYD_NEW_VAL_STORE_ONLY, NULL), cleanup);
 
 cleanup:
     free(dyn);
@@ -382,7 +382,7 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
             }
 
             /* set the none operation */
-            LY_CHECK_RET(lyd_new_meta(NULL, elem, NULL, "yang:operation", "none", 0, NULL));
+            LY_CHECK_RET(lyd_new_meta(NULL, elem, NULL, "yang:operation", "none", LYD_NEW_VAL_STORE_ONLY, NULL));
         }
 
         dup = diff_parent;
@@ -424,12 +424,12 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
 
         /* add parent operation, if any */
         if (diff_parent && (diff_parent != dup)) {
-            LY_CHECK_RET(lyd_new_meta(NULL, diff_parent, NULL, "yang:operation", "none", 0, NULL));
+            LY_CHECK_RET(lyd_new_meta(NULL, diff_parent, NULL, "yang:operation", "none", LYD_NEW_VAL_STORE_ONLY, NULL));
         }
     }
 
     /* add subtree operation */
-    LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:operation", lyd_diff_op2str(op), 0, NULL));
+    LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:operation", lyd_diff_op2str(op), LYD_NEW_VAL_STORE_ONLY, NULL));
 
     if (op == LYD_DIFF_OP_CREATE) {
         /* all nested user-ordered (leaf-)lists need special metadata for create op */
@@ -443,37 +443,37 @@ lyd_diff_add(const struct lyd_node *node, enum lyd_diff_op op, const char *orig_
 
     /* orig-default */
     if (orig_default) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-default", orig_default, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-default", orig_default, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* orig-value */
     if (orig_value) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-value", orig_value, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-value", orig_value, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* key */
     if (key) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:key", key, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:key", key, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* value */
     if (value) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:value", value, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:value", value, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* position */
     if (position) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:position", position, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:position", position, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* orig-key */
     if (orig_key) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-key", orig_key, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-key", orig_key, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     /* orig-position */
     if (orig_position) {
-        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-position", orig_position, 0, NULL));
+        LY_CHECK_RET(lyd_new_meta(NULL, dup, NULL, "yang:orig-position", orig_position, LYD_NEW_VAL_STORE_ONLY, NULL));
     }
 
     return LY_SUCCESS;
@@ -1460,7 +1460,7 @@ lyd_diff_change_op(struct lyd_node *node, enum lyd_diff_op op)
     lyd_diff_del_meta(node, "operation");
 
     if (node->schema) {
-        return lyd_new_meta(LYD_CTX(node), node, NULL, "yang:operation", lyd_diff_op2str(op), 0, NULL);
+        return lyd_new_meta(LYD_CTX(node), node, NULL, "yang:operation", lyd_diff_op2str(op), LYD_NEW_VAL_STORE_ONLY, NULL);
     } else {
         return lyd_new_attr(node, "yang", "operation", lyd_diff_op2str(op), NULL);
     }
@@ -1685,7 +1685,7 @@ lyd_diff_merge_create(struct lyd_node **diff_match, struct lyd_node **diff, enum
 
                 /* current value is the previous one (meta) */
                 LY_CHECK_RET(lyd_new_meta(LYD_CTX(src_diff), *diff_match, NULL, "yang:orig-value",
-                        lyd_get_value(*diff_match), 0, NULL));
+                        lyd_get_value(*diff_match), LYD_NEW_VAL_STORE_ONLY, NULL));
 
                 /* update the value itself */
                 LY_CHECK_RET(lyd_change_term(*diff_match, lyd_get_value(src_diff)));
@@ -1699,10 +1699,10 @@ lyd_diff_merge_create(struct lyd_node **diff_match, struct lyd_node **diff, enum
                 to_free = *diff_match;
                 *diff_match = src_dup;
 
-                r = lyd_new_meta(ctx, src_dup, NULL, "yang:orig-value", lyd_get_value(to_free), 0, NULL);
+                r = lyd_new_meta(ctx, src_dup, NULL, "yang:orig-value", lyd_get_value(to_free), LYD_NEW_VAL_STORE_ONLY, NULL);
                 lyd_free_tree(to_free);
                 LY_CHECK_RET(r);
-                LY_CHECK_RET(lyd_new_meta(ctx, src_dup, NULL, "yang:operation", lyd_diff_op2str(LYD_DIFF_OP_REPLACE), 0, NULL));
+                LY_CHECK_RET(lyd_new_meta(ctx, src_dup, NULL, "yang:operation", lyd_diff_op2str(LYD_DIFF_OP_REPLACE), LYD_NEW_VAL_STORE_ONLY, NULL));
             }
         } else {
             /* deleted + created -> operation NONE */
@@ -1713,7 +1713,7 @@ lyd_diff_merge_create(struct lyd_node **diff_match, struct lyd_node **diff, enum
         if ((*diff_match)->schema->nodetype & LYD_NODE_TERM) {
             /* add orig-dflt metadata */
             LY_CHECK_RET(lyd_new_meta(LYD_CTX(src_diff), *diff_match, NULL, "yang:orig-default",
-                    trg_flags & LYD_DEFAULT ? "true" : "false", 0, NULL));
+                    trg_flags & LYD_DEFAULT ? "true" : "false", LYD_NEW_VAL_STORE_ONLY, NULL));
 
             /* update dflt flag itself */
             (*diff_match)->flags &= ~LYD_DEFAULT;
@@ -1763,7 +1763,7 @@ lyd_diff_merge_delete(struct lyd_node *diff_match, enum lyd_diff_op cur_op, cons
         if (diff_match->schema->nodetype & LYD_NODE_TERM) {
             /* add orig-default meta because it is expected */
             LY_CHECK_RET(lyd_new_meta(LYD_CTX(src_diff), diff_match, NULL, "yang:orig-default",
-                    src_diff->flags & LYD_DEFAULT ? "true" : "false", 0, NULL));
+                    src_diff->flags & LYD_DEFAULT ? "true" : "false", LYD_NEW_VAL_STORE_ONLY, NULL));
         }
         break;
     case LYD_DIFF_OP_REPLACE:

--- a/src/parser_common.c
+++ b/src/parser_common.c
@@ -284,8 +284,10 @@ lyd_parser_create_term(struct lyd_ctx *lydctx, const struct lysc_node *schema, c
 {
     LY_ERR r;
     ly_bool incomplete;
+    ly_bool store_only = (lydctx->parse_opts & LYD_PARSE_STORE_ONLY) ? 1 : 0;
 
-    if ((r = lyd_create_term(schema, value, value_len, 1, dynamic, format, prefix_data, hints, &incomplete, node))) {
+    if ((r = lyd_create_term(schema, value, value_len, 1, store_only, dynamic, format, prefix_data,
+            hints, &incomplete, node))) {
         if (lydctx->data_ctx->ctx != schema->module->ctx) {
             /* move errors to the main context */
             ly_err_move(schema->module->ctx, (struct ly_ctx *)lydctx->data_ctx->ctx);
@@ -308,6 +310,7 @@ lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct l
     char *dpath = NULL, *path = NULL;
     ly_bool incomplete;
     struct lyd_meta *first = NULL;
+    ly_bool store_only = (lydctx->parse_opts & LYD_PARSE_STORE_ONLY) ? 1 : 0;
 
     if (meta && *meta) {
         /* remember the first metadata */
@@ -323,7 +326,7 @@ lyd_parser_create_meta(struct lyd_ctx *lydctx, struct lyd_node *parent, struct l
     }
     ly_log_location(NULL, NULL, path, NULL);
 
-    LY_CHECK_GOTO(rc = lyd_create_meta(parent, meta, mod, name, name_len, value, value_len, 1, dynamic, format,
+    LY_CHECK_GOTO(rc = lyd_create_meta(parent, meta, mod, name, name_len, value, value_len, 1, store_only, dynamic, format,
             prefix_data, hints, ctx_node, 0, &incomplete), cleanup);
 
     if (incomplete && !(lydctx->parse_opts & LYD_PARSE_ONLY)) {

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -134,6 +134,7 @@ struct ly_in;
  * - when statements on existing nodes are evaluated, if not satisfied, a validation error is raised,
  * - invalid multiple data instances/data from several cases cause a validation error,
  * - implicit nodes (NP containers and default values) are added.
+ * - Validations based on leaf/leaf-list types restriction is being done regardless of setting LYD_PARSE_ONLY
  * @{
  */
 /* note: keep the lower 16bits free for use by LYD_VALIDATE_ flags. They are not supposed to be combined together,
@@ -171,6 +172,8 @@ struct ly_in;
 #define LYD_PARSE_NO_NEW 0x1000000          /**< Do not set ::LYD_NEW (non-validated node flag) for any nodes. Use
                                                  when parsing validated data to skip some validation tasks and modify
                                                  some validation behavior (auto-deletion of cases). */
+#define LYD_PARSE_STORE_ONLY 0x2000000      /**< Perform only storing operation, no validation based on leaf/leaf-list type
+                                                 restrictions will be performed. */
 
 #define LYD_PARSE_OPTS_MASK 0xFFFF0000      /**< Mask for all the LYD_PARSE_ options. */
 

--- a/src/path.c
+++ b/src/path.c
@@ -710,8 +710,8 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
                 if (key) {
                     LOG_LOCSET(key, NULL);
                 }
-                ret = lyd_value_store(ctx, &p->value, ((struct lysc_node_leaf *)key)->type, val, val_len, 0, NULL,
-                        format, prefix_data, LYD_HINT_DATA, key, NULL);
+                ret = lyd_value_store(ctx, &p->value, ((struct lysc_node_leaf *)key)->type, val, val_len, 0, 0,
+                        NULL, format, prefix_data, LYD_HINT_DATA, key, NULL);
                 LOG_LOCBACK(key ? 1 : 0, 0);
                 LY_CHECK_ERR_GOTO(ret, p->value.realtype = NULL, cleanup);
 
@@ -776,8 +776,8 @@ ly_path_compile_predicate(const struct ly_ctx *ctx, const struct lysc_node *cur_
         if (ctx_node) {
             LOG_LOCSET(ctx_node, NULL);
         }
-        ret = lyd_value_store(ctx, &p->value, ((struct lysc_node_leaflist *)ctx_node)->type, val, val_len, 0, NULL,
-                format, prefix_data, LYD_HINT_DATA, ctx_node, NULL);
+        ret = lyd_value_store(ctx, &p->value, ((struct lysc_node_leaflist *)ctx_node)->type, val, val_len, 0, 0,
+                NULL, format, prefix_data, LYD_HINT_DATA, ctx_node, NULL);
         LOG_LOCBACK(ctx_node ? 1 : 0, 0);
         LY_CHECK_ERR_GOTO(ret, p->value.realtype = NULL, cleanup);
         ++(*tok_idx);
@@ -1356,7 +1356,7 @@ ly_path_eval_partial(const struct ly_path *path, const struct lyd_node *start, c
             case LY_PATH_PREDTYPE_LIST_VAR:
             case LY_PATH_PREDTYPE_LIST:
                 /* we will use hashes to find one list instance */
-                LY_CHECK_RET(lyd_create_list(path[u].node, path[u].predicates, vars, &target));
+                LY_CHECK_RET(lyd_create_list(path[u].node, path[u].predicates, vars, 1, &target));
                 lyd_find_sibling_first(start, target, &node);
                 lyd_free_tree(target);
                 break;

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -442,7 +442,7 @@ plugins_insert_dir(enum LYPLG type)
 #endif
 
 LY_ERR
-lyplg_init(void)
+lyplg_init(ly_bool builtin_plugins_only)
 {
     LY_ERR ret;
 
@@ -468,34 +468,36 @@ lyplg_init(void)
     LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_string), error);
     LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_union), error);
 
-    /* yang */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_instanceid_keys), error);
+    if (!builtin_plugins_only) {
+        /* yang */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_instanceid_keys), error);
 
-    /* ietf-inet-types */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_address), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_address_no_zone), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_address), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_address_no_zone), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_prefix), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_prefix), error);
+        /* ietf-inet-types */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_address), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_address_no_zone), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_address), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_address_no_zone), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv4_prefix), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_ipv6_prefix), error);
 
-    /* ietf-yang-types */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_date_and_time), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_hex_string), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_xpath10), error);
+        /* ietf-yang-types */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_date_and_time), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_hex_string), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_xpath10), error);
 
-    /* ietf-netconf-acm */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_node_instanceid), error);
+        /* ietf-netconf-acm */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_node_instanceid), error);
 
-    /* lyds_tree */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_lyds_tree), error);
+        /* lyds_tree */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_TYPE, plugins_lyds_tree), error);
 
-    /* internal extensions */
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_metadata), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_nacm), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_yangdata), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_schema_mount), error);
-    LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_structure), error);
+        /* internal extensions */
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_metadata), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_nacm), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_yangdata), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_schema_mount), error);
+        LY_CHECK_GOTO(ret = plugins_insert(LYPLG_EXTENSION, plugins_structure), error);
+    }
 
 #ifndef STATIC
     /* external types */

--- a/src/plugins_internal.h
+++ b/src/plugins_internal.h
@@ -48,11 +48,12 @@
  *
  * Covers both the types and extensions plugins.
  *
+ * @param[in] builtin_plugins_only Whether to load only built-in YANG plugin types and extensions.
  * @return LY_SUCCESS in case of success
  * @return LY_EINT in case of internal error
  * @return LY_EMEM in case of memory allocation failure.
  */
-LY_ERR lyplg_init(void);
+LY_ERR lyplg_init(ly_bool builtin_plugins_only);
 
 /**
  * @brief Remove (unload) all the plugins currently available.

--- a/src/plugins_types.h
+++ b/src/plugins_types.h
@@ -475,6 +475,7 @@ LIBYANG_API_DECL LY_ERR lyplg_type_print_xpath10_value(const struct lyd_value_xp
 #define LYPLG_TYPE_STORE_IMPLEMENT 0x02 /**< If a foreign module is needed to be implemented to successfully instantiate
                                              the value, make the module implemented. */
 #define LYPLG_TYPE_STORE_IS_UTF8   0x04 /**< The value is guaranteed to be a valid UTF-8 string, if applicable for the type. */
+#define LYPLG_TYPE_STORE_ONLY      0x08 /**< The value is stored only. The validation must be done using [validate](@ref lyplg_type_validate_clb) */
 /** @} plugintypestoreopts */
 
 /**

--- a/src/plugins_types/binary.c
+++ b/src/plugins_types/binary.c
@@ -42,6 +42,8 @@
  */
 static const char b64_etable[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
+static LY_ERR lyplg_type_validate_binary(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node), const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err);
+
 /**
  * @brief Encode binary value into a base64 string value.
  *
@@ -165,12 +167,11 @@ binary_base64_decode(const char *value, size_t value_len, void **data, size_t *s
  *
  * @param[in] value Value to validate.
  * @param[in] value_len Length of @p value.
- * @param[in] type type of the value.
  * @param[out] err Error information.
  * @return LY_ERR value.
  */
 static LY_ERR
-binary_base64_validate(const char *value, size_t value_len, const struct lysc_type_bin *type, struct ly_err_item **err)
+binary_base64_validate(const char *value, size_t value_len, struct ly_err_item **err)
 {
     uint32_t idx, pad;
 
@@ -202,13 +203,6 @@ binary_base64_validate(const char *value, size_t value_len, const struct lysc_ty
     if (value_len & 3) {
         /* base64 length must be multiple of 4 chars */
         return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Base64 encoded value length must be divisible by 4.");
-    }
-
-    /* length restriction of the binary value */
-    if (type->length) {
-        const uint32_t octet_count = ((idx + pad) / 4) * 3 - pad;
-
-        LY_CHECK_RET(lyplg_type_validate_range(LY_TYPE_BINARY, type->length, octet_count, value, value_len, err));
     }
 
     return LY_SUCCESS;
@@ -266,7 +260,6 @@ lyplg_type_store_binary(const struct ly_ctx *ctx, const struct lysc_type *type, 
         struct ly_err_item **err)
 {
     LY_ERR ret = LY_SUCCESS;
-    struct lysc_type_bin *type_bin = (struct lysc_type_bin *)type;
     struct lyd_value_binary *val;
 
     /* init storage */
@@ -306,7 +299,7 @@ lyplg_type_store_binary(const struct ly_ctx *ctx, const struct lysc_type *type, 
         LY_CHECK_GOTO(ret, cleanup);
 
         /* validate */
-        ret = binary_base64_validate(value, value_len, type_bin, err);
+        ret = binary_base64_validate(value, value_len, err);
         LY_CHECK_GOTO(ret, cleanup);
     }
 
@@ -324,6 +317,12 @@ lyplg_type_store_binary(const struct ly_ctx *ctx, const struct lysc_type *type, 
         LY_CHECK_GOTO(ret, cleanup);
     }
 
+    if (!(options & LYPLG_TYPE_STORE_ONLY)) {
+        /* validate value */
+        ret = lyplg_type_validate_binary(ctx, type, NULL, NULL, storage, err);
+        LY_CHECK_GOTO(ret, cleanup);
+    }
+
 cleanup:
     if (options & LYPLG_TYPE_STORE_DYNAMIC) {
         free((void *)value);
@@ -333,6 +332,33 @@ cleanup:
         lyplg_type_free_binary(ctx, storage);
     }
     return ret;
+}
+
+/**
+ * @brief Implementation of ::lyplg_type_validate_clb for the binary type.
+ */
+static LY_ERR
+lyplg_type_validate_binary(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node),
+        const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
+{
+    struct lysc_type_bin *type_bin = (struct lysc_type_bin *)type;
+    struct lyd_value_binary *val;
+    const void *value;
+    size_t value_len;
+
+    LY_CHECK_ARG_RET(NULL, type, storage, err, LY_EINVAL);
+
+    val = LYPLG_TYPE_VAL_IS_DYN(val) ? (struct lyd_value_binary *)(storage->dyn_mem) : (struct lyd_value_binary *)(storage->fixed_mem);
+    value = storage->_canonical;
+    value_len = strlen(storage->_canonical);
+    *err = NULL;
+
+    /* length restriction of the binary value */
+    if (type_bin->length) {
+        LY_CHECK_RET(lyplg_type_validate_range(LY_TYPE_BINARY, type_bin->length, val->size, value, value_len, err));
+    }
+
+    return LY_SUCCESS;
 }
 
 LIBYANG_API_DEF LY_ERR
@@ -470,7 +496,7 @@ const struct lyplg_type_record plugins_binary[] = {
 
         .plugin.id = "libyang 2 - binary, version 1",
         .plugin.store = lyplg_type_store_binary,
-        .plugin.validate = NULL,
+        .plugin.validate = lyplg_type_validate_binary,
         .plugin.compare = lyplg_type_compare_binary,
         .plugin.sort = lyplg_type_sort_binary,
         .plugin.print = lyplg_type_print_binary,

--- a/src/plugins_types/decimal64.c
+++ b/src/plugins_types/decimal64.c
@@ -33,6 +33,8 @@
  * | 8        | yes | `int64_t *` | little-endian value represented without floating point |
  */
 
+static LY_ERR lyplg_type_validate_decimal64(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node), const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err);
+
 /**
  * @brief Convert decimal64 number to canonical string.
  *
@@ -140,10 +142,9 @@ lyplg_type_store_decimal64(const struct ly_ctx *ctx, const struct lysc_type *typ
         LY_CHECK_GOTO(ret, cleanup);
     }
 
-    if (type_dec->range) {
-        /* check range of the number */
-        ret = lyplg_type_validate_range(type->basetype, type_dec->range, num, storage->_canonical,
-                strlen(storage->_canonical), err);
+    if (!(options & LYPLG_TYPE_STORE_ONLY)) {
+        /* validate value */
+        ret = lyplg_type_validate_decimal64(ctx, type, NULL, NULL, storage, err);
         LY_CHECK_GOTO(ret, cleanup);
     }
 
@@ -156,6 +157,31 @@ cleanup:
         lyplg_type_free_simple(ctx, storage);
     }
     return ret;
+}
+
+/**
+ * @brief Implementation of ::lyplg_type_validate_clb for the built-in decimal64 type.
+ */
+static LY_ERR
+lyplg_type_validate_decimal64(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node),
+        const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
+{
+    LY_ERR ret;
+    struct lysc_type_dec *type_dec = (struct lysc_type_dec *)type;
+    int64_t num;
+
+    LY_CHECK_ARG_RET(NULL, type, storage, err, LY_EINVAL);
+    *err = NULL;
+    num = storage->dec64;
+
+    if (type_dec->range) {
+        /* check range of the number */
+        ret = lyplg_type_validate_range(type->basetype, type_dec->range, num, storage->_canonical,
+                strlen(storage->_canonical), err);
+        LY_CHECK_RET(ret);
+    }
+
+    return LY_SUCCESS;
 }
 
 LIBYANG_API_DEF LY_ERR
@@ -236,7 +262,7 @@ const struct lyplg_type_record plugins_decimal64[] = {
 
         .plugin.id = "libyang 2 - decimal64, version 1",
         .plugin.store = lyplg_type_store_decimal64,
-        .plugin.validate = NULL,
+        .plugin.validate = lyplg_type_validate_decimal64,
         .plugin.compare = lyplg_type_compare_decimal64,
         .plugin.sort = lyplg_type_sort_decimal64,
         .plugin.print = lyplg_type_print_decimal64,

--- a/src/plugins_types/string.c
+++ b/src/plugins_types/string.c
@@ -34,6 +34,8 @@
  * | string length | yes | `char *` | string itself |
  */
 
+static LY_ERR lyplg_type_validate_string(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node), const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err);
+
 /**
  * @brief Check string value for invalid characters.
  *
@@ -64,7 +66,6 @@ lyplg_type_store_string(const struct ly_ctx *ctx, const struct lysc_type *type, 
         struct ly_err_item **err)
 {
     LY_ERR ret = LY_SUCCESS;
-    struct lysc_type_str *type_str = (struct lysc_type_str *)type;
 
     /* init storage */
     memset(storage, 0, sizeof *storage);
@@ -80,17 +81,6 @@ lyplg_type_store_string(const struct ly_ctx *ctx, const struct lysc_type *type, 
     ret = lyplg_type_check_hints(hints, value, value_len, type->basetype, NULL, err);
     LY_CHECK_GOTO(ret, cleanup);
 
-    /* length restriction of the string */
-    if (type_str->length) {
-        /* value_len is in bytes, but we need number of characters here */
-        ret = lyplg_type_validate_range(LY_TYPE_STRING, type_str->length, ly_utf8len(value, value_len), value, value_len, err);
-        LY_CHECK_GOTO(ret, cleanup);
-    }
-
-    /* pattern restrictions */
-    ret = lyplg_type_validate_patterns(type_str->patterns, value, value_len, err);
-    LY_CHECK_GOTO(ret, cleanup);
-
     /* store canonical value */
     if (options & LYPLG_TYPE_STORE_DYNAMIC) {
         ret = lydict_insert_zc(ctx, (char *)value, &storage->_canonical);
@@ -98,6 +88,12 @@ lyplg_type_store_string(const struct ly_ctx *ctx, const struct lysc_type *type, 
         LY_CHECK_GOTO(ret, cleanup);
     } else {
         ret = lydict_insert(ctx, value_len ? value : "", value_len, &storage->_canonical);
+        LY_CHECK_GOTO(ret, cleanup);
+    }
+
+    if (!(options & LYPLG_TYPE_STORE_ONLY)) {
+        /* validate value */
+        ret = lyplg_type_validate_string(ctx, type, NULL, NULL, storage, err);
         LY_CHECK_GOTO(ret, cleanup);
     }
 
@@ -110,6 +106,37 @@ cleanup:
         lyplg_type_free_simple(ctx, storage);
     }
     return ret;
+}
+
+/**
+ * @brief Implementation of ::lyplg_type_validate_clb for the string type.
+ */
+static LY_ERR
+lyplg_type_validate_string(const struct ly_ctx *UNUSED(ctx), const struct lysc_type *type, const struct lyd_node *UNUSED(ctx_node),
+        const struct lyd_node *UNUSED(tree), struct lyd_value *storage, struct ly_err_item **err)
+{
+    LY_ERR ret;
+    struct lysc_type_str *type_str = (struct lysc_type_str *)type;
+    const void *value;
+    size_t value_len;
+
+    LY_CHECK_ARG_RET(NULL, type, storage, err, LY_EINVAL);
+    value = storage->_canonical;
+    value_len = strlen(storage->_canonical);
+    *err = NULL;
+
+    /* length restriction of the string */
+    if (type_str->length) {
+        /* value_len is in bytes, but we need number of characters here */
+        ret = lyplg_type_validate_range(LY_TYPE_STRING, type_str->length, ly_utf8len(value, value_len), value, value_len, err);
+        LY_CHECK_RET(ret);
+    }
+
+    /* pattern restrictions */
+    ret = lyplg_type_validate_patterns(type_str->patterns, value, value_len, err);
+    LY_CHECK_RET(ret);
+
+    return LY_SUCCESS;
 }
 
 /**
@@ -127,7 +154,7 @@ const struct lyplg_type_record plugins_string[] = {
 
         .plugin.id = "libyang 2 - string, version 1",
         .plugin.store = lyplg_type_store_string,
-        .plugin.validate = NULL,
+        .plugin.validate = lyplg_type_validate_string,
         .plugin.compare = lyplg_type_compare_simple,
         .plugin.sort = lyplg_type_sort_simple,
         .plugin.print = lyplg_type_print_simple,

--- a/src/tree_data_common.c
+++ b/src/tree_data_common.c
@@ -505,8 +505,8 @@ ly_err_print_build_path(const struct ly_ctx *ctx, const struct lyd_node *node, c
 
 LY_ERR
 lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct lysc_type *type, const void *value,
-        size_t value_len, ly_bool is_utf8, ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints,
-        const struct lysc_node *ctx_node, ly_bool *incomplete)
+        size_t value_len, ly_bool is_utf8, ly_bool store_only, ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data,
+        uint32_t hints, const struct lysc_node *ctx_node, ly_bool *incomplete)
 {
     LY_ERR ret;
     struct ly_err_item *err = NULL;
@@ -524,6 +524,9 @@ lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct ly
     }
     if (is_utf8) {
         options |= LYPLG_TYPE_STORE_IS_UTF8;
+    }
+    if (store_only) {
+        options |= LYPLG_TYPE_STORE_ONLY;
     }
 
     ret = type->plugin->store(ctx, type, value, value_len, options, format, prefix_data, hints, ctx_node, val, NULL, &err);
@@ -688,7 +691,7 @@ lyd_value_compare(const struct lyd_node_term *node, const char *value, size_t va
 
     /* store the value */
     LOG_LOCSET(NULL, &node->node);
-    ret = lyd_value_store(ctx, &val, type, value, value_len, 0, NULL, LY_VALUE_JSON, NULL, LYD_HINT_DATA, node->schema, NULL);
+    ret = lyd_value_store(ctx, &val, type, value, value_len, 0, 0, NULL, LY_VALUE_JSON, NULL, LYD_HINT_DATA, node->schema, NULL);
     LOG_LOCBACK(0, 1);
     LY_CHECK_RET(ret);
 

--- a/src/tree_data_internal.h
+++ b/src/tree_data_internal.h
@@ -225,6 +225,7 @@ const char *ly_format2str(LY_VALUE_FORMAT format);
  * @param[in] value String value to be parsed.
  * @param[in] value_len Length of @p value, must be set correctly.
  * @param[in] is_utf8 Whether @p value is a valid UTF-8 string, if applicable.
+ * @param[in] store_only Whether to perform storing operation only.
  * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
  * @param[in] format Input format of @p value.
  * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
@@ -236,8 +237,8 @@ const char *ly_format2str(LY_VALUE_FORMAT format);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_term(const struct lysc_node *schema, const char *value, size_t value_len, ly_bool is_utf8,
-        ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints, ly_bool *incomplete,
-        struct lyd_node **node);
+        ly_bool store_only, ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints,
+        ly_bool *incomplete, struct lyd_node **node);
 
 /**
  * @brief Create a term (leaf/leaf-list) node from a parsed value by duplicating it.
@@ -274,12 +275,13 @@ LY_ERR lyd_create_inner(const struct lysc_node *schema, struct lyd_node **node);
  * @param[in] schema Schema node of the new data node.
  * @param[in] predicates Compiled key list predicates.
  * @param[in] vars Array of defined variables to use in predicates, may be NULL.
+ * @param[in] store_only Whether to perform storing operation only.
  * @param[out] node Created node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_list(const struct lysc_node *schema, const struct ly_path_predicate *predicates,
-        const struct lyxp_var *vars, struct lyd_node **node);
+        const struct lyxp_var *vars, ly_bool store_only, struct lyd_node **node);
 
 /**
  * @brief Create a list with all its keys (cannot be used for key-less list).
@@ -289,11 +291,13 @@ LY_ERR lyd_create_list(const struct lysc_node *schema, const struct ly_path_pred
  * @param[in] schema Schema node of the new data node.
  * @param[in] keys Key list predicates.
  * @param[in] keys_len Length of @p keys.
+ * @param[in] store_only Whether to perform storing operation only.
  * @param[out] node Created node.
  * @return LY_SUCCESS on success.
  * @return LY_ERR value if an error occurred.
  */
-LY_ERR lyd_create_list2(const struct lysc_node *schema, const char *keys, size_t keys_len, struct lyd_node **node);
+LY_ERR lyd_create_list2(const struct lysc_node *schema, const char *keys, size_t keys_len, ly_bool store_only,
+        struct lyd_node **node);
 
 /**
  * @brief Create an anyxml/anydata node.
@@ -464,6 +468,7 @@ void lyd_unlink_meta_single(struct lyd_meta *meta);
  * @param[in] value String value to be parsed.
  * @param[in] value_len Length of @p value, must be set correctly.
  * @param[in] is_utf8 Whether @p value is a valid UTF-8 string, if applicable.
+ * @param[in] store_only Whether to perform storing operation only.
  * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
  * @param[in] format Input format of @p value.
  * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
@@ -476,8 +481,9 @@ void lyd_unlink_meta_single(struct lyd_meta *meta);
  * @return LY_ERR value if an error occurred.
  */
 LY_ERR lyd_create_meta(struct lyd_node *parent, struct lyd_meta **meta, const struct lys_module *mod, const char *name,
-        size_t name_len, const char *value, size_t value_len, ly_bool is_utf8, ly_bool *dynamic, LY_VALUE_FORMAT format,
-        void *prefix_data, uint32_t hints, const struct lysc_node *ctx_node, ly_bool clear_dflt, ly_bool *incomplete);
+        size_t name_len, const char *value, size_t value_len, ly_bool is_utf8, ly_bool store_only, ly_bool *dynamic,
+        LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints, const struct lysc_node *ctx_node, ly_bool clear_dflt,
+        ly_bool *incomplete);
 
 /**
  * @brief Create a copy of the metadata.
@@ -533,6 +539,7 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @param[in] value Value to be parsed, must not be NULL.
  * @param[in] value_len Length of the give @p value, must be set correctly.
  * @param[in] is_utf8 Whether @p value is a valid UTF-8 string, if applicable.
+ * @param[in] store_only Whether to perform storing operation only.
  * @param[in,out] dynamic Flag if @p value is dynamically allocated, is adjusted when @p value is consumed.
  * @param[in] format Input format of @p value.
  * @param[in] prefix_data Format-specific data for resolving any prefixes (see ::ly_resolve_prefix).
@@ -543,8 +550,8 @@ LY_ERR lyd_create_attr(struct lyd_node *parent, struct lyd_attr **attr, const st
  * @return LY_ERR value on error.
  */
 LY_ERR lyd_value_store(const struct ly_ctx *ctx, struct lyd_value *val, const struct lysc_type *type, const void *value,
-        size_t value_len, ly_bool is_utf8, ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data, uint32_t hints,
-        const struct lysc_node *ctx_node, ly_bool *incomplete);
+        size_t value_len, ly_bool is_utf8, ly_bool store_only, ly_bool *dynamic, LY_VALUE_FORMAT format, void *prefix_data,
+        uint32_t hints, const struct lysc_node *ctx_node, ly_bool *incomplete);
 
 /**
  * @brief Validate previously incompletely stored value.

--- a/src/tree_data_sorted.c
+++ b/src/tree_data_sorted.c
@@ -1170,7 +1170,7 @@ lyds_create_metadata(struct lyd_node *leader, struct lyd_meta **meta_p)
     LY_CHECK_ERR_RET(!modyang, LOGERR(LYD_CTX(leader), LY_EINT, "The yang module is not installed."), LY_EINT);
 
     /* create new metadata, its rbt is NULL */
-    ret = lyd_create_meta(leader, &meta, modyang, RB_NAME, RB_NAME_LEN, NULL, 0, 0, NULL,
+    ret = lyd_create_meta(leader, &meta, modyang, RB_NAME, RB_NAME_LEN, NULL, 0, 0, 1, NULL,
             LY_VALUE_CANON, NULL, LYD_HINT_DATA, NULL, 0, NULL);
     LY_CHECK_RET(ret);
 

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -6220,7 +6220,7 @@ moveto_node_hash_child(struct lyxp_set *set, const struct lysc_node *scnode, con
 
     /* create specific data instance if needed */
     if (scnode->nodetype == LYS_LIST) {
-        LY_CHECK_GOTO(ret = lyd_create_list(scnode, predicates, NULL, &inst), cleanup);
+        LY_CHECK_GOTO(ret = lyd_create_list(scnode, predicates, NULL, 1, &inst), cleanup);
     } else if (scnode->nodetype == LYS_LEAFLIST) {
         LY_CHECK_GOTO(ret = lyd_create_term2(scnode, &predicates[0].value, &inst), cleanup);
     }

--- a/tests/utests/basic/test_context.c
+++ b/tests/utests/basic/test_context.c
@@ -222,10 +222,20 @@ test_options(void **state)
     assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_PREFER_SEARCHDIRS));
     assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_PREFER_SEARCHDIRS);
 
+    /* LY_CTX_LEAFREF_EXTENDED */
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_EXTENDED);
+    assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_LEAFREF_EXTENDED));
+    assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_EXTENDED);
+
     /* LY_CTX_LEAFREF_LINKING */
     assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
     assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING));
     assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
+
+    /* LY_CTX_BUILTIN_PLUGINS_ONLY */
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_BUILTIN_PLUGINS_ONLY);
+    assert_int_equal(LY_SUCCESS, ly_ctx_unset_options(UTEST_LYCTX, LY_CTX_BUILTIN_PLUGINS_ONLY));
+    assert_int_equal(0, UTEST_LYCTX->flags & LY_CTX_BUILTIN_PLUGINS_ONLY);
 
     assert_int_equal(UTEST_LYCTX->flags, ly_ctx_get_options(UTEST_LYCTX));
 
@@ -250,9 +260,17 @@ test_options(void **state)
     assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_PREFER_SEARCHDIRS));
     assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_PREFER_SEARCHDIRS);
 
+    /* LY_CTX_LEAFREF_EXTENDED */
+    assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_EXTENDED));
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_EXTENDED);
+
     /* LY_CTX_LEAFREF_LINKING */
     assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_LEAFREF_LINKING));
     assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_LEAFREF_LINKING);
+
+    /* LY_CTX_BUILTIN_PLUGINS_ONLY */
+    assert_int_equal(LY_SUCCESS, ly_ctx_set_options(UTEST_LYCTX, LY_CTX_BUILTIN_PLUGINS_ONLY));
+    assert_int_not_equal(0, UTEST_LYCTX->flags & LY_CTX_BUILTIN_PLUGINS_ONLY);
 
     assert_int_equal(UTEST_LYCTX->flags, ly_ctx_get_options(UTEST_LYCTX));
 }

--- a/tests/utests/data/test_new.c
+++ b/tests/utests/data/test_new.c
@@ -136,8 +136,27 @@ test_top_level(void **state)
 
     uint32_t val_lens[] = {1, 1};
 
+    assert_int_equal(lyd_new_list3(NULL, mod, "l1", key_vals, val_lens, LYD_NEW_VAL_BIN_VALUE, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(options & 0x04) (lyd_new_list3()).", NULL, 0);
     assert_int_equal(lyd_new_list3_bin(NULL, mod, "l1", (const void **)key_vals, val_lens, 0, &node), LY_SUCCESS);
     lyd_free_tree(node);
+    assert_int_equal(lyd_new_list3_bin(NULL, mod, "l1", (const void **)key_vals, val_lens, LYD_NEW_VAL_STORE_ONLY, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (_lyd_new_list3()).", NULL, 0);
+
+    assert_int_equal(lyd_new_list3(NULL, mod, "l1", key_vals, val_lens, LYD_NEW_VAL_CANON_VALUE, &node), LY_SUCCESS);
+    lyd_free_tree(node);
+    assert_int_equal(lyd_new_list3(NULL, mod, "l1", key_vals, val_lens, LYD_NEW_VAL_CANON_VALUE | LYD_NEW_VAL_STORE_ONLY, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (_lyd_new_list3()).", NULL, 0);
+
+    assert_int_equal(lyd_new_list(NULL, mod, "l1", LYD_NEW_VAL_BIN_VALUE, &node, "val_a", 5, "val_b", 5), LY_SUCCESS);
+    lyd_free_tree(node);
+    assert_int_equal(lyd_new_list(NULL, mod, "l1", LYD_NEW_VAL_BIN_VALUE | LYD_NEW_VAL_STORE_ONLY, &node, "val_a", 5, "val_b", 5), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (lyd_new_list()).", NULL, 0);
+
+    assert_int_equal(lyd_new_list(NULL, mod, "l1", LYD_NEW_VAL_CANON_VALUE, &node, "val_a", "val_b"), LY_SUCCESS);
+    lyd_free_tree(node);
+    assert_int_equal(lyd_new_list(NULL, mod, "l1", LYD_NEW_VAL_CANON_VALUE | LYD_NEW_VAL_STORE_ONLY, &node, "val_a", "val_b"), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (lyd_new_list()).", NULL, 0);
 
     /* leaf */
     assert_int_equal(lyd_new_term(NULL, mod, "foo", "[a='a'][b='b'][c='c']", 0, &node), LY_EVALID);
@@ -148,6 +167,18 @@ test_top_level(void **state)
 
     assert_int_equal(lyd_new_term(NULL, mod, "foo", "256", 0, &node), LY_SUCCESS);
     lyd_free_tree(node);
+
+    assert_int_equal(lyd_new_term(NULL, mod, "foo", "25", LYD_NEW_VAL_BIN_VALUE, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(options & 0x04) (lyd_new_term()).", NULL, 0);
+    assert_int_equal(lyd_new_term_bin(NULL, mod, "foo", "25", 2, LYD_NEW_VAL_BIN_VALUE, &node), LY_SUCCESS);
+    lyd_free_tree(node);
+    assert_int_equal(lyd_new_term_bin(NULL, mod, "foo", "25", 2, LYD_NEW_VAL_STORE_ONLY, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (_lyd_new_term()).", NULL, 0);
+
+    assert_int_equal(lyd_new_term(NULL, mod, "foo", "25", LYD_NEW_VAL_CANON_VALUE, &node), LY_SUCCESS);
+    lyd_free_tree(node);
+    assert_int_equal(lyd_new_term(NULL, mod, "foo", "25", LYD_NEW_VAL_CANON_VALUE | LYD_NEW_VAL_STORE_ONLY, &node), LY_EINVAL);
+    CHECK_LOG_CTX("Invalid argument !(store_only && (format == LY_VALUE_CANON || format == LY_VALUE_LYB)) (_lyd_new_term()).", NULL, 0);
 
     /* leaf-list */
     assert_int_equal(lyd_new_term(NULL, mod, "ll", "ahoy", 0, &node), LY_SUCCESS);
@@ -164,9 +195,9 @@ test_top_level(void **state)
     CHECK_LOG_CTX("Inner node (container, notif, RPC, or action) \"l2\" not found.", NULL, 0);
 
     /* anydata */
-    assert_int_equal(lyd_new_any(NULL, mod, "any", "{\"node\":\"val\"}", 0, LYD_ANYDATA_STRING, 0, &node), LY_SUCCESS);
+    assert_int_equal(lyd_new_any(NULL, mod, "any", "{\"node\":\"val\"}", 0, LYD_ANYDATA_STRING, &node), LY_SUCCESS);
     lyd_free_tree(node);
-    assert_int_equal(lyd_new_any(NULL, mod, "any", "<node>val</node>", 0, LYD_ANYDATA_STRING, 0, &node), LY_SUCCESS);
+    assert_int_equal(lyd_new_any(NULL, mod, "any", "<node>val</node>", 0, LYD_ANYDATA_STRING, &node), LY_SUCCESS);
     lyd_free_tree(node);
 
     /* key-less list */
@@ -186,7 +217,7 @@ test_top_level(void **state)
     assert_int_equal(lyd_new_inner(NULL, mod, "oper", 0, &rpc), LY_SUCCESS);
     assert_int_equal(lyd_new_term(rpc, mod, "param", "22", 0, &node), LY_SUCCESS);
     assert_int_equal(LY_TYPE_STRING, ((struct lysc_node_leaf *)node->schema)->type->basetype);
-    assert_int_equal(lyd_new_term(rpc, mod, "param", "22", 1, &node), LY_SUCCESS);
+    assert_int_equal(lyd_new_term(rpc, mod, "param", "22", LYD_NEW_VAL_OUTPUT, &node), LY_SUCCESS);
     assert_int_equal(LY_TYPE_INT8, ((struct lysc_node_leaf *)node->schema)->type->basetype);
     lyd_free_tree(rpc);
 }

--- a/tests/utests/types/binary.c
+++ b/tests/utests/types/binary.c
@@ -232,6 +232,15 @@ test_plugin_store(void **state)
     assert_int_equal(LY_EVALID, ly_ret);
     assert_string_equal(err->msg, "Unsatisfied length - string \"MTIz\" length is not allowed.");
     ly_err_free(err);
+
+    /* LYPLG_TYPE_STORE_ONLY test */
+    val = "MTIz";
+    err = NULL;
+    ly_ret = type->store(UTEST_LYCTX, lysc_type2, val, strlen(val),
+            LYPLG_TYPE_STORE_ONLY, LY_VALUE_XML, NULL, LYD_VALHINT_STRING, NULL, &value, NULL, &err);
+    assert_int_equal(LY_SUCCESS, ly_ret);
+    type->free(UTEST_LYCTX, &value);
+    ly_err_free(err);
 }
 
 static void

--- a/tests/utests/types/decimal64.c
+++ b/tests/utests/types/decimal64.c
@@ -60,6 +60,14 @@
         lyd_free_all(tree_2); \
     }
 
+#define TEST_SUCCESS_PARSE_STORE_ONLY_XML(MOD_NAME, NODE_NAME, DATA) \
+    {\
+        struct lyd_node *tree; \
+        const char *data = "<" NODE_NAME " xmlns=\"urn:tests:" MOD_NAME "\">" DATA "</" NODE_NAME ">"; \
+        CHECK_PARSE_LYD_PARAM(data, LYD_XML, LYD_PARSE_STORE_ONLY, LYD_VALIDATE_PRESENT, LY_SUCCESS, tree); \
+        lyd_free_all(tree); \
+    }
+
 static void
 test_data_xml(void **state)
 {
@@ -94,6 +102,9 @@ test_data_xml(void **state)
 
     TEST_ERROR_XML("defs", "l1", "8.55  xxx");
     CHECK_LOG_CTX("Value \"8.55\" of decimal64 type exceeds defined number (1) of fraction digits.", "/defs:l1", 1);
+
+    /* LYPLG_TYPE_STORE_ONLY test */
+    TEST_SUCCESS_PARSE_STORE_ONLY_XML("defs", "l1", "\n 15 \t\n  ");
 }
 
 static void

--- a/tests/utests/types/int8.c
+++ b/tests/utests/types/int8.c
@@ -1527,6 +1527,16 @@ test_plugin_store(void **state)
     assert_int_equal(LY_EVALID, ly_ret);
     ly_err_free(err);
 
+    /* LYPLG_TYPE_STORE_ONLY test */
+    val_text = "-60";
+    err = NULL;
+    ly_ret = type->store(UTEST_LYCTX, lysc_type, val_text, strlen(val_text),
+            LYPLG_TYPE_STORE_ONLY, LY_VALUE_XML, NULL, LYD_VALHINT_DECNUM, NULL,
+            &value, NULL, &err);
+    assert_int_equal(LY_SUCCESS, ly_ret);
+    type->free(UTEST_LYCTX, &value);
+    ly_err_free(err);
+
     UTEST_LOG_CTX_CLEAN;
 }
 

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -1184,6 +1184,15 @@ test_plugin_store(void **state)
     assert_int_equal(LY_EVALID, ly_ret);
     ly_err_free(err);
 
+    /* LYPLG_TYPE_STORE_ONLY test */
+    val_text = "10 \"| bcdei";
+    err = NULL;
+    ly_ret = type->store(UTEST_LYCTX, lysc_type, val_text, strlen(val_text),
+            LYPLG_TYPE_STORE_ONLY, LY_VALUE_XML, NULL, LYD_VALHINT_STRING, NULL,
+            &value, NULL, &err);
+    assert_int_equal(LY_SUCCESS, ly_ret);
+    type->free(UTEST_LYCTX, &value);
+    ly_err_free(err);
 }
 
 static void

--- a/tests/utests/types/uint8.c
+++ b/tests/utests/types/uint8.c
@@ -50,6 +50,14 @@
         assert_null(tree); \
     }
 
+#define TEST_SUCCESS_PARSE_STORE_ONLY_XML(MOD_NAME, DATA) \
+    {\
+        struct lyd_node *tree; \
+        const char *data = "<port xmlns=\"urn:tests:" MOD_NAME "\">" DATA "</port>"; \
+        CHECK_PARSE_LYD_PARAM(data, LYD_XML, LYD_PARSE_STORE_ONLY, LYD_VALIDATE_PRESENT, LY_SUCCESS, tree); \
+        lyd_free_all(tree); \
+    }
+
 static void
 test_data_xml(void **state)
 {
@@ -63,6 +71,9 @@ test_data_xml(void **state)
 
     TEST_ERROR_XML("defs", "\n 15 \t\n  ");
     CHECK_LOG_CTX("Unsatisfied range - value \"15\" is out of the allowed range.", "/defs:port", 3);
+
+    /* LYPLG_TYPE_STORE_ONLY test */
+    TEST_SUCCESS_PARSE_STORE_ONLY_XML("defs", "\n 15 \t\n  ");
 }
 
 int


### PR DESCRIPTION
This patch separates the build-in type validations from store operations to allow storing a node even if the value doesn't pass the validations. To do that a new context option was introduced:
  LY_CTX_STORE_INVALID_DATA

This option also prevent loading of advanced plugins, which cannot really separate store and validation operations