### PR TITLE
Fix edit-config doesn't replace non-predicated value by value with pr…

### DIFF
--- a/src/plugins_types/instanceid.c
+++ b/src/plugins_types/instanceid.c
@@ -267,7 +267,7 @@ lyplg_type_compare_instanceid(const struct lyd_value *val1, const struct lyd_val
         struct ly_path *s1 = &val1->target[u];
         struct ly_path *s2 = &val2->target[u];
 
-        if ((s1->node != s2->node) || (s1->predicates && (LY_ARRAY_COUNT(s1->predicates) != LY_ARRAY_COUNT(s2->predicates)))) {
+        if ((s1->node != s2->node) || (LY_ARRAY_COUNT(s1->predicates) != LY_ARRAY_COUNT(s2->predicates))) {
             return LY_ENOT;
         }
         LY_ARRAY_FOR(s1->predicates, v) {


### PR DESCRIPTION
Fix edit-config doesn't replace non-predicated value by value with predicate

* removed unnecessary check, that s1->predicates not equals to NULL. It's possible due LY_ARRAY_COUNT can handles NULL pointer by itself
* before this fix comparison old value without predicate and a new one with predicate returned LY_SUCCES instead of LY_ENOT

Please, look for mote details in [https://github.com/CESNET/libyang/issues/2172](url)