### PR TITLE
This commit fixes absent clearing memory, allocated by vasprintf for …

### DIFF
--- a/src/out.c
+++ b/src/out.c
@@ -437,6 +437,7 @@ ly_vprint_(struct ly_out *out, const char *format, va_list ap)
             if (!*out->method.mem.buf) {
                 out->method.mem.len = 0;
                 out->method.mem.size = 0;
+                free(msg);
                 LOGMEM(NULL);
                 return LY_EMEM;
             }


### PR DESCRIPTION
This commit fixes absent clearing memory, allocated by vasprintf for "char *msg".

In case ly_realloc for *out->method.mem.buf fail, we don't free msg pointer now.
So, it can produces a memory leak.