### PR TITLE
xpath processing BUGFIX pointer null judgment

### DIFF
--- a/src/xpath.c
+++ b/src/xpath.c
@@ -4168,7 +4168,7 @@ xpath_derived_(struct lyxp_set **args, struct lyxp_set *set, uint32_t options, l
             leaf = (struct lyd_node_term *)args[0]->val.nodes[i].node;
             sleaf = (struct lysc_node_leaf *)leaf->schema;
             val = &leaf->value;
-            if ((sleaf == NULL) || !(sleaf->nodetype & LYD_NODE_TERM) || (leaf->value.realtype->basetype != LY_TYPE_IDENT)) {
+            if (!sleaf || !(sleaf->nodetype & LYD_NODE_TERM) || (leaf->value.realtype->basetype != LY_TYPE_IDENT)) {
                 /* uninteresting */
                 continue;
             }

--- a/src/xpath.c
+++ b/src/xpath.c
@@ -4168,7 +4168,7 @@ xpath_derived_(struct lyxp_set **args, struct lyxp_set *set, uint32_t options, l
             leaf = (struct lyd_node_term *)args[0]->val.nodes[i].node;
             sleaf = (struct lysc_node_leaf *)leaf->schema;
             val = &leaf->value;
-            if (!(sleaf->nodetype & LYD_NODE_TERM) || (leaf->value.realtype->basetype != LY_TYPE_IDENT)) {
+            if ((sleaf == NULL) || !(sleaf->nodetype & LYD_NODE_TERM) || (leaf->value.realtype->basetype != LY_TYPE_IDENT)) {
                 /* uninteresting */
                 continue;
             }


### PR DESCRIPTION
the schema node lysc_node_leaf obtained from the lyd_node_term node may be empty. When accessing nodetype, check whether the schema node is empty to avoid null pointer dereference.