### PR TITLE
Fix segfault of tree_data_sorted

### DIFF
--- a/src/tree_data_sorted.c
+++ b/src/tree_data_sorted.c
@@ -1227,7 +1227,7 @@ lyds_insert(struct lyd_node **first_sibling, struct lyd_node **leader, struct ly
     /* get the Red-black tree from the @p leader */
     rbt = lyds_get_rb_tree(*leader, &root_meta);
     if (!root_meta) {
-        lyds_create_metadata(*leader, &root_meta);
+        LY_CHECK_RET(lyds_create_metadata(*leader, &root_meta));
     }
     if (!rbt) {
         /* Due to optimization, the Red-black tree has not been created so far, so it will be


### PR DESCRIPTION
This patch fixes segfault in case of usage of anydata nodes and LY_CTX_BUILTIN_PLUGINS_ONLY within sorted data tree.