### PR TITLE
Update link to Rust bindings library

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ available separately.
 
 * [Python](https://github.com/CESNET/libyang-python/)
 * [C++](https://github.com/CESNET/libyang-cpp/)
-* [Rust](https://github.com/rwestphal/yang2-rs/)
+* [Rust](https://github.com/holo-routing/yang2-rs/)
 
 ## yanglint
 


### PR DESCRIPTION
The *yang2-rs* project has been relocated to a different GitHub account.