### PR TITLE
BUGFIX lyd_new_list3 duplicates first key value to the rest of the keys

### DIFF
--- a/src/tree_data_new.c
+++ b/src/tree_data_new.c
@@ -824,6 +824,7 @@ _lyd_new_list3(struct lyd_node *parent, const struct lys_module *module, const c
         rc = lyd_create_term(key_s, key_val, key_len, 0, NULL, format, NULL, LYD_HINT_DATA, NULL, &key);
         LY_CHECK_GOTO(rc, cleanup);
         lyd_insert_node(ret, NULL, key, 1);
+        ++i;
     }
 
     if (parent) {


### PR DESCRIPTION
When using lyd_new_list3 to create using its keys values and lengths, it function only takes the first key value and duplicates it to the other keys:

Example, this function extracts keys from a json object and creates lyd_node:
```
if (get_list_keys(list, list_obj, lys_flags, &key_values, &values_lengths, &keys_count) == EXIT_SUCCESS) 
{
  // Print keys values:
  printf("Keys content:\n);
  for (int i = 0; i < keys_count; i++) {
    printf("Key %d: %s\n", i, key_values[i]);
  }
  
  // create list
  lyd_new_list3(*parent_data_node, NULL, s_node->name, key_values, values_lengths, 0, &new_data_node);
  
  // print created list
  char *node_print_text;
  lyd_print_mem(&node_print_text, new_data_node, LYD_XML, 0);
  printf("lyd_node:\n);
  printf("%s", node_print_text);
}
```

The outputs of debugging prints are below:
```
Keys content:
Key 0: 20
Key 1: 30
lyd_node:
<nh xmlns="urn:okda:iproute2:ip:nexthop">
  <id>20</id>
  <weight>20</weight>
</nh>
```
As seen the created node had duplicated key 0 to key 1 in the resulting lyd_node.

By checking `lyd_new_list3` code, its missing counter i increment which causes the duplication:
https://github.com/CESNET/libyang/blob/master/src/tree_data_new.c#L818