### PR TITLE
distro UPDATE separate package for YANG modules

### DIFF
--- a/distro/pkg/deb/control
+++ b/distro/pkg/deb/control
@@ -63,3 +63,11 @@ Description: parser toolkit for IETF YANG data modeling - executable tools
  during the creation of IETF YANG schemas.  The tools are not generally
  useful for normal operation where libyang primarily processes configuration
  data, not schemas.
+
+Package: libyang-modules
+Section: devel
+Architecture: all
+Description: parser toolkit for IETF YANG data modeling - YANG modules
+ This package provides the IETF YANG modules used by libyang. These modules
+ are embedded into libyang so this package is not necessary for libyang
+ operation.

--- a/distro/pkg/deb/libyang-modules.install
+++ b/distro/pkg/deb/libyang-modules.install
@@ -1,0 +1,1 @@
+usr/share/yang/modules/libyang

--- a/distro/pkg/deb/libyang3.install
+++ b/distro/pkg/deb/libyang3.install
@@ -1,2 +1,1 @@
 usr/lib/*/*.so.*
-usr/share/yang/modules/libyang

--- a/distro/pkg/rpm/libyang.spec
+++ b/distro/pkg/rpm/libyang.spec
@@ -17,6 +17,9 @@ BuildRequires:  cmake(cmocka) >= 1.0.1
 BuildRequires:  make
 BuildRequires:  pkgconfig(libpcre2-8) >= 10.21
 
+%package modules
+Summary:    YANG modules for libyang
+
 %package devel
 Summary:    Development files for libyang
 Requires:   %{name}%{?_isa} = %{version}-%{release}
@@ -31,6 +34,9 @@ Summary:        YANG validator tools
 Requires:       %{name}%{?_isa} = %{version}-%{release}
 # This was not properly split out before
 Conflicts:      %{name} < 1.0.225-3
+
+%description modules
+YANG modules for libyang.
 
 %description devel
 Headers of libyang library.
@@ -92,6 +98,8 @@ mkdir -m0755 -p %{buildroot}/%{_docdir}/libyang
 %license LICENSE
 %{_libdir}/libyang.so.3
 %{_libdir}/libyang.so.3.*
+
+%files modules
 %{_datadir}/yang/modules/libyang/*.yang
 %dir %{_datadir}/yang/
 %dir %{_datadir}/yang/modules/


### PR DESCRIPTION
Currently, YANG modules are installed as part of the main libyang deb/rpm package. This makes it impossible to install both libyang2 and libyang3 at the same time, because package managers don't allow to simultaneously install packages that provide the same files.

As the YANG modules are already embedded into libyang binaries and not needed for libyang operation, we can move them to a separate libyang-data optional package. It allows to install both libyang2 and libyang3 at the same time.

P.S. Another option is to install YANG modules as part of `libyang-dev` package. Please, let me know if you think it's a better option and I'll update my PR accordingly.