### PR TITLE
Adding context based extensions plugins support

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -1384,7 +1384,11 @@ ly_ctx_destroy(struct ly_ctx *ctx)
     /* LYB hash lock */
     pthread_mutex_destroy(&ctx->lyb_hash_lock);
 
-    /* plugins - will be removed only if this is the last context */
+    /* context specific plugins */
+    ly_set_erase(&ctx->plugins_types, NULL);
+    ly_set_erase(&ctx->plugins_extensions, NULL);
+
+    /* shared plugins - will be removed only if this is the last context */
     lyplg_clean();
 
     free(ctx);

--- a/src/ly_common.h
+++ b/src/ly_common.h
@@ -356,6 +356,8 @@ struct ly_ctx {
     struct ly_ht *err_ht;             /**< hash table of thread-specific list of errors related to the context */
     pthread_mutex_t lyb_hash_lock;    /**< lock for storing LYB schema hashes in schema nodes */
     struct ly_ht *leafref_links_ht;   /**< hash table of leafref links between term data nodes */
+    struct ly_set plugins_types;      /**< context specific set of type plugins */
+    struct ly_set plugins_extensions; /**< contets specific set of extension plugins */
 };
 
 /**

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -594,7 +594,24 @@ lyplg_add(const char *pathname)
 #endif
 }
 
-LIBYANG_API_DEF LY_ERR
+/**
+ * @brief Manually load an extension plugins from memory
+ *
+ * Note, that a plugin can be loaded only if there is at least one context. The loaded plugins are connected with the
+ * existence of a context. When all the contexts are destroyed, all the plugins are unloaded.
+ *
+ * @param[in] ctx The context to which the plugin should be associated with. If NULL, the plugin is considered to be shared
+ * between all existing contexts.
+ * @param[in] version The version of plugin records.
+ * @param[in] type The type of plugins records.
+ * @param[in] recs An array of plugin records provided by the plugin implementation. The array must be terminated by a zeroed
+ * record.
+ *
+ * @return LY_SUCCESS if the plugins with compatible version were successfully loaded.
+ * @return LY_EDENIED in case there is no context and the plugin cannot be loaded.
+ * @return LY_EINVAL when recs is NULL or the plugin contains invalid content for this libyang version.
+ */
+static LY_ERR
 lyplg_add_plugin(struct ly_ctx *ctx, uint32_t version, enum LYPLG type, const void *recs)
 {
     LY_ERR ret = LY_SUCCESS;
@@ -620,4 +637,16 @@ lyplg_add_plugin(struct ly_ctx *ctx, uint32_t version, enum LYPLG type, const vo
     pthread_mutex_unlock(&plugins_guard);
 
     return ret;
+}
+
+LIBYANG_API_DEF LY_ERR
+lyplg_add_extension_plugin(struct ly_ctx *ctx, uint32_t version, const struct lyplg_ext_record *recs)
+{
+    return lyplg_add_plugin(ctx, version, LYPLG_EXTENSION, recs);
+}
+
+LIBYANG_API_DEF LY_ERR
+lyplg_add_type_plugin(struct ly_ctx *ctx, uint32_t version, const struct lyplg_type_record *recs)
+{
+    return lyplg_add_plugin(ctx, version, LYPLG_TYPE, recs);
 }

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -85,6 +85,24 @@ enum LYPLG {
  */
 LIBYANG_API_DECL LY_ERR lyplg_add(const char *pathname);
 
+/**
+ * @brief Manually load a plugins from memory
+ *
+ * Note, that a plugin can be loaded only if there is at least one context. The loaded plugins are connected with the
+ * existence of a context. When all the contexts are destroyed, all the plugins are unloaded.
+ *
+ * @param[in] ctx The context to which the plugin should be associated with. If NULL, the plugin is considered to be shared
+ * between all existing contexts.
+ * @param[in] version The version of plugin records.
+ * @param[in] type The type of plugins records.
+ * @param[in] recs An array of plugin records provided by the plugin implementation. The array must be terminated by a zeroed
+ * record.
+ *
+ * @return LY_SUCCESS if the plugins with compatible version were successfully loaded.
+ * @return LY_EDENIED in case there is no context and the plugin cannot be loaded.
+ * @return LY_EINVAL when recs is NULL or the plugin contains invalid content for this libyang version.
+ */
+LIBYANG_API_DECL LY_ERR lyplg_add_plugin(struct ly_ctx *ctx, uint32_t version, enum LYPLG type, const void *recs);
 /** @} plugins */
 
 #ifdef __cplusplus

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -17,6 +17,9 @@
 
 #include "log.h"
 
+struct lyplg_ext_record;
+struct lyplg_type_record;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,7 +89,7 @@ enum LYPLG {
 LIBYANG_API_DECL LY_ERR lyplg_add(const char *pathname);
 
 /**
- * @brief Manually load a plugins from memory
+ * @brief Manually load extension plugins from memory
  *
  * Note, that a plugin can be loaded only if there is at least one context. The loaded plugins are connected with the
  * existence of a context. When all the contexts are destroyed, all the plugins are unloaded.
@@ -94,7 +97,6 @@ LIBYANG_API_DECL LY_ERR lyplg_add(const char *pathname);
  * @param[in] ctx The context to which the plugin should be associated with. If NULL, the plugin is considered to be shared
  * between all existing contexts.
  * @param[in] version The version of plugin records.
- * @param[in] type The type of plugins records.
  * @param[in] recs An array of plugin records provided by the plugin implementation. The array must be terminated by a zeroed
  * record.
  *
@@ -102,7 +104,25 @@ LIBYANG_API_DECL LY_ERR lyplg_add(const char *pathname);
  * @return LY_EDENIED in case there is no context and the plugin cannot be loaded.
  * @return LY_EINVAL when recs is NULL or the plugin contains invalid content for this libyang version.
  */
-LIBYANG_API_DECL LY_ERR lyplg_add_plugin(struct ly_ctx *ctx, uint32_t version, enum LYPLG type, const void *recs);
+LIBYANG_API_DECL LY_ERR lyplg_add_extension_plugin(struct ly_ctx *ctx, uint32_t version, const struct lyplg_ext_record *recs);
+
+/**
+ * @brief Manually load type plugins from memory
+ *
+ * Note, that a plugin can be loaded only if there is at least one context. The loaded plugins are connected with the
+ * existence of a context. When all the contexts are destroyed, all the plugins are unloaded.
+ *
+ * @param[in] ctx The context to which the plugin should be associated with. If NULL, the plugin is considered to be shared
+ * between all existing contexts.
+ * @param[in] version The version of plugin records.
+ * @param[in] recs An array of plugin records provided by the plugin implementation. The array must be terminated by a zeroed
+ * record.
+ *
+ * @return LY_SUCCESS if the plugins with compatible version were successfully loaded.
+ * @return LY_EDENIED in case there is no context and the plugin cannot be loaded.
+ * @return LY_EINVAL when recs is NULL or the plugin contains invalid content for this libyang version.
+ */
+LIBYANG_API_DECL LY_ERR lyplg_add_type_plugin(struct ly_ctx *ctx, uint32_t version, const struct lyplg_type_record *recs);
 /** @} plugins */
 
 #ifdef __cplusplus

--- a/src/plugins_internal.h
+++ b/src/plugins_internal.h
@@ -63,6 +63,7 @@ void lyplg_clean(void);
 /**
  * @brief Find a type plugin.
  *
+ * @param[in] ctx The optional context for which the plugin should be find. If NULL, only shared plugins will be searched
  * @param[in] module Name of the module where the type is defined. Must not be NULL, in case of plugins for
  * built-in types, the module is "".
  * @param[in] revision Revision of the module for which the plugin is implemented. NULL is not a wildcard, it matches
@@ -70,17 +71,18 @@ void lyplg_clean(void);
  * @param[in] name Name of the type which the plugin implements.
  * @return Found type plugin, NULL if none found.
  */
-struct lyplg_type *lyplg_type_plugin_find(const char *module, const char *revision, const char *name);
+struct lyplg_type *lyplg_type_plugin_find(const struct ly_ctx *ctx, const char *module, const char *revision, const char *name);
 
 /**
  * @brief Find an extension plugin.
  *
+ * @param[in] ctx The optional context for which the plugin should be find. If NULL, only shared plugins will be searched
  * @param[in] module Name of the module where the extension is defined.
  * @param[in] revision Revision of the module for which the plugin is implemented. NULL is not a wildcard, it matches
  * only the plugins with NULL revision specified.
  * @param[in] name Name of the extension which the plugin implements.
  * @return Found extension record, NULL if none found.
  */
-struct lyplg_ext_record *lyplg_ext_record_find(const char *module, const char *revision, const char *name);
+struct lyplg_ext_record *lyplg_ext_record_find(const struct ly_ctx *ctx, const char *module, const char *revision, const char *name);
 
 #endif /* LY_PLUGINS_INTERNAL_H_ */

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2263,7 +2263,7 @@ preparenext:
         }
 
         /* try to find loaded user type plugins */
-        plugin = lyplg_type_plugin_find(tctx->tpdf->type.pmod->mod->name, tctx->tpdf->type.pmod->mod->revision,
+        plugin = lyplg_type_plugin_find(ctx->ctx, tctx->tpdf->type.pmod->mod->name, tctx->tpdf->type.pmod->mod->revision,
                 tctx->tpdf->name);
         if (!plugin && base) {
             /* use the base type implementation if available */
@@ -2271,7 +2271,7 @@ preparenext:
         }
         if (!plugin) {
             /* use the internal built-in type implementation */
-            plugin = lyplg_type_plugin_find("", NULL, ly_data_type2str[basetype]);
+            plugin = lyplg_type_plugin_find(ctx->ctx, "", NULL, ly_data_type2str[basetype]);
         }
         assert(plugin);
 
@@ -2312,7 +2312,7 @@ preparenext:
     /* process the type definition in leaf */
     if (type_p->flags || type_p->exts || !base || (basetype == LY_TYPE_LEAFREF)) {
         /* leaf type has changes that need to be compiled into the type */
-        plugin = base ? base->plugin : lyplg_type_plugin_find("", NULL, ly_data_type2str[basetype]);
+        plugin = base ? base->plugin : lyplg_type_plugin_find(ctx->ctx, "", NULL, ly_data_type2str[basetype]);
         ret = lys_compile_type_(ctx, context_pnode, context_flags, context_name, (struct lysp_type *)type_p, basetype,
                 NULL, base, plugin, &tpdf_chain, 0, type);
         LY_CHECK_GOTO(ret, cleanup);

--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1362,7 +1362,7 @@ lysp_resolve_ext_instance_records(struct lysp_ctx *pctx)
             LY_CHECK_RET(lysp_ext_instance_resolve_argument(PARSER_CTX(pctx), ext));
 
             /* find the extension record, if any */
-            ext->record = lyplg_ext_record_find(mod->name, mod->revision, ext->def->name);
+            ext->record = lyplg_ext_record_find(mod->ctx, mod->name, mod->revision, ext->def->name);
         }
     }
 

--- a/tests/utests/basic/test_plugins.c
+++ b/tests/utests/basic/test_plugins.c
@@ -131,7 +131,7 @@ test_simple_from_memory(void **state)
     struct lys_module *mod;
     struct lysc_node_leaf *leaf;
 
-    lyplg_add_plugin(UTEST_LYCTX, LYPLG_EXT_API_VERSION, LYPLG_EXTENSION, memory_recs);
+    lyplg_add_extension_plugin(UTEST_LYCTX, LYPLG_EXT_API_VERSION, memory_recs);
     UTEST_ADD_MODULE(simple, LYS_IN_YANG, NULL, &mod);
 
     leaf = (struct lysc_node_leaf *)mod->compiled->data;

--- a/tests/utests/types/binary.c
+++ b/tests/utests/types/binary.c
@@ -51,7 +51,7 @@ test_plugin_store(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value value = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BINARY]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BINARY]);
     struct lysc_type *lysc_type, *lysc_type2;
     LY_ERR ly_ret;
     const char *schema;
@@ -250,7 +250,7 @@ test_plugin_print(void **state)
     struct lyd_value value = {0};
     struct lys_module *mod;
     struct lysc_type *lysc_type;
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BINARY]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BINARY]);
     struct ly_err_item *err = NULL;
 
     /* create schema. Prepare common used variables */
@@ -273,7 +273,7 @@ test_plugin_duplicate(void **state)
     struct lyd_value value = {0}, dup;
     struct lys_module *mod;
     struct lysc_type *lysc_type;
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BINARY]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BINARY]);
     struct ly_err_item *err = NULL;
 
     /* create schema. Prepare common used variables */
@@ -298,7 +298,7 @@ test_plugin_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BINARY]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BINARY]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 

--- a/tests/utests/types/bits.c
+++ b/tests/utests/types/bits.c
@@ -800,7 +800,7 @@ test_plugin_store(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value value = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BITS]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BITS]);
     struct lysc_type *lysc_type;
     struct lysc_type lysc_type_test;
     LY_ERR ly_ret;
@@ -894,7 +894,7 @@ test_plugin_compare(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BITS]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BITS]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     const char *schema;
@@ -956,7 +956,7 @@ test_plugin_sort(void **state)
 {
     const char *schema;
     struct lys_module *mod;
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BITS]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BITS]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
     struct lyd_value val1 = {0}, val2 = {0};
@@ -993,7 +993,7 @@ test_plugin_print(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BITS]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BITS]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     const char *schema;
@@ -1035,7 +1035,7 @@ test_plugin_dup(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_BITS]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_BITS]);
     struct lysc_type *lysc_type;
     const char *schema;
     LY_ERR ly_ret;

--- a/tests/utests/types/enumeration.c
+++ b/tests/utests/types/enumeration.c
@@ -94,7 +94,7 @@ test_plugin_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_ENUM]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_ENUM]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 

--- a/tests/utests/types/inet_types.c
+++ b/tests/utests/types/inet_types.c
@@ -196,7 +196,7 @@ test_plugin_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_UNION]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_UNION]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 
@@ -238,7 +238,7 @@ test_plugin_sort(void **state)
 
     /* ipv6-address */
     lysc_type = ((struct lysc_node_leaflist *)mod->compiled->data->next)->type;
-    type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
 
     v1 = "2008:15:0:0:0:0:feAC:1";
     assert_int_equal(LY_SUCCESS, type->store(UTEST_LYCTX, lysc_type, v1, strlen(v1),
@@ -266,7 +266,7 @@ test_plugin_sort(void **state)
 
     /* ipv4-address-no-zone */
     lysc_type = ((struct lysc_node_leaflist *)mod->compiled->data->next->next)->type;
-    type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_UNION]);
+    type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_UNION]);
     v1 = "127.0.0.1";
     assert_int_equal(LY_SUCCESS, type->store(UTEST_LYCTX, lysc_type, v1, strlen(v1),
             0, LY_VALUE_JSON, NULL, LYD_VALHINT_STRING, NULL, &val1, NULL, &err));
@@ -281,7 +281,7 @@ test_plugin_sort(void **state)
 
     /* ipv6-address-no-zone */
     lysc_type = ((struct lysc_node_leaflist *)mod->compiled->data->next->next->next)->type;
-    type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
     v1 = "A:B:c:D:e:f:1:1";
     assert_int_equal(LY_SUCCESS, type->store(UTEST_LYCTX, lysc_type, v1, strlen(v1),
             0, LY_VALUE_JSON, NULL, LYD_VALHINT_STRING, NULL, &val1, NULL, &err));

--- a/tests/utests/types/int8.c
+++ b/tests/utests/types/int8.c
@@ -1399,7 +1399,7 @@ test_plugin_store(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value value = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_INT8]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_INT8]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     char *alloc;
@@ -1546,7 +1546,7 @@ test_plugin_compare(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_INT8]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_INT8]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     const char *schema;
@@ -1631,7 +1631,7 @@ test_plugin_print(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_INT8]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_INT8]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     const char *schema;
@@ -1671,7 +1671,7 @@ test_plugin_dup(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_INT8]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_INT8]);
     struct lysc_type *lysc_type[2];
     const char *schema;
     LY_ERR ly_ret;

--- a/tests/utests/types/leafref.c
+++ b/tests/utests/types/leafref.c
@@ -216,7 +216,7 @@ test_plugin_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_LEAFREF]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_LEAFREF]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -1060,7 +1060,7 @@ test_plugin_store(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value value = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
     struct lysc_type *lysc_type;
     char *alloc_text;
     unsigned int alloc_text_size;
@@ -1201,7 +1201,7 @@ test_plugin_compare(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
     const char *schema;
@@ -1259,7 +1259,7 @@ test_plugin_print(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
     struct lysc_type *lysc_type;
     LY_ERR ly_ret;
 
@@ -1298,7 +1298,7 @@ test_plugin_dup(void **state)
     struct ly_err_item *err = NULL;
     struct lys_module *mod;
     struct lyd_value values[10];
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_STRING]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_STRING]);
     struct lysc_type *lysc_type[2];
     const char *schema;
     LY_ERR ly_ret;

--- a/tests/utests/types/union.c
+++ b/tests/utests/types/union.c
@@ -154,7 +154,7 @@ test_plugin_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("", NULL, ly_data_type2str[LY_TYPE_UNION]);
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[LY_TYPE_UNION]);
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 

--- a/tests/utests/types/yang_types.c
+++ b/tests/utests/types/yang_types.c
@@ -235,7 +235,7 @@ test_sort(void **state)
     const char *schema;
     struct lys_module *mod;
     struct lyd_value val1 = {0}, val2 = {0};
-    struct lyplg_type *type = lyplg_type_plugin_find("ietf-yang-types", "2013-07-15", "date-and-time");
+    struct lyplg_type *type = lyplg_type_plugin_find(NULL, "ietf-yang-types", "2013-07-15", "date-and-time");
     struct lysc_type *lysc_type;
     struct ly_err_item *err = NULL;
 

--- a/tests/utests/utests.h
+++ b/tests/utests/utests.h
@@ -231,7 +231,7 @@ struct utest_context {
     assert_non_null(NODE); \
     assert_int_equal((NODE)->basetype, TYPE); \
     CHECK_ARRAY((NODE)->exts, EXTS); \
-    assert_ptr_equal((NODE)->plugin, lyplg_type_plugin_find("", NULL, ly_data_type2str[TYPE]))
+    assert_ptr_equal((NODE)->plugin, lyplg_type_plugin_find(NULL, "", NULL, ly_data_type2str[TYPE]))
 
 /**
  * @brief check compileted numeric type


### PR DESCRIPTION
This patch adds ability to load plugins directly from memory without need to create shared library by using lyplg_add_plugin() API.

It also allows to associate plugin directly with context, so given plugin will not affect all contexts, just given context