### PR TITLE
src/version.[ch]: Add version information API calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ set(libsrc
     src/xml.c
     src/xpath.c
     src/validation.c
+    src/version.c
     ${type_plugins})
 
 set(headers

--- a/src/version.c
+++ b/src/version.c
@@ -1,0 +1,53 @@
+/**
+ * @file version.c
+ * @author David Schweizer <dschweizer@netdef.org>
+ * @brief Libyang version API calls
+ *
+ * Copyright (c) 2024 Network Device Education Foundation (NetDEF), Inc.
+ *
+ * This source code is licensed under BSD 3-Clause License (the "License").
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://opensource.org/licenses/BSD-3-Clause
+ */
+
+#include "version.h"
+
+static struct ly_version _v_so = {
+    .major = LY_VERSION_MAJOR,
+    .minor = LY_VERSION_MINOR,
+    .micro = LY_VERSION_MICRO,
+    .str = LY_VERSION
+};
+
+static struct ly_version _v_proj = {
+    .major = LY_PROJ_VERSION_MAJOR,
+    .minor = LY_PROJ_VERSION_MINOR,
+    .micro = LY_PROJ_VERSION_MICRO,
+    .str = LY_PROJ_VERSION
+};
+
+LIBYANG_API_DEF struct ly_version
+ly_get_so_version(void)
+{
+    return _v_so;
+}
+
+LIBYANG_API_DEF const char *
+ly_get_so_version_str(void)
+{
+    return _v_so.str;
+}
+
+LIBYANG_API_DEF struct ly_version
+ly_get_project_version(void)
+{
+    return _v_proj;
+}
+
+LIBYANG_API_DEF const char *
+ly_get_project_version_str(void)
+{
+    return _v_proj.str;
+}

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -15,6 +15,14 @@
 #ifndef LY_VERSION_H_
 #define LY_VERSION_H_
 
+#include <stdint.h>
+
+#include "ly_config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define LY_VERSION_MAJOR @LIBYANG_MAJOR_SOVERSION@ /**< libyang major version number */
 #define LY_VERSION_MINOR @LIBYANG_MINOR_SOVERSION@ /**< libyang minor version number */
 #define LY_VERSION_MICRO @LIBYANG_MICRO_SOVERSION@ /**< libyang micro version number */
@@ -24,5 +32,47 @@
 #define LY_PROJ_VERSION_MINOR @LIBYANG_MINOR_VERSION@ /**< project minor version number */
 #define LY_PROJ_VERSION_MICRO @LIBYANG_MICRO_VERSION@ /**< project micro version number */
 #define LY_PROJ_VERSION "@LIBYANG_VERSION@" /**< project version string */
+
+/**
+ * @brief Structure to hold libyang version information.
+ */
+struct ly_version {
+    uint32_t major; /**< Major version number */
+    uint32_t minor; /**< Minor version number */
+    uint32_t micro; /**< Micro version number */
+    const char *str; /**< Version string */
+};
+
+/**
+ * @brief Get libyang shared object library version information struct.
+ *
+ * @return Shared object library version information struct.
+ */
+LIBYANG_API_DECL struct ly_version ly_get_so_version(void);
+
+/**
+ * @brief Get libyang shared object library version string.
+ *
+ * @return Shared object library version string.
+ */
+LIBYANG_API_DECL const char *ly_get_so_version_str(void);
+
+/**
+ * @brief Get libyang project version information struct.
+ *
+ * @return Project version information struct.
+ */
+LIBYANG_API_DECL struct ly_version ly_get_project_version(void);
+
+/**
+ * @brief Get libyang project version string.
+ *
+ * @return Project version string.
+ */
+LIBYANG_API_DECL const char *ly_get_project_version_str(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LY_VERSION_H_ */


### PR DESCRIPTION
Add shared object library and project version information API calls. This will enable downstream projects to compare the library versions of the one installed on the system (via API calls) and the one linked against (via defines in 'version.h' during build) at runtime.