### PR TITLE
src/version.h.in: Add missing include to prevent build errors.

### DIFF
--- a/src/version.h.in
+++ b/src/version.h.in
@@ -16,6 +16,8 @@
 #ifndef LY_VERSION_H_
 #define LY_VERSION_H_
 
+#include "ly_config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Add missing include of `ly_config.h` to prevent build errors as shown below when including `libyang/version.h` in downstream projects.

```bash
/usr/include/libyang/version.h:43:17: error: expected ‘;’ before ‘extern’
   43 | LIBYANG_API_DECL extern struct ly_version ly_version_so;
      |                 ^~~~~~~
      |                 ;
/usr/include/libyang/version.h:48:17: error: expected ‘;’ before ‘extern’
   48 | LIBYANG_API_DECL extern struct ly_version ly_version_proj;
      |                 ^~~~~~~
      |                 ;
```