### PR TITLE
CI: fix Mac OS build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
             cc: "clang",
             options: "-DENABLE_TESTS=ON -DPATH_EXPECT=",
             packager: "brew",
-            packages: "cmocka shunit2",
+            packages: "cmocka shunit2 tcl-tk",
             snaps: "",
             build-cmd: "make"
           }


### PR DESCRIPTION
Some of these tests use `expect`, and the native version that's available in the CI images is old/different/whatever. Let's use "the usual one" which is available through Homebrew.