### PR TITLE
Fix compilation and printing of extensions in rpc in/out

### DIFF
--- a/src/printer_yang.c
+++ b/src/printer_yang.c
@@ -1162,7 +1162,7 @@ yprp_inout(struct lys_ypr_ctx *pctx, const struct lysp_node_action_inout *inout,
     ly_print_(pctx->out, "%*s%s {\n", INDENT, inout->name);
     LEVEL++;
 
-    yprp_extension_instances(pctx, LY_STMT_MUST, 0, inout->exts, NULL);
+    yprp_extension_instances(pctx, lyplg_ext_nodetype2stmt(inout->nodetype), 0, inout->exts, NULL);
     LY_ARRAY_FOR(inout->musts, u) {
         yprp_restr(pctx, &inout->musts[u], LY_STMT_MUST, NULL);
     }

--- a/src/schema_compile_node.c
+++ b/src/schema_compile_node.c
@@ -2794,7 +2794,6 @@ lys_compile_node_action_inout(struct lysc_ctx *ctx, struct lysp_node *pnode, str
     struct lysc_node_action_inout *inout = (struct lysc_node_action_inout *)node;
 
     COMPILE_ARRAY_GOTO(ctx, inout_p->musts, inout->musts, lys_compile_must, ret, done);
-    COMPILE_EXTS_GOTO(ctx, inout_p->exts, inout->exts, inout, ret, done);
     ctx->compile_opts |= (inout_p->nodetype == LYS_INPUT) ? LYS_COMPILE_RPC_INPUT : LYS_COMPILE_RPC_OUTPUT;
 
     LY_LIST_FOR(inout_p->child, child_p) {


### PR DESCRIPTION
These 2 commits fix the compilation and the printing of extensions in rpc input and output nodes.

Fixes #2276
Fixes #2280
