### PR TITLE
tree data new BUGFIX correctly mark lyd_new_term_bin definition

### DIFF
--- a/src/tree_data_new.c
+++ b/src/tree_data_new.c
@@ -885,7 +885,7 @@ lyd_new_term(struct lyd_node *parent, const struct lys_module *module, const cha
     return _lyd_new_term(parent, module, name, value, value ? strlen(value) : 0, options, node);
 }
 
-LIBYANG_API_DECL LY_ERR
+LIBYANG_API_DEF LY_ERR
 lyd_new_term_bin(struct lyd_node *parent, const struct lys_module *module, const char *name,
         const void *value, size_t value_len, uint32_t options, struct lyd_node **node)
 {


### PR DESCRIPTION
The `lyd_new_term_bin` is declared as an API function using `LIBYANG_API_DECL`.
Its definition however also uses `LIBYANG_API_DECL`, whereas I believe it should use `LIBYANG_API_DEF` like all the other functions.

```
/** Exporting symbols to a shared library and importing back afterwards
 *
 * - use LIBYANG_API_DECL to mark a declaration in the public header
 * - use LIBYANG_API_DEF to mark a definition (in the source code for the actual implementaiton)
 * */
```
