### PR TITLE
Fixed failing of lysp_check_date when using DST configurations with savingtimes >=24h

### DIFF
--- a/src/tree_schema_common.c
+++ b/src/tree_schema_common.c
@@ -91,8 +91,8 @@ lysp_check_date(struct lysp_ctx *ctx, const char *date, size_t date_len, const c
     }
     memcpy(&tm_, &tm, sizeof tm);
 
-    /* DST may move the hour back resulting in a different day */
-    tm_.tm_hour = 1;
+    /* Disabling DST: Set tm_isdst to -1 so that mktime() won't adjust for daylight saving time. */
+    tm_.tm_isdst = -1;
 
     mktime(&tm_); /* mktime modifies tm_ if it refers invalid date */
     if (tm.tm_mday != tm_.tm_mday) { /* e.g 2018-02-29 -> 2018-03-01 */


### PR DESCRIPTION
Disabled DST by setting tm_isdst to -1 so that mktime() won't adjust for daylight saving time.
This is especially important for custom DST settings.
Without this fix `lysp_check_date() `fails due to `if (tm.tm_mday != tm_.tm_mday)`

This bug can be reproduced i.e. by creating a custom DST like this one:
```
# Rule NAME    FROM    TO      -   IN   ON      AT    SAVE    LETTER/S
Rule   Custom  2020    max     -   Oct  1       0:00  25:00       S
Rule   Custom  2020    max     -   May  1       0:00  0         -

# Zone NAME    GMT_offset  RULES/SAVE  FORMAT   [UNTIL]
Zone  Custom/TZ    1:00   Custom       C%sT
```

1) Create the `custom_timezone.txt`
2) Compile the TZ file: `zic custom_timezone.txt`
3) Copy the custom TZ to /etc/localtime: `cp /usr/share/zoneinfo/Custom/TZ /etc/localtime `
4) Change the TZ i.e. with `export TZ="Custom/TZ"`
5) See that `date` and `date -u` have different days due to the insane DST configuration.
6) Run the tests and observe all of them failing without the fix.

Also this fix is compatible with the previous issue when using TZ "Europe/Dublin".