### PR TITLE
docs: fix docstrings for enum lyd_type

### DIFF
--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -332,29 +332,29 @@ LIBYANG_API_DECL LY_ERR lyd_parse_ext_data(const struct lysc_ext_instance *ext, 
  * @{
  */
 enum lyd_type {
-    LYD_TYPE_DATA_YANG = 0,     /* generic YANG instance data */
-    LYD_TYPE_RPC_YANG,          /* instance of a YANG RPC/action request with only "input" data children,
-                                   including all parents and optional top-level "action" element in case of an action */
-    LYD_TYPE_NOTIF_YANG,        /* instance of a YANG notification, including all parents in case of a nested one */
-    LYD_TYPE_REPLY_YANG,        /* instance of a YANG RPC/action reply with only "output" data children,
-                                   including all parents in case of an action */
+    LYD_TYPE_DATA_YANG = 0,     /**< generic YANG instance data */
+    LYD_TYPE_RPC_YANG,          /**< instance of a YANG RPC/action request with only "input" data children,
+                                     including all parents and optional top-level "action" element in case of an action */
+    LYD_TYPE_NOTIF_YANG,        /**< instance of a YANG notification, including all parents in case of a nested one */
+    LYD_TYPE_REPLY_YANG,        /**< instance of a YANG RPC/action reply with only "output" data children,
+                                     including all parents in case of an action */
 
-    LYD_TYPE_RPC_NETCONF,       /* complete NETCONF RPC invocation as defined for
-                                   [RPC](https://tools.ietf.org/html/rfc7950#section-7.14.4) and
-                                   [action](https://tools.ietf.org/html/rfc7950#section-7.15.2) */
-    LYD_TYPE_NOTIF_NETCONF,     /* complete NETCONF notification message as defined for
-                                   [notification](https://tools.ietf.org/html/rfc7950#section-7.16.2) */
-    LYD_TYPE_REPLY_NETCONF,     /* complete NETCONF RPC reply as defined for
-                                   [RPC](https://tools.ietf.org/html/rfc7950#section-7.14.4) and
-                                   [action](https://tools.ietf.org/html/rfc7950#section-7.15.2) */
+    LYD_TYPE_RPC_NETCONF,       /**< complete NETCONF RPC invocation as defined for
+                                     [RPC](https://tools.ietf.org/html/rfc7950#section-7.14.4) and
+                                     [action](https://tools.ietf.org/html/rfc7950#section-7.15.2) */
+    LYD_TYPE_NOTIF_NETCONF,     /**< complete NETCONF notification message as defined for
+                                     [notification](https://tools.ietf.org/html/rfc7950#section-7.16.2) */
+    LYD_TYPE_REPLY_NETCONF,     /**< complete NETCONF RPC reply as defined for
+                                     [RPC](https://tools.ietf.org/html/rfc7950#section-7.14.4) and
+                                     [action](https://tools.ietf.org/html/rfc7950#section-7.15.2) */
 
-    LYD_TYPE_RPC_RESTCONF,      /* message-body of a RESTCONF operation input parameters
-                                   ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-3.6.1)) */
-    LYD_TYPE_NOTIF_RESTCONF,    /* RESTCONF JSON notification data
-                                   ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-6.4)), to parse
-                                   a notification in XML, use ::LYD_TYPE_NOTIF_NETCONF */
-    LYD_TYPE_REPLY_RESTCONF     /* message-body of a RESTCONF operation output parameters
-                                   ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-3.6.2)) */
+    LYD_TYPE_RPC_RESTCONF,      /**< message-body of a RESTCONF operation input parameters
+                                     ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-3.6.1)) */
+    LYD_TYPE_NOTIF_RESTCONF,    /**< RESTCONF JSON notification data
+                                     ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-6.4)), to parse
+                                     a notification in XML, use ::LYD_TYPE_NOTIF_NETCONF */
+    LYD_TYPE_REPLY_RESTCONF     /**< message-body of a RESTCONF operation output parameters
+                                     ([ref](https://www.rfc-editor.org/rfc/rfc8040.html#section-3.6.2)) */
 };
 /** @} datatype */
 


### PR DESCRIPTION
Doxygen needs a special markup to render these in the generated docs.

Fixes: e0665747c data tree FEATURE support for NETCONF messages