### PR TITLE
Fix memory leak in lyd_print_mem

### DIFF
--- a/src/printer_data.c
+++ b/src/printer_data.c
@@ -98,7 +98,7 @@ lyd_print_mem(char **strp, const struct lyd_node *root, LYD_FORMAT format, uint3
 
     LY_CHECK_RET(ly_out_new_memory(strp, 0, &out));
     ret = lyd_print_(out, root, format, options);
-    ly_out_free(out, NULL, 0);
+    ly_out_free(out, NULL, 1);
     return ret;
 }
 


### PR DESCRIPTION
The lyd_print_mem function makes a call to ly_out_new_memory which sets the output type to LY_OUT_MEMORY

Later on ly_write_ allocates memory to the out->method.mem.buf

*out->method.mem.buf = ly_realloc(*out->method.mem.buf, new_mem_size);

the ly_out_free function has a destroy set to 0 so will never free this memory. Change the destroy to 1 so the memory is cleared.