### PR TITLE
data: option to allow json int/bool as strings

### DIFF
--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -179,7 +179,10 @@ struct ly_in;
 #define LYD_PARSE_JSON_NULL 0x4000000       /**< Allow using JSON empty value 'null' within JSON input, such nodes are
                                                  silently skipped and treated as non-existent. By default, such values
                                                  are invalid. */
-
+#define LYD_PARSE_JSON_STRING_DATATYPES 0x8000000 /*!**< By default, JSON data values are validated to be in the proper format.
+                                                        For instance numbers are expected to not be enclosed in quotes, nor
+                                                        are boolean values.  Setting this option will disable this
+                                                        validation.  Prior to v1.0.212 this was the default behavior. */
 #define LYD_PARSE_OPTS_MASK 0xFFFF0000      /**< Mask for all the LYD_PARSE_ options. */
 
 /** @} dataparseroptions */

--- a/src/parser_data.h
+++ b/src/parser_data.h
@@ -179,10 +179,10 @@ struct ly_in;
 #define LYD_PARSE_JSON_NULL 0x4000000       /**< Allow using JSON empty value 'null' within JSON input, such nodes are
                                                  silently skipped and treated as non-existent. By default, such values
                                                  are invalid. */
-#define LYD_PARSE_JSON_STRING_DATATYPES 0x8000000 /*!**< By default, JSON data values are validated to be in the proper format.
-                                                        For instance numbers are expected to not be enclosed in quotes, nor
-                                                        are boolean values.  Setting this option will disable this
-                                                        validation.  Prior to v1.0.212 this was the default behavior. */
+#define LYD_PARSE_JSON_STRING_DATATYPES 0x8000000 /**< By default, JSON data values are expected to be in the correct
+                                                       format according to RFC 7951 based on their type. Using this
+                                                       option the validation can be softened to accept boolean and
+                                                       number type values enclosed in quotes. */
 #define LYD_PARSE_OPTS_MASK 0xFFFF0000      /**< Mask for all the LYD_PARSE_ options. */
 
 /** @} dataparseroptions */

--- a/src/parser_json.c
+++ b/src/parser_json.c
@@ -351,6 +351,7 @@ static LY_ERR
 lydjson_value_type_hint(struct lyd_json_ctx *lydctx, enum LYJSON_PARSER_STATUS *status_p, uint32_t *type_hint_p)
 {
     struct lyjson_ctx *jsonctx = lydctx->jsonctx;
+
     *type_hint_p = 0;
 
     if (*status_p == LYJSON_ARRAY) {

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -686,7 +686,7 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
         LY_CHECK_ARG_RET(NULL, base, LY_EINVAL);
 
         if (!(hints & (LYD_VALHINT_DECNUM | LYD_VALHINT_OCTNUM | LYD_VALHINT_HEXNUM)) &&
-            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
+                !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-number-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -697,7 +697,7 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
         LY_CHECK_ARG_RET(NULL, base, LY_EINVAL);
 
         if (!(hints & LYD_VALHINT_NUM64) &&
-            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
+                !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-num64-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }
@@ -717,7 +717,7 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
         break;
     case LY_TYPE_BOOL:
         if (!(hints & LYD_VALHINT_BOOLEAN) &&
-            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
+                !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-boolean-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }

--- a/src/plugins_types.c
+++ b/src/plugins_types.c
@@ -685,7 +685,8 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
     case LY_TYPE_INT32:
         LY_CHECK_ARG_RET(NULL, base, LY_EINVAL);
 
-        if (!(hints & (LYD_VALHINT_DECNUM | LYD_VALHINT_OCTNUM | LYD_VALHINT_HEXNUM))) {
+        if (!(hints & (LYD_VALHINT_DECNUM | LYD_VALHINT_OCTNUM | LYD_VALHINT_HEXNUM)) &&
+            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-number-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }
@@ -695,7 +696,8 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
     case LY_TYPE_INT64:
         LY_CHECK_ARG_RET(NULL, base, LY_EINVAL);
 
-        if (!(hints & LYD_VALHINT_NUM64)) {
+        if (!(hints & LYD_VALHINT_NUM64) &&
+            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-num64-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }
@@ -714,7 +716,8 @@ lyplg_type_check_hints(uint32_t hints, const char *value, size_t value_len, LY_D
         }
         break;
     case LY_TYPE_BOOL:
-        if (!(hints & LYD_VALHINT_BOOLEAN)) {
+        if (!(hints & LYD_VALHINT_BOOLEAN) &&
+            !(hints & LYD_VALHINT_STRING_DATATYPES)) {
             return ly_err_new(err, LY_EVALID, LYVE_DATA, NULL, NULL, "Invalid non-boolean-encoded %s value \"%.*s\".",
                     lys_datatype2str(type), (int)value_len, value);
         }

--- a/src/tree_data.h
+++ b/src/tree_data.h
@@ -944,6 +944,7 @@ struct lyd_node_any {
 #define LYD_VALHINT_NUM64      0x0010 /**< value is allowed to be an int64 or uint64 */
 #define LYD_VALHINT_BOOLEAN    0x0020 /**< value is allowed to be a boolean */
 #define LYD_VALHINT_EMPTY      0x0040 /**< value is allowed to be empty */
+#define LYD_VALHINT_STRING_DATATYPES 0x0080 /**< boolean and numeric fields are allowed to be quoted */
 /**
  * @} lydvalhints
  */

--- a/tests/utests/data/test_parser_json.c
+++ b/tests/utests/data/test_parser_json.c
@@ -168,6 +168,21 @@ test_leaf(void **state)
     PARSER_CHECK_ERROR(data, 0, LYD_VALIDATE_PRESENT, tree, LY_EVALID, "Invalid non-string-encoded string value \"\".", "/a:foo", 1);
     CHECK_PARSE_LYD(data, LYD_PARSE_JSON_NULL, LYD_VALIDATE_PRESENT, tree);
     assert_null(tree);
+
+    /* validate integer in quotes errors out by default */
+    data = "{\"a:foo3\":\"1234\"}";
+    PARSER_CHECK_ERROR(data, LYD_PARSE_STRICT, LYD_VALIDATE_PRESENT, tree, LY_EVALID,
+            "Invalid non-number-encoded uint32 value \"1234\".", "/a:foo3", 1);
+
+    /* validate integers are parsed correctly */
+    data = "{\"a:foo3\":1234}";
+    CHECK_PARSE_LYD(data, 0, LYD_VALIDATE_PRESENT, tree);
+    lyd_free_all(tree);
+
+    /* validate LYD_PARSE_JSON_STRING_DATATYPES parser flag allows integers in quotes */
+    data = "{\"a:foo3\":\"1234\"}";
+    CHECK_PARSE_LYD(data, LYD_PARSE_JSON_STRING_DATATYPES, LYD_VALIDATE_PRESENT, tree);
+    lyd_free_all(tree);
 }
 
 static void


### PR DESCRIPTION
Prior to v1.0.212 the default behavior was to allow numbers
and boolean values to be in quotes, which is technically a
violation of the spec.

This adds a new `LYD_PARSE_JSON_STRING_DATATYPES` parse option
which will restore the prior behavior when enabled.

SONiC is using v1.0.73 currently and has a large installed base which
may be in violation of the new behavior, so adding such a flag is
required for this usecase.

Signed-off-by: Brad House (@bradh352)