### PR TITLE
use strnlen instead of strlen to check valid time

### DIFF
--- a/src/tree_data_common.c
+++ b/src/tree_data_common.c
@@ -1670,7 +1670,7 @@ ly_time_str2time(const char *value, time_t *time, char **fractions_s)
     int64_t shift, shift_m;
     time_t t;
 
-    LY_CHECK_ARG_RET(NULL, value, strlen(value) > 17, time, LY_EINVAL);
+    LY_CHECK_ARG_RET(NULL, value, strnlen(value, 18) > 17, time, LY_EINVAL);
 
     tm.tm_year = atoi(&value[0]) - 1900;
     tm.tm_mon = atoi(&value[5]) - 1;


### PR DESCRIPTION
Using strlen() on large strings (large imported data) is extremely inefficient. The ly_time_str2time() only needs to check that the string is at least as long as a valid time value.

However, the full value string can be very long (even > 10MB), and evaluating strlen() for every time value results in poor performance.