### PR TITLE
validate: unions with leafrefs may return misleading error codes

### DIFF
--- a/src/plugins_types/union.c
+++ b/src/plugins_types/union.c
@@ -153,6 +153,8 @@ lyb_parse_union(const void *lyb_data, size_t lyb_data_len, uint32_t *type_idx, c
 /**
  * @brief For leafref failures, ensure the appropriate error is propagated, not a type validation failure.
  *
+ * RFC7950 Section 15.5 defines the appropriate error app tag of "require-instance".
+ *
  * @param[in,out] err Error record to be updated
  * @param[in] type leafref type used to extract target path
  * @param[in] value value attempting to be stored

--- a/src/plugins_types/union.c
+++ b/src/plugins_types/union.c
@@ -150,17 +150,26 @@ lyb_parse_union(const void *lyb_data, size_t lyb_data_len, uint32_t *type_idx, c
     }
 }
 
+/**
+ * @brief For leafref failures, ensure the appropriate error is propagated, not a type validation failure.
+ *
+ * @param[in] ctx_node Context node for prefix resolution.
+ * @param[in,out] err Error record to be updated
+ * @param[in] type leafref type used to extract target path
+ * @param[in] value value attempting to be stored
+ * @param[in] value_len Length of value that was attempted to be stored.
+ */
 static void
-union_lref_error_rewrite(const struct lyd_node *ctx_node, struct ly_err_item *err, struct lysc_type *type, const void *value, size_t value_len)
+union_update_lref_err(const struct lyd_node *ctx_node, struct ly_err_item *err, const struct lysc_type *type, const void *value, size_t value_len)
 {
-    struct lysc_type_leafref *lref;
+    const struct lysc_type_leafref *lref;
     char *valstr = NULL;
 
     if ((err == NULL) || (type->basetype != LY_TYPE_LEAFREF)) {
         return;
     }
 
-    lref = (struct lysc_type_leafref *)type;
+    lref = (const struct lysc_type_leafref *)type;
     free(err->apptag);
     err->apptag = strdup("instance-required");
 
@@ -217,7 +226,7 @@ union_store_type(const struct ly_ctx *ctx, struct lysc_type_union *type_u, uint3
                 memset(&subvalue->value, 0, sizeof subvalue->value);
 
                 /* if this is a leafref, lets make sure we propagate the appropriate error, and not a type validation failure */
-                union_lref_error_rewrite(ctx_node, *err, type_u->types[ti], value, value_len);
+                union_update_lref_err(ctx_node, *err, type_u->types[ti], value, value_len);
                 return rc;
             }
 
@@ -258,9 +267,7 @@ union_store_type(const struct ly_ctx *ctx, struct lysc_type_union *type_u, uint3
         memset(&subvalue->value, 0, sizeof subvalue->value);
 
         /* if this is a leafref, lets make sure we propagate the appropriate error, and not a type validation failure */
-        if (type->basetype == LY_TYPE_LEAFREF) {
-            union_lref_error_rewrite(ctx_node, *err, type, value, value_len);
-        }
+        union_update_lref_err(ctx_node, *err, type, value, value_len);
         return rc;
     }
 

--- a/tests/utests/types/union.c
+++ b/tests/utests/types/union.c
@@ -105,8 +105,8 @@ test_data_xml(void **state)
     TEST_ERROR_XML2("",
             "defs", "", "un1", "123456789012345678901", LY_EVALID);
     CHECK_LOG_CTX("Invalid union value \"123456789012345678901\" - no matching subtype found:\n"
-            "    libyang 2 - leafref, version 1: Invalid type int8 value \"123456789012345678901\".\n"
-            "    libyang 2 - leafref, version 1: Invalid type int64 value \"123456789012345678901\".\n"
+            "    libyang 2 - leafref, version 1: Invalid leafref value \"123456789012345678901\" - no target instance \"/int8\" with the same value.\n"
+            "    libyang 2 - leafref, version 1: Invalid leafref value \"123456789012345678901\" - no target instance \"/int64\" with the same value.\n"
             "    libyang 2 - identityref, version 1: Invalid identityref \"123456789012345678901\" value - identity not found in module \"defs\".\n"
             "    libyang 2 - instance-identifier, version 1: Invalid instance-identifier \"123456789012345678901\" value - syntax error.\n"
             "    libyang 2 - string, version 1: Unsatisfied length - string \"123456789012345678901\" length is not allowed.\n",
@@ -295,7 +295,8 @@ test_validation(void **state)
     assert_int_equal(LY_EVALID, lyd_validate_all(&tree, NULL, LYD_VALIDATE_PRESENT, NULL));
     CHECK_LOG_CTX("Invalid LYB union value - no matching subtype found:\n"
             "    libyang 2 - leafref, version 1: Invalid leafref value \"one\" - no target instance \"../../a/name\" with the same value.\n"
-            "    libyang 2 - leafref, version 1: Invalid type uint32 value \"one\".\n", "/lref:test/community[name='test']/view", 0);
+            "    libyang 2 - leafref, version 1: Invalid leafref value \"one\" - no target instance \"../../b/name\" with the same value.\n",
+            "/lref:test/community[name='test']/view", 0);
 
     lyd_free_all(tree);
 }


### PR DESCRIPTION
When a leafref is not found in a union, it should not return an error indicating the value for the leafref wouldn't match the restrictions for a target but instead just say the leafref target wasn't found.

The only data that should indicate the error message for data type restrictions is data associated with the target itself, not leafrefs.

Fixes #2359