### PR TITLE
avoid repeated tzset() calls

### DIFF
--- a/src/tree_data_common.c
+++ b/src/tree_data_common.c
@@ -1620,6 +1620,21 @@ ly_time_tz_offset(void)
     return ly_time_tz_offset_at(time(NULL));
 }
 
+/**
+ * @brief Call tzset() if not already called by this process.
+ */
+static void
+ly_tzset_once(void)
+{
+    static int ly_tzset_called = 0;
+
+    if (ly_tzset_called) {
+        return;
+    }
+    tzset();
+    ly_tzset_called = 1;
+}
+
 LIBYANG_API_DEF int
 ly_time_tz_offset_at(time_t time)
 {
@@ -1627,7 +1642,7 @@ ly_time_tz_offset_at(time_t time)
     int result = 0;
 
     /* init timezone */
-    tzset();
+    ly_tzset_once();
 
     /* get local and UTC time */
     localtime_r(&time, &tm_local);
@@ -1777,7 +1792,7 @@ ly_time_time2str(time_t time, const char *fractions_s, char **str)
     LY_CHECK_ARG_RET(NULL, str, LY_EINVAL);
 
     /* init timezone */
-    tzset();
+    ly_tzset_once();
 
     /* convert */
     if (!localtime_r(&time, &tm)) {


### PR DESCRIPTION
The  `tzset()` function  initializes  the tzname variable from the
TZ environment variable.

There doesn't seem to be any valid usecase of calling this repeatedly.
It is an overhead that can be avoided.