### PR TITLE
utests - call tzset after setenv TZ

### DIFF
--- a/src/tree_data_common.c
+++ b/src/tree_data_common.c
@@ -1620,29 +1620,11 @@ ly_time_tz_offset(void)
     return ly_time_tz_offset_at(time(NULL));
 }
 
-/**
- * @brief Call tzset() if not already called by this process.
- */
-static void
-ly_tzset_once(void)
-{
-    static int ly_tzset_called = 0;
-
-    if (ly_tzset_called) {
-        return;
-    }
-    tzset();
-    ly_tzset_called = 1;
-}
-
 LIBYANG_API_DEF int
 ly_time_tz_offset_at(time_t time)
 {
     struct tm tm_local, tm_utc;
     int result = 0;
-
-    /* init timezone */
-    ly_tzset_once();
 
     /* get local and UTC time */
     localtime_r(&time, &tm_local);
@@ -1790,9 +1772,6 @@ ly_time_time2str(time_t time, const char *fractions_s, char **str)
     int zonediff_s, zonediff_h, zonediff_m;
 
     LY_CHECK_ARG_RET(NULL, str, LY_EINVAL);
-
-    /* init timezone */
-    ly_tzset_once();
 
     /* convert */
     if (!localtime_r(&time, &tm)) {

--- a/tests/utests/utests.h
+++ b/tests/utests/utests.h
@@ -1326,6 +1326,8 @@ utest_setup(void **state)
 
     /* set CET */
     setenv("TZ", "CET+02:00", 1);
+    /* call tzset explicitly, to update the tzname, timezone and daylight global variables */
+    tzset();
 
     return 0;
 }


### PR DESCRIPTION
unit-tests can fail if run in an env where TZ is already set. This is because utest.h setup calls setenv("TZ"), but does not call tzset() immediately after that.

This causes tzname, timezone, and daylight global variables to by out of sync from the newly set environment value of "TZ".

To fix this, explicitly call tzset().

It's unlikely that a program would call setenv("TZ") during it's lifetime, and this should ideally only happen in a test env.