### PR TITLE
ly_path_parse OPTIMIZE fail faster on invalid path

### DIFF
--- a/src/path.c
+++ b/src/path.c
@@ -343,6 +343,13 @@ ly_path_parse(const struct ly_ctx *ctx, const struct lysc_node *ctx_node, const 
         path_len = strlen(str_path);
     }
 
+    /* check if path begins with '/' if expected to and fail early if not */
+    if ((begin == LY_PATH_BEGIN_ABSOLUTE) && (str_path[0] != '/')) {
+        LOGVAL(ctx, LYVE_XPATH, "XPath \"%.*s\" was expected to be absolute.", (int)path_len, str_path);
+        ret = LY_EVALID;
+        goto error;
+    }
+
     /* parse as a generic XPath expression, reparse is performed manually */
     LY_CHECK_GOTO(ret = lyxp_expr_parse(ctx, str_path, path_len, 0, &exp), error);
     tok_idx = 0;

--- a/tests/utests/types/instanceid.c
+++ b/tests/utests/types/instanceid.c
@@ -200,7 +200,7 @@ test_data_xml(void **state)
 
     TEST_ERROR_XML2("<cont xmlns=\"urn:tests:mod\"/>",
             "defs", "xmlns:m=\"urn:tests:mod\"", "l1", "[1]", LY_EVALID);
-    CHECK_LOG_CTX("Invalid instance-identifier \"[1]\" value - syntax error: Unexpected XPath token \"[\" (\"[1]\"), expected \"Operator(Path)\".",
+    CHECK_LOG_CTX("Invalid instance-identifier \"[1]\" value - syntax error: XPath \"[1]\" was expected to be absolute.",
             "/defs:l1", 1);
 
     TEST_ERROR_XML2("<cont xmlns=\"urn:tests:mod\"><l2/></cont>",


### PR DESCRIPTION
`ly_path_parse()` is called from various functions like `lyplg_type_store_node_instanceid()` and `lyplg_type_lypath_new()` with the `LY_PATH_BEGIN_ABSOLUTE` flag set.

This means that the path is expected to start with a '/' character. If it doesn't, this could mean that the value is not a valid path.

This can happen while finding a union type, where it is not optimal to call `lyxp_expr_parse()`, which is much heavier to compute.