### PR TITLE
context UPDATE add ietf-yang-library-augmentedby support

### DIFF
--- a/models/ietf-yang-library-augmentedby@2023-10-27.yang
+++ b/models/ietf-yang-library-augmentedby@2023-10-27.yang
@@ -1,0 +1,86 @@
+module ietf-yang-library-augmentedby {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-library-augmentedby";
+  prefix yanglib-aug;
+
+  import ietf-yang-library {
+    prefix yanglib;
+    reference
+      "RFC 8525: YANG Library";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Zhuoyao Lin
+               <mailto:zhuoyao.lin1@huawei-parteners.com>
+               Benoit Claise
+               <mailto:benoit.claise@huawei.com>
+               IGNACIO DOMINGUEZ MARTINEZ-CASANUEVA
+               <matilto:ignacio.dominguezmartinez@telefonica.com>";
+
+  description
+    "This module augments the ietf-yang-library defined in
+     [RFC8525] to provide not only the deviation list, but also
+     the augmented-by list, in order to give sufficient
+     information about the YANG modules reverse dependency. It
+     facilitates the process of obtaining the entire
+     dependencies of YANG module.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all
+     capitals, as shown here.
+
+     Copyright (c) 2022 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Revised BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+     This version of this YANG module is part of RFC XXXX; see the
+     RFC itself for full legal notices.  ";
+
+  revision 2023-10-27 {
+    description
+      "Added list augmented-by in yang-library/module-set/module to
+       make the module store the entire reverse dependency information
+       (augmented-by and deviation).";
+    reference
+      "RFC XXXX: Support of augmentedby in ietf-yang-library";
+  }
+
+  augment "/yanglib:yang-library/yanglib:module-set/yanglib:module" {
+    description
+      "Augment the augmented-by list from module info with the
+       module-augmented-by grouping" ;
+
+    leaf-list augmented-by {
+      type leafref {
+        path "../../yanglib:module/yanglib:name";
+      }
+
+      description
+        "Leaf-list of the augmentation used by this server to
+         modify the conformance of the module associated with
+         this entry.  Note that the same module can be used for
+         augmented-by for multiple modules, so the same
+         entry MAY appear within multiple 'module' entries.
+
+         This reference MUST NOT (directly or indirectly)
+         refer to the module being augmented.
+
+         Robust clients may want to make sure that they handle a
+         situation where a module augments itself (directly or
+         indirectly) gracefully.";
+    }
+  }
+}

--- a/src/context.c
+++ b/src/context.c
@@ -1159,6 +1159,26 @@ ylib_deviation(struct lyd_node *parent, const struct lys_module *cur_mod, ly_boo
 }
 
 static LY_ERR
+ylib_augmentedby(struct lyd_node *parent, const struct lys_module *cur_mod)
+{
+    struct lys_module *mod, *ylab_mod;
+    LY_ARRAY_COUNT_TYPE i;
+
+    ylab_mod = ly_ctx_get_module_implemented(LYD_CTX(parent), "ietf-yang-library-augmentedby");
+
+    if (!cur_mod->implemented || !ylab_mod) {
+        return LY_SUCCESS;
+    }
+
+    LY_ARRAY_FOR(cur_mod->augmented_by, i) {
+        mod = cur_mod->augmented_by[i];
+        LY_CHECK_RET(lyd_new_term(parent, ylab_mod, "augmented-by", mod->name, 0, NULL));
+    }
+
+    return LY_SUCCESS;
+}
+
+static LY_ERR
 ylib_submodules(struct lyd_node *parent, const struct lysp_module *pmod, ly_bool bis)
 {
     LY_ERR ret;
@@ -1303,6 +1323,9 @@ ly_ctx_get_yanglib_data(const struct ly_ctx *ctx, struct lyd_node **root_p, cons
 
             /* deviation */
             LY_CHECK_GOTO(ret = ylib_deviation(cont, mod, 1), error);
+
+            /* augmentation list */
+            LY_CHECK_GOTO(ret = ylib_augmentedby(cont, mod), error);
         }
     }
 


### PR DESCRIPTION
Add the list of modules that augment a particular yang module. The modules and their augmentations are visible under the "/ietf-yang-library:yang-library xpath".

Link: https://datatracker.ietf.org/doc/html/draft-ietf-netconf-yang-library-augmentedby