### PR TITLE
CI: pin CMake to 3.x on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,11 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1
 
+      - name: pin CMake to the latest 3.x series
+        uses: jwlawson/actions-setup-cmake@09fd9b0fb3b239b4b68d9256cd65adf8d6b91da0
+        with:
+          cmake-version: '3.31.6'
+
       - name: Install Windows dependencies
         run: vcpkg install --triplet=${{ matrix.triplet }} pcre2 pthreads dirent dlfcn-win32 cmocka getopt xxhash
 


### PR DESCRIPTION
An update in GitHub action runners upgraded CMake to 4.0.0, which is backwards-incompatible. The first breakage in the dependency stack happens in dlfcn-win32 which explicitly sets the minimal required CMake version to 3.5, and that one got deprecated in CMake 4, apparently.

Let's just chicken out and revert stuff rather than trying to fix an unknown number of 3rd-party packages.

Bug: https://github.com/actions/runner-images/issues/11926