### PR TITLE
ly_out add API for ly_out_printed_total

### DIFF
--- a/src/out.c
+++ b/src/out.c
@@ -681,6 +681,12 @@ ly_out_printed(const struct ly_out *out)
     return out->func_printed;
 }
 
+LIBYANG_API_DEF size_t
+ly_out_printed_total(const struct ly_out *out)
+{
+    return out->printed;
+}
+
 LY_ERR
 ly_write_skip(struct ly_out *out, size_t count, size_t *position)
 {

--- a/src/out.h
+++ b/src/out.h
@@ -63,6 +63,7 @@ extern "C" {
  *
  * - ::ly_out_type()
  * - ::ly_out_printed()
+ * - ::ly_out_printed_total()
  *
  * - ::ly_out_reset()
  * - ::ly_out_free()
@@ -290,6 +291,14 @@ LIBYANG_API_DECL LY_ERR ly_write(struct ly_out *out, const char *buf, size_t len
  * @return Number of printed bytes.
  */
 LIBYANG_API_DECL size_t ly_out_printed(const struct ly_out *out);
+
+/**
+ * @brief Get the total number of printed bytes of this out structure.
+ *
+ * @param[in] out Out structure used.
+ * @return Number of printed bytes.
+ */
+LIBYANG_API_DECL size_t ly_out_printed_total(const struct ly_out *out);
 
 /**
  * @brief Free the printer handler.


### PR DESCRIPTION
`ly_out_printed()` only gives the bytes printed in the last writer function call.
There are use cases where we need to know total number of bytes written as well.

So, expose this with `ly_out_printed_total()` API