### PR TITLE
tree schema FEATURE emit paths suitable for key search

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -695,7 +695,7 @@ lysc_path_until(const struct lysc_node *node, const struct lysc_node *parent, LY
         buffer[0] = '\0';
     }
 
-    if ((pathtype == LYSC_PATH_DATA) || (pathtype == LYSC_PATH_DATA_PATTERN)) {
+    if ((pathtype == LYSC_PATH_DATA) || (pathtype == LYSC_PATH_DATA_PATTERN) || (pathtype == LYSC_PATH_KEY_PATTERN)) {
         /* skip schema-only nodes */
         skip_schema = 1;
     } else {
@@ -711,11 +711,11 @@ lysc_path_until(const struct lysc_node *node, const struct lysc_node *parent, LY
             continue;
         }
 
-        if ((pathtype == LYSC_PATH_DATA_PATTERN) && (iter->nodetype == LYS_LIST)) {
+        if (((pathtype == LYSC_PATH_DATA_PATTERN) || (pathtype == LYSC_PATH_KEY_PATTERN)) && (iter->nodetype == LYS_LIST)) {
             char *predicates = NULL;
 
             key = NULL;
-            while ((key = lys_getnext(key, iter, NULL, 0)) && lysc_is_key(key)) {
+            while ((key = lys_getnext(key, iter, NULL, 0)) && lysc_is_key(key) && ((pathtype != LYSC_PATH_KEY_PATTERN) || (key != node))) {
                 s = predicates;
 
                 /* print key predicate */

--- a/src/tree_schema.h
+++ b/src/tree_schema.h
@@ -2114,8 +2114,10 @@ LIBYANG_API_DECL const struct lysc_node *lys_find_path(const struct ly_ctx *ctx,
 typedef enum {
     LYSC_PATH_LOG,  /**< Descriptive path format used in log messages */
     LYSC_PATH_DATA, /**< Similar to ::LYSC_PATH_LOG except that schema-only nodes (choice, case) are skipped */
-    LYSC_PATH_DATA_PATTERN  /**< Similar to ::LYSC_PATH_DATA but there are predicates for all list keys added with
-                                 "%s" where their values should be so that they can be printed there */
+    LYSC_PATH_DATA_PATTERN, /**< Similar to ::LYSC_PATH_DATA but there are predicates for all list keys added with
+                                  "%s" where their values should be so that they can be printed there */
+    LYSC_PATH_KEY_PATTERN   /**< Similar to ::LYSC_PATH_DATA_PATTERN but if target node is a list key predicates
+                                for this and subsequent keys are not emitted */
 } LYSC_PATH_TYPE;
 
 /**

--- a/tests/utests/schema/test_schema.c
+++ b/tests/utests/schema/test_schema.c
@@ -1896,6 +1896,14 @@ test_lysc_path(void **state)
     path = lysc_path(node, LYSC_PATH_DATA_PATTERN, NULL, 0);
     assert_string_equal(path, "/b:a/l[k='%s'][l='%s'][m='%s']/n");
     free(path);
+    /* node is the same as in previous test */
+    path = lysc_path(node, LYSC_PATH_KEY_PATTERN, NULL, 0);
+    assert_string_equal(path, "/b:a/l[k='%s'][l='%s'][m='%s']/n");
+    free(path);
+    node = lys_find_path(UTEST_LYCTS, NULL, "/b:a/l/l", 0);
+    path = lysc_path(node, LYSC_PATH_KEY_PATTERN, NULL, 0);
+    assert_string_equal(path, "/b:a/l[k='%s']/l");
+    free(path);
 }
 
 /* TEST */


### PR DESCRIPTION
Motivation: consider the structure with list hierarchy:
```
container earth {
  list country {
    key name;
    leaf name {....};
    list city {
      key name;
......
```
and you want to find cities in some country. Path built with LYSC_PATH_DATA_PATTERN (```/earth/country[name='%s']/city[name='%s']/name```) can't be used for this task because it contains predicate for city (so you must know it in advance), and path built with LYSC_PATH_DATA (```/earth/country/city/name```) will find cities in the entrie earth, not limited by country.
New LYSC_PATH_KEY_PATTERN will emit ```/earth/country[name='%s']/city/name``` here making the task doable.