### PR TITLE
yanglint BUGFIX restore terminal after tests

### DIFF
--- a/tests/yanglint/interactive/all.tcl
+++ b/tests/yanglint/interactive/all.tcl
@@ -1,4 +1,11 @@
 package require tcltest
+package require Expect
+
+# Save current terminal size
+set stty_output [exec stty size]
+scan $stty_output "%d %d" orig_lines orig_columns
+# setting some large terminal width
+stty columns 720
 
 # Hook to determine if any of the tests failed.
 # Sets a global variable exitCode to 1 if any test fails otherwise it is set to 0.
@@ -11,5 +18,10 @@ if {[info exists ::env(TESTS_DIR)]} {
     tcltest::configure -testdir "$env(TESTS_DIR)/interactive"
 }
 
+# run all interactive tests
 tcltest::runAllTests
+
+# Restore original terminal size
+exec stty rows $orig_lines cols $orig_columns
+
 exit $exitCode

--- a/tests/yanglint/interactive/ly.tcl
+++ b/tests/yanglint/interactive/ly.tcl
@@ -13,8 +13,6 @@ set timeout 5
 set prompt "> "
 # turn off dialog between expect and yanglint
 log_user 0
-# setting some large terminal width
-stty columns 720
 
 # default setup for every unit test
 variable ly_setup {


### PR DESCRIPTION
The problem is with the 'stty columns' command, which is set to a high number in the tests to be sure to correctly capture long strings. But this command persist even after the tests, so e.g. the 'vim' program will display incorrectly.