### PR TITLE
context UPDATE add option to force obsolete nodes compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,8 @@ set(PLUGINS_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libyang" CACHE 
 set(PLUGINS_DIR_EXTENSIONS "${PLUGINS_DIR}/extensions" CACHE STRING "Directory with libyang user extensions plugins")
 set(PLUGINS_DIR_TYPES "${PLUGINS_DIR}/types" CACHE STRING "Directory with libyang user types plugins")
 
+set(FORCE_LY_CTX_COMPILE_OBSOLETE 0 CACHE STRING "Compile obsolete nodes in libyang context by default")
+
 #
 # checks
 #

--- a/src/context.c
+++ b/src/context.c
@@ -300,6 +300,11 @@ ly_ctx_new(const char *search_dir, uint32_t options, struct ly_ctx **new_ctx)
     static_plugins_only = (options & LY_CTX_STATIC_PLUGINS_ONLY) ? 1 : 0;
     LY_CHECK_GOTO(rc = lyplg_init(builtin_plugins_only, static_plugins_only), cleanup);
 
+    /* obsolete nodes */
+    if (FORCE_LY_CTX_COMPILE_OBSOLETE) {
+        options |= LY_CTX_COMPILE_OBSOLETE;
+    }
+
     /* options */
     ctx->opts = options;
 

--- a/src/ly_config.h.in
+++ b/src/ly_config.h.in
@@ -31,6 +31,9 @@
 /** size of fixed_mem in lyd_value, minimum is 8 (B) */
 #define LYD_VALUE_FIXED_MEM_SIZE @LYD_VALUE_SIZE@
 
+/* compile obsolete nodes */
+#define FORCE_LY_CTX_COMPILE_OBSOLETE @FORCE_LY_CTX_COMPILE_OBSOLETE@
+
 /** plugins */
 #define LYPLG_SUFFIX "@CMAKE_SHARED_MODULE_SUFFIX@"
 #define LYPLG_SUFFIX_LEN (sizeof LYPLG_SUFFIX - 1)


### PR DESCRIPTION
Since version 4 of libyang, obsolete nodes are not compiled by default. To compile them, the LY_CTX_COMPILE_OBSOLETE option must be passed to ly_ctx_new.
To avoid having to add this option to all existing ly_ctx_new calls, add the FORCE_LY_CTX_COMPILE_OBSOLETE build option to compile the obsolete nodes by default.