### PR TITLE
`lysp_ext_instance_path_append`: prevent undefined behavior

### DIFF
--- a/src/tree_schema.c
+++ b/src/tree_schema.c
@@ -1526,7 +1526,7 @@ lysp_ext_instance_path_append(char **buf, uint32_t *size, const char *format, ..
 
     /* learn the required length */
     va_start(ap, format);
-    len = vsnprintf(*buf + *size, 0, format, ap);
+    len = vsnprintf(*buf ? *buf + *size : NULL, 0, format, ap);
     va_end(ap);
 
     /* realloc */


### PR DESCRIPTION
As ASAN's UBSAN correctly reports (runtime error: applying zero offset to null pointer), a null pointer cannot be added to or subtracted from.