### PR TITLE
Unicode block bug

### DIFF
--- a/src/ly_common.c
+++ b/src/ly_common.c
@@ -4,7 +4,6 @@
  * @brief common internal definitions for libyang
  *
  * Copyright (c) 2018 - 2026 CESNET, z.s.p.o.
- * Copyright (c) 2026 Nokia
  *
  * This source code is licensed under BSD 3-Clause License (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/ly_common.c
+++ b/src/ly_common.c
@@ -4,6 +4,7 @@
  * @brief common internal definitions for libyang
  *
  * Copyright (c) 2018 - 2026 CESNET, z.s.p.o.
+ * Copyright (c) 2026 Nokia
  *
  * This source code is licensed under BSD 3-Clause License (the "License").
  * You may not use this file except in compliance with the License.
@@ -813,7 +814,7 @@ ly_pat_compile_xmlschema_chblocks_xmlschema2perl(const char *pattern, char **reg
         {NULL, NULL}
     };
 
-    size_t idx, idx2, start, end;
+    size_t idx, idx2, start, end, ublock;
     char *perl_regex, *ptr;
 
     perl_regex = *regex;
@@ -849,6 +850,7 @@ ly_pat_compile_xmlschema_chblocks_xmlschema2perl(const char *pattern, char **reg
             return ly_err_new(err, LY_EVALID, 0, NULL, NULL, "Regular expression \"%s\" is not valid (\"%s\": %s).",
                     pattern, perl_regex + start + 5, "unknown block name");
         }
+        ublock = idx;
 
         /* make the space in the string and replace the block (but we cannot include brackets if it was already enclosed in them) */
         for (idx2 = 0, idx = 0; idx2 < start; ++idx2) {
@@ -863,10 +865,10 @@ ly_pat_compile_xmlschema_chblocks_xmlschema2perl(const char *pattern, char **reg
         if (idx) {
             /* skip brackets */
             memmove(perl_regex + start + (URANGE_LEN - 2), perl_regex + end, strlen(perl_regex + end) + 1);
-            memcpy(perl_regex + start, ublock2urange[idx][1] + 1, URANGE_LEN - 2);
+            memcpy(perl_regex + start, ublock2urange[ublock][1] + 1, URANGE_LEN - 2);
         } else {
             memmove(perl_regex + start + URANGE_LEN, perl_regex + end, strlen(perl_regex + end) + 1);
-            memcpy(perl_regex + start, ublock2urange[idx][1], URANGE_LEN);
+            memcpy(perl_regex + start, ublock2urange[ublock][1], URANGE_LEN);
         }
     }
 

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -845,8 +845,8 @@ test_data_xml(void **state)
 
     /* Unicode block test 6 - Basic Latin, Latin-1 Supplement, and Latin Extended-A */
     schema = MODULE_CREATE_YANG("T_UB_6", "leaf port {type string {"
-            "       pattern '[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}\\p{IsLatinExtended-A}]+';"
-            "}} ");
+                        "       pattern '[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}\\p{IsLatinExtended-A}]+';"
+                        "}} ");
     UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
     TEST_SUCCESS_XML("T_UB_6", "Árvíztűrő tükörfúrógép!", STRING, "Árvíztűrő tükörfúrógép!");
 
@@ -854,15 +854,15 @@ test_data_xml(void **state)
     schema = MODULE_CREATE_YANG("T_UB_7", "leaf port {type string { pattern '\\p{IsUnknownUnicodeBlock}+';} } ");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
     CHECK_LOG_CTX("Regular expression \"\\p{IsUnknownUnicodeBlock}+\" "
-                  "is not valid (\"UnknownUnicodeBlock}+\": unknown block name).", "/T_UB_7:port", 0);
+                        "is not valid (\"UnknownUnicodeBlock}+\": unknown block name).", "/T_UB_7:port", 0);
 
     /* Unicode block test 8 - Unknown Unicode block with Basic Latin */
     schema = MODULE_CREATE_YANG("T_UB_8", "leaf port {type string { "
-            "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
-            "}} ");
+i                       "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
+                        "}} ");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
     CHECK_LOG_CTX("Regular expression \"[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+\" "
-                  "is not valid (\"UnknownUnicodeBlock}]+\": unknown block name).", "/T_UB_8:port", 0);
+                        "is not valid (\"UnknownUnicodeBlock}]+\": unknown block name).", "/T_UB_8:port", 0);
 }
 
 static void

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -4,7 +4,6 @@
  * @brief test for string values
  *
  * Copyright (c) 2021 CESNET, z.s.p.o.
- * Copyright (c) 2026 Nokia
  *
  * This source code is licensed under BSD 3-Clause License (the "License").
  * You may not use this file except in compliance with the License.

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -858,7 +858,7 @@ test_data_xml(void **state)
 
     /* Unicode block test 8 - Unknown Unicode block with Basic Latin */
     schema = MODULE_CREATE_YANG("T_UB_8", "leaf port {type string { "
-i                       "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
+                        "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
                         "}} ");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
     CHECK_LOG_CTX("Regular expression \"[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+\" "

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -845,8 +845,8 @@ test_data_xml(void **state)
 
     /* Unicode block test 6 - Basic Latin, Latin-1 Supplement, and Latin Extended-A */
     schema = MODULE_CREATE_YANG("T_UB_6", "leaf port {type string {"
-                        "       pattern '[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}\\p{IsLatinExtended-A}]+';"
-                        "}} ");
+            "       pattern '[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}\\p{IsLatinExtended-A}]+';"
+            "}} ");
     UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
     TEST_SUCCESS_XML("T_UB_6", "Árvíztűrő tükörfúrógép!", STRING, "Árvíztűrő tükörfúrógép!");
 
@@ -854,15 +854,15 @@ test_data_xml(void **state)
     schema = MODULE_CREATE_YANG("T_UB_7", "leaf port {type string { pattern '\\p{IsUnknownUnicodeBlock}+';} } ");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
     CHECK_LOG_CTX("Regular expression \"\\p{IsUnknownUnicodeBlock}+\" "
-                        "is not valid (\"UnknownUnicodeBlock}+\": unknown block name).", "/T_UB_7:port", 0);
+            "is not valid (\"UnknownUnicodeBlock}+\": unknown block name).", "/T_UB_7:port", 0);
 
     /* Unicode block test 8 - Unknown Unicode block with Basic Latin */
     schema = MODULE_CREATE_YANG("T_UB_8", "leaf port {type string { "
-                        "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
-                        "}} ");
+            "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
+            "}} ");
     UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
     CHECK_LOG_CTX("Regular expression \"[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+\" "
-                        "is not valid (\"UnknownUnicodeBlock}]+\": unknown block name).", "/T_UB_8:port", 0);
+            "is not valid (\"UnknownUnicodeBlock}]+\": unknown block name).", "/T_UB_8:port", 0);
 }
 
 static void

--- a/tests/utests/types/string.c
+++ b/tests/utests/types/string.c
@@ -4,6 +4,7 @@
  * @brief test for string values
  *
  * Copyright (c) 2021 CESNET, z.s.p.o.
+ * Copyright (c) 2026 Nokia
  *
  * This source code is licensed under BSD 3-Clause License (the "License").
  * You may not use this file except in compliance with the License.
@@ -817,6 +818,52 @@ test_data_xml(void **state)
     CHECK_LOG_CTX("Unsatisfied pattern - \"abc\" does not match \"a.*b\".", "/T_ANCHOR:port", 1);
     TEST_ERROR_XML("T_ANCHOR", "cab");
     CHECK_LOG_CTX("Unsatisfied pattern - \"cab\" does not match \"a.*b\".", "/T_ANCHOR:port", 1);
+
+    /* Unicode block test 1 - Basic Latin */
+    schema = MODULE_CREATE_YANG("T_UB_1", "leaf port {type string { pattern '\\p{IsBasicLatin}+';} } ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_1", "B4s1cLatin!", STRING, "B4s1cLatin!");
+
+    /* Unicode block test 2 - Basic Latin within brackets */
+    schema = MODULE_CREATE_YANG("T_UB_2", "leaf port {type string { pattern '[\\p{IsBasicLatin}]+';} } ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_2", "B4s1cLatin!", STRING, "B4s1cLatin!");
+
+    /* Unicode block test 3 - Latin-1 Supplement */
+    schema = MODULE_CREATE_YANG("T_UB_3", "leaf port {type string { pattern '[\\p{IsLatin-1Supplement}]+';} } ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_3", "ÁÉÍÓÖÜ", STRING, "ÁÉÍÓÖÜ");
+
+    /* Unicode block test 4 - Latin-1 Supplement */
+    schema = MODULE_CREATE_YANG("T_UB_4", "leaf port {type string { pattern '[\\p{IsLatin-1Supplement}]+';} } ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_4", "ÁÉÍÓÖÜ", STRING, "ÁÉÍÓÖÜ");
+
+    /* Unicode block test 5 - Latin Extended-A */
+    schema = MODULE_CREATE_YANG("T_UB_5", "leaf port {type string { pattern '[\\p{IsLatinExtended-A}]+';} } ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_5", "ŐŰőű", STRING, "ŐŰőű");
+
+    /* Unicode block test 6 - Basic Latin, Latin-1 Supplement, and Latin Extended-A */
+    schema = MODULE_CREATE_YANG("T_UB_6", "leaf port {type string {"
+            "       pattern '[\\p{IsBasicLatin}\\p{IsLatin-1Supplement}\\p{IsLatinExtended-A}]+';"
+            "}} ");
+    UTEST_ADD_MODULE(schema, LYS_IN_YANG, NULL, NULL);
+    TEST_SUCCESS_XML("T_UB_6", "Árvíztűrő tükörfúrógép!", STRING, "Árvíztűrő tükörfúrógép!");
+
+    /* Unicode block test 7 - Unknown Unicode block */
+    schema = MODULE_CREATE_YANG("T_UB_7", "leaf port {type string { pattern '\\p{IsUnknownUnicodeBlock}+';} } ");
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    CHECK_LOG_CTX("Regular expression \"\\p{IsUnknownUnicodeBlock}+\" "
+                  "is not valid (\"UnknownUnicodeBlock}+\": unknown block name).", "/T_UB_7:port", 0);
+
+    /* Unicode block test 8 - Unknown Unicode block with Basic Latin */
+    schema = MODULE_CREATE_YANG("T_UB_8", "leaf port {type string { "
+            "       pattern '[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+';"
+            "}} ");
+    UTEST_INVALID_MODULE(schema, LYS_IN_YANG, NULL, LY_EVALID);
+    CHECK_LOG_CTX("Regular expression \"[\\p{IsBasicLatin}\\p{IsUnknownUnicodeBlock}]+\" "
+                  "is not valid (\"UnknownUnicodeBlock}]+\": unknown block name).", "/T_UB_8:port", 0);
 }
 
 static void


### PR DESCRIPTION
libyang supports patterns that further restrict a string leaf's set of values. The YANG RFC [1] allows the use of Unicode blocks [2] in patterns (e.g. Basic Latin, Cyrillic). libyang, due to a coding error, interprets every Unicode block pattern as Latin-1 Supplement, if multiple Unicode blocks are present in the same pattern. In the corresponding code, the variable responsible to store the Unicode block information, gets overwritten.

The PR corrects the behavior and provides also unit tests.

Corresponding issue: https://github.com/CESNET/libyang/issues/2507

[1] https://datatracker.ietf.org/doc/html/rfc6020
[2] https://www.w3.org/TR/2004/REC-xmlschema-2-20041028/#dt-ccesblock