### PR TITLE
parser_lyb: fix integer overflow and OOM in lyb_read_string/lyb_read_value

### DIFF
--- a/src/parser_lyb.c
+++ b/src/parser_lyb.c
@@ -284,6 +284,9 @@ lyb_read_string(char **str, struct lylyb_parse_ctx *lybctx)
     /* read length in bytes */
     lyb_read_size(&str_len, lybctx);
 
+    /* str_len + 1 wraps to 0 when str_len == UINT32_MAX, causing malloc(0) followed by an out-of-bounds write */
+    LY_CHECK_ERR_RET(str_len == UINT32_MAX, LOGERR(lybctx->ctx, LY_EINVAL, "LYB string length overflow."), LY_EINVAL);
+
     /* allocate mem */
     *str = malloc((str_len + 1) * sizeof **str);
     LY_CHECK_ERR_RET(!*str, LOGMEM(lybctx->ctx), LY_EMEM);
@@ -339,6 +342,11 @@ lyb_read_value(const struct lysc_type *type, uint8_t **val, uint64_t *val_size_b
             *val_size_bits *= 8;
         }
     }
+
+    /* LYPLG_BITS2BYTES(val_size_bits) + 1 can reach 4 GiB when lyb_size_bits == UINT32_MAX and
+     * size_type == VARIABLE_BYTES, causing calloc to attempt a 4 GiB allocation (OOM / DoS) */
+    LY_CHECK_ERR_RET(LYPLG_BITS2BYTES(*val_size_bits) >= UINT32_MAX,
+            LOGERR(lybctx->ctx, LY_EINVAL, "LYB value size overflow."), LY_EINVAL);
 
     /* allocate zeroed memory with an addition zero byte */
     *val = calloc(LYPLG_BITS2BYTES(*val_size_bits) + 1, sizeof **val);


### PR DESCRIPTION
## Summary

Two memory-safety bugs in the LYB parser, both triggered by a malformed length field (`0xFFFFFFFF`) in LYB input:

### Bug 1 — `lyb_read_string` (line ~288): integer overflow → WRITE SEGV

`malloc((str_len + 1) * sizeof **str)` — when `str_len == UINT32_MAX`, `str_len + 1` wraps to `0`. `malloc(0)` returns a non-NULL pointer on most platforms, bypassing the NULL check. The subsequent `(*str)[UINT32_MAX] = '\0'` writes 4 GiB past the start of the allocation → WRITE SEGV (confirmed with ASAN).

**Fix:** reject `str_len == UINT32_MAX` before the malloc.

### Bug 2 — `lyb_read_value` (line ~344): OOM / DoS via 4 GiB calloc

When `size_type == VARIABLE_BYTES` and `lyb_size_bits == UINT32_MAX`, `*val_size_bits *= 8` produces `~8.6e9`. `LYPLG_BITS2BYTES()` yields `0xFFFFFFFF`, and `calloc(0x100000000, 1)` attempts a 4 GiB allocation → immediate OOM crash (confirmed with ASAN + `allocator_may_return_null=1`).

**Fix:** reject allocations where `LYPLG_BITS2BYTES(*val_size_bits) >= UINT32_MAX`.

## Reproduction

```bash
cmake .. -DCMAKE_C_FLAGS="-fsanitize=address" && make yanglint
./yanglint -f lyb -o valid.lyb tests/yanglint/modules/modconfig.yang tests/yanglint/data/modconfig.xml
python3 -c "
import struct
d = bytearray(open('valid.lyb','rb').read())
idx = d.find(b'modconfig') - 4
struct.pack_into('<I', d, idx, 0xFFFFFFFF)
open('crash.lyb','wb').write(d)
"
ASAN_OPTIONS=allocator_may_return_null=1 ./yanglint -f xml tests/yanglint/modules/modconfig.yang crash.lyb
```

## Notes

As noted by the maintainer, these are two instances of a broader pattern — length-prefixed fields throughout `parser_lyb.c` read untrusted integers directly into allocators without bounds checks. A fuller audit of similar patterns in the file would be worthwhile.

Reported-by: Dominik Blain, Cobalt AI