### PR TITLE
diff BUGFIX climb data tree parents to cross schema-mount boundary

### DIFF
--- a/src/diff.c
+++ b/src/diff.c
@@ -352,11 +352,9 @@ lyd_diff_dup(const struct lyd_node *node, enum lyd_diff_op op, struct lyd_node *
     dup_parent = *dup;
     node_parent = node;
     sparent = parent ? parent->schema : NULL;
-    while (lysc_data_parent(dup_parent->schema) &&
-            !lyd_compare_schema_equal(lysc_data_parent(dup_parent->schema), sparent, 0)) {
-        node_parent = node_parent->parent;
-
+    while (node_parent->parent && (!sparent || !lyd_compare_schema_equal(node_parent->parent->schema, sparent, 0))) {
         /* duplicate the next parent */
+        node_parent = node_parent->parent;
         LY_CHECK_RET(lyd_dup_single(node_parent, NULL, LYD_DUP_NO_META | LYD_DUP_WITH_FLAGS, &d));
 
         /* connect the existing dup tree into the parent */


### PR DESCRIPTION
In lyd_diff_dup(), the parent-climbing loop used lysc_data_parent() to find the next parent, which returns NULL at a schema mount boundary. This caused the diff to miss the host module's parent containers around mounted module data.

Use the data tree parent (node_parent->parent) instead, which crosses the mount boundary correctly. Also stop climbing once the existing diff parent level is reached.