### PR TITLE
fix warning message for YANG module revision ordering

### DIFF
--- a/src/tree_schema_common.c
+++ b/src/tree_schema_common.c
@@ -91,7 +91,7 @@ lysp_last_revision(const struct lysp_module *pmod, const struct lysp_revision *r
         cmp = strcmp(revs[u].date, revs[u + 1].date);
         if (cmp < 0) {
             if (ctx) {
-                LOGWRN(ctx, "Older revision %s found after a newer revision %s in %s \"%s\".", revs[u].date,
+                LOGWRN(ctx, "Older revision %s found before a newer revision %s in %s \"%s\".", revs[u].date,
                         revs[u + 1].date, mod_str, name);
             }
 


### PR DESCRIPTION
The [standard](https://datatracker.ietf.org/doc/html/rfc7950#section-7.1.9) says that:

> [...] a new [revision] SHOULD be added in front of the revisions
> sequence so that all revisions are in reverse chronological order

The actual error message was misleading, saying that an older revision was found after a new revision. That is actually a correct order. The check was correct, but the error message should have said that the older revision was found *before* a newer one.

We actually "fixed" our YANG models based on this diagnostic message, only to revert that later on.