### PR TITLE
tree data: duplicate anydata children into target context

### DIFF
--- a/tests/utests/data/test_tree_data.c
+++ b/tests/utests/data/test_tree_data.c
@@ -282,6 +282,39 @@ test_compare_diff_ctx(void **state)
 }
 
 static void
+test_dup_anydata_to_ctx(void **state)
+{
+    struct ly_ctx *ctx1 = NULL, *ctx2 = NULL;
+    struct lyd_node *tree = NULL, *dup = NULL;
+    const char *schema;
+    const char *data;
+
+    (void)state;
+
+    schema = "module c {yang-version 1.1; namespace \"urn:tests:c\"; prefix c;"
+            "container root {anydata payload;}}";
+    data = "<root xmlns=\"urn:tests:c\">"
+            "<payload><unknown xmlns=\"urn:unknown:c\" xmlns:x=\"urn:x\" x:attr=\"1\">"
+            "<child>text</child></unknown></payload></root>";
+
+    assert_int_equal(LY_SUCCESS, ly_ctx_new(TESTS_SRC "/../modules", 0, &ctx1));
+    assert_int_equal(LY_SUCCESS, ly_ctx_new(TESTS_SRC "/../modules", 0, &ctx2));
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(ctx1, schema, LYS_IN_YANG, NULL));
+    assert_int_equal(LY_SUCCESS, lys_parse_mem(ctx2, schema, LYS_IN_YANG, NULL));
+
+    assert_int_equal(LY_SUCCESS, lyd_parse_data_mem(ctx1, data, LYD_XML, 0, LYD_VALIDATE_PRESENT, &tree));
+    assert_int_equal(LY_SUCCESS, lyd_dup_siblings_to_ctx(tree, ctx2, NULL, LYD_DUP_RECURSIVE | LYD_DUP_WITH_FLAGS, &dup));
+
+    lyd_free_all(tree);
+    ly_ctx_destroy(ctx1);
+
+    assert_int_equal(LY_SUCCESS, lyd_trim_xpath(&dup, "//*", NULL));
+
+    lyd_free_all(dup);
+    ly_ctx_destroy(ctx2);
+}
+
+static void
 test_dup(void **state)
 {
     struct lyd_node *tree1, *tree2;
@@ -836,6 +869,7 @@ main(void)
     const struct CMUnitTest tests[] = {
         UTEST(test_compare, setup),
         UTEST(test_compare_diff_ctx, setup),
+        UTEST(test_dup_anydata_to_ctx),
         UTEST(test_dup, setup),
         UTEST(test_target, setup),
         UTEST(test_list_pos, setup),


### PR DESCRIPTION
## Summary

Fix a use-after-free in cross-context duplication of data trees containing
`anydata` XML subtrees.

This addresses `GHSA-jq97-j23h-2vqw`:
https://github.com/CESNET/libyang/security/advisories/GHSA-jq97-j23h-2vqw

## Problem

`lyd_dup_siblings_to_ctx()` is expected to duplicate a data tree into the target
context. However, when duplicating an `anydata` node that stores its value as a
child subtree, the embedded children were copied with `lyd_dup_siblings()`.

That preserves references to the source context. If the source tree and source
context are freed after successful duplication, later operations on the duplicate
can access freed memory. One affected path is XPath traversal through
`lyd_trim_xpath()`.

## Fix

Duplicate `anydata` child subtrees with `lyd_dup_siblings_to_ctx()` and
`LYD_CTX(trg)` so embedded children are copied into the same target context as
the containing `anydata` node.

Add a regression test that duplicates an `anydata` XML subtree into a second
context, destroys the original context, and then evaluates XPath on the
duplicate.

## Verification

I ran the advisory reproducer against an ASan/UBSan build with this fix applied.
The reproducer completes successfully and no use-after-free is reported.
