### PR TITLE
cmake BUGFIX remove minimum version

### DIFF
--- a/CMakeModules/uninstall.cmake
+++ b/CMakeModules/uninstall.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.0.2)
-
 set(MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
 
 if(NOT EXISTS ${MANIFEST})


### PR DESCRIPTION
Setting a minimum required version to <3.5 triggers a cmake error: "Compatibility with CMake < 3.5 has been removed from CMake."

No part actually requires 3.0.2 version, so just remove it.